### PR TITLE
Add basic Point methods

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,7 @@
+use std::ops::Add;
+use std::ops::Neg;
+use std::ops::Sub;
+
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub struct Coordinate {
     pub x: f64,
@@ -133,6 +137,60 @@ impl Point {
     /// ```
     pub fn set_lat(&mut self, lat: f64) -> &mut Point {
         self.set_y(lat)
+    }
+}
+
+impl Neg for Point {
+    type Output = Point;
+
+    /// Add a point to the given point.
+    ///
+    /// ```
+    /// use geo::Point;
+    ///
+    /// let p = -Point::new(-1.25, 2.5);
+    ///
+    /// assert_eq!(p.x(), 1.25);
+    /// assert_eq!(p.y(), -2.5);
+    /// ```
+    fn neg(self) -> Point {
+        Point::new(-self.x(), -self.y())
+    }
+}
+
+impl Add for Point {
+    type Output = Point;
+
+    /// Add a point to the given point.
+    ///
+    /// ```
+    /// use geo::Point;
+    ///
+    /// let p = Point::new(1.25, 2.5) + Point::new(1.5, 2.5);
+    ///
+    /// assert_eq!(p.x(), 2.75);
+    /// assert_eq!(p.y(), 5.0);
+    /// ```
+    fn add(self, _rhs: Point) -> Point {
+        Point::new(self.x() + _rhs.x(), self.y() + _rhs.y())
+    }
+}
+
+impl Sub for Point {
+    type Output = Point;
+
+    /// Subtract a point from the given point.
+    ///
+    /// ```
+    /// use geo::Point;
+    ///
+    /// let p = Point::new(1.25, 3.0) - Point::new(1.5, 2.5);
+    ///
+    /// assert_eq!(p.x(), -0.25);
+    /// assert_eq!(p.y(), 0.5);
+    /// ```
+    fn sub(self, _rhs: Point) -> Point {
+        Point::new(self.x() - _rhs.x(), self.y() - _rhs.y())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,76 @@ pub struct Coordinate {
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub struct Point(pub Coordinate);
 
+impl Point {
+    /// Returns the x/horizontal component of the point.
+    ///
+    /// ```
+    /// use geo::Coordinate;
+    /// use geo::Point;
+    ///
+    /// let p = Point(Coordinate{
+    ///     x: 1.234,
+    ///     y: 2.345,
+    /// });
+    ///
+    /// assert_eq!(p.x(), 1.234);
+    /// ```
+    pub fn x(&self) -> f64 {
+        self.0.x
+    }
+
+    /// Returns the y/vertical component of the point.
+    ///
+    /// ```
+    /// use geo::Coordinate;
+    /// use geo::Point;
+    ///
+    /// let p = Point(Coordinate{
+    ///     x: 1.234,
+    ///     y: 2.345,
+    /// });
+    ///
+    /// assert_eq!(p.y(), 2.345);
+    /// ```
+    pub fn y(&self) -> f64 {
+        self.0.y
+    }
+
+    /// Returns the longitude/horizontal component of the point.
+    ///
+    /// ```
+    /// use geo::Coordinate;
+    /// use geo::Point;
+    ///
+    /// let p = Point(Coordinate{
+    ///     x: 1.234,
+    ///     y: 2.345,
+    /// });
+    ///
+    /// assert_eq!(p.lng(), 1.234);
+    /// ```
+    pub fn lng(&self) -> f64 {
+        self.x()
+    }
+
+    /// Returns the latitude/vertical component of the point.
+    ///
+    /// ```
+    /// use geo::Coordinate;
+    /// use geo::Point;
+    ///
+    /// let p = Point(Coordinate{
+    ///     x: 1.234,
+    ///     y: 2.345,
+    /// });
+    ///
+    /// assert_eq!(p.lat(), 2.345);
+    /// ```
+    pub fn lat(&self) -> f64 {
+        self.y()
+    }
+}
+
 #[derive(PartialEq, Clone, Debug)]
 pub struct MultiPoint(pub Vec<Point>);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -138,6 +138,21 @@ impl Point {
     pub fn set_lat(&mut self, lat: f64) -> &mut Point {
         self.set_y(lat)
     }
+
+    /// Returns the dot product of the two points:
+    /// `dot = x1 * x2 + y1 * y2`
+    ///
+    /// ```
+    /// use geo::Point;
+    ///
+    /// let p = Point::new(1.5, 0.5);
+    /// let dot = p.dot(&Point::new(2.0, 4.5));
+    ///
+    /// assert_eq!(dot, 5.25);
+    /// ```
+    pub fn dot(&self, point: &Point) -> f64 {
+        self.x() * point.x() + self.y() * point.y()
+    }
 }
 
 impl Neg for Point {

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,16 +8,29 @@ pub struct Coordinate {
 pub struct Point(pub Coordinate);
 
 impl Point {
+    /// Creates a new point.
+    ///
+    /// ```
+    /// use geo::Point;
+    ///
+    /// let p = Point::new(1.234, 2.345);
+    ///
+    /// assert_eq!(p.x(), 1.234);
+    /// assert_eq!(p.y(), 2.345);
+    /// ```
+    pub fn new(x: f64, y: f64) -> Point {
+        Point(Coordinate {
+            x: x,
+            y: y,
+        })
+    }
+
     /// Returns the x/horizontal component of the point.
     ///
     /// ```
-    /// use geo::Coordinate;
     /// use geo::Point;
     ///
-    /// let p = Point(Coordinate{
-    ///     x: 1.234,
-    ///     y: 2.345,
-    /// });
+    /// let p = Point::new(1.234, 2.345);
     ///
     /// assert_eq!(p.x(), 1.234);
     /// ```
@@ -28,13 +41,9 @@ impl Point {
     /// Returns the y/vertical component of the point.
     ///
     /// ```
-    /// use geo::Coordinate;
     /// use geo::Point;
     ///
-    /// let p = Point(Coordinate{
-    ///     x: 1.234,
-    ///     y: 2.345,
-    /// });
+    /// let p = Point::new(1.234, 2.345);
     ///
     /// assert_eq!(p.y(), 2.345);
     /// ```
@@ -45,13 +54,9 @@ impl Point {
     /// Returns the longitude/horizontal component of the point.
     ///
     /// ```
-    /// use geo::Coordinate;
     /// use geo::Point;
     ///
-    /// let p = Point(Coordinate{
-    ///     x: 1.234,
-    ///     y: 2.345,
-    /// });
+    /// let p = Point::new(1.234, 2.345);
     ///
     /// assert_eq!(p.lng(), 1.234);
     /// ```
@@ -62,13 +67,9 @@ impl Point {
     /// Returns the latitude/vertical component of the point.
     ///
     /// ```
-    /// use geo::Coordinate;
     /// use geo::Point;
     ///
-    /// let p = Point(Coordinate{
-    ///     x: 1.234,
-    ///     y: 2.345,
-    /// });
+    /// let p = Point::new(1.234, 2.345);
     ///
     /// assert_eq!(p.lat(), 2.345);
     /// ```

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,6 +38,21 @@ impl Point {
         self.0.x
     }
 
+    /// Sets the x/horizontal component of the point.
+    ///
+    /// ```
+    /// use geo::Point;
+    ///
+    /// let mut p = Point::new(1.234, 2.345);
+    /// p.set_x(9.876);
+    ///
+    /// assert_eq!(p.x(), 9.876);
+    /// ```
+    pub fn set_x(&mut self, x: f64) -> &mut Point {
+        self.0.x = x;
+        self
+    }
+
     /// Returns the y/vertical component of the point.
     ///
     /// ```
@@ -49,6 +64,21 @@ impl Point {
     /// ```
     pub fn y(&self) -> f64 {
         self.0.y
+    }
+
+    /// Sets the y/vertical component of the point.
+    ///
+    /// ```
+    /// use geo::Point;
+    ///
+    /// let mut p = Point::new(1.234, 2.345);
+    /// p.set_y(9.876);
+    ///
+    /// assert_eq!(p.y(), 9.876);
+    /// ```
+    pub fn set_y(&mut self, y: f64) -> &mut Point {
+        self.0.y = y;
+        self
     }
 
     /// Returns the longitude/horizontal component of the point.
@@ -64,6 +94,20 @@ impl Point {
         self.x()
     }
 
+    /// Sets the longitude/horizontal component of the point.
+    ///
+    /// ```
+    /// use geo::Point;
+    ///
+    /// let mut p = Point::new(1.234, 2.345);
+    /// p.set_lng(9.876);
+    ///
+    /// assert_eq!(p.lng(), 9.876);
+    /// ```
+    pub fn set_lng(&mut self, lng: f64) -> &mut Point {
+        self.set_x(lng)
+    }
+
     /// Returns the latitude/vertical component of the point.
     ///
     /// ```
@@ -75,6 +119,20 @@ impl Point {
     /// ```
     pub fn lat(&self) -> f64 {
         self.y()
+    }
+
+    /// Sets the latitude/vertical component of the point.
+    ///
+    /// ```
+    /// use geo::Point;
+    ///
+    /// let mut p = Point::new(1.234, 2.345);
+    /// p.set_lat(9.876);
+    ///
+    /// assert_eq!(p.lat(), 9.876);
+    /// ```
+    pub fn set_lat(&mut self, lat: f64) -> &mut Point {
+        self.set_y(lat)
     }
 }
 


### PR DESCRIPTION
This PR adds some basic methods to the `Point` type. This includes an XY constructor, getters and setters for x, y, lat and lng and implementations for the `Add`, `Sub`, `Neg` traits.

All methods are documented and include examples that are runnable as doctests.