### PR TITLE
Merge Coordinate into Point type

### DIFF
--- a/examples/types.rs
+++ b/examples/types.rs
@@ -3,13 +3,6 @@ extern crate geo;
 use geo::*;
 
 fn main() {
-    let c = Coordinate {
-        x: 40.02f64,
-        y: 116.34
-    };
-
-    let p = Point(c);
-
-    let Point(coord) = p;
-    println!("Point at ({}, {})", coord.x, coord.y);
+    let p = Point::new(40.02, 116.34);
+    println!("Point at ({}, {})", p.x(), p.y());
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,10 +3,7 @@ use std::ops::Neg;
 use std::ops::Sub;
 
 #[derive(PartialEq, Clone, Copy, Debug)]
-pub struct Point {
-    x: f64,
-    y: f64,
-}
+pub struct Point(f64, f64);
 
 impl Point {
     /// Creates a new point.
@@ -20,10 +17,7 @@ impl Point {
     /// assert_eq!(p.y(), 2.345);
     /// ```
     pub fn new(x: f64, y: f64) -> Point {
-        Point {
-            x: x,
-            y: y,
-        }
+        Point(x, y)
     }
 
     /// Returns the x/horizontal component of the point.
@@ -36,7 +30,7 @@ impl Point {
     /// assert_eq!(p.x(), 1.234);
     /// ```
     pub fn x(&self) -> f64 {
-        self.x
+        self.0
     }
 
     /// Sets the x/horizontal component of the point.
@@ -50,7 +44,7 @@ impl Point {
     /// assert_eq!(p.x(), 9.876);
     /// ```
     pub fn set_x(&mut self, x: f64) -> &mut Point {
-        self.x = x;
+        self.0 = x;
         self
     }
 
@@ -64,7 +58,7 @@ impl Point {
     /// assert_eq!(p.y(), 2.345);
     /// ```
     pub fn y(&self) -> f64 {
-        self.y
+        self.1
     }
 
     /// Sets the y/vertical component of the point.
@@ -78,7 +72,7 @@ impl Point {
     /// assert_eq!(p.y(), 9.876);
     /// ```
     pub fn set_y(&mut self, y: f64) -> &mut Point {
-        self.y = y;
+        self.1 = y;
         self
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,13 +3,10 @@ use std::ops::Neg;
 use std::ops::Sub;
 
 #[derive(PartialEq, Clone, Copy, Debug)]
-pub struct Coordinate {
-    pub x: f64,
-    pub y: f64,
+pub struct Point {
+    x: f64,
+    y: f64,
 }
-
-#[derive(PartialEq, Clone, Copy, Debug)]
-pub struct Point(pub Coordinate);
 
 impl Point {
     /// Creates a new point.
@@ -23,10 +20,10 @@ impl Point {
     /// assert_eq!(p.y(), 2.345);
     /// ```
     pub fn new(x: f64, y: f64) -> Point {
-        Point(Coordinate {
+        Point {
             x: x,
             y: y,
-        })
+        }
     }
 
     /// Returns the x/horizontal component of the point.
@@ -39,7 +36,7 @@ impl Point {
     /// assert_eq!(p.x(), 1.234);
     /// ```
     pub fn x(&self) -> f64 {
-        self.0.x
+        self.x
     }
 
     /// Sets the x/horizontal component of the point.
@@ -53,7 +50,7 @@ impl Point {
     /// assert_eq!(p.x(), 9.876);
     /// ```
     pub fn set_x(&mut self, x: f64) -> &mut Point {
-        self.0.x = x;
+        self.x = x;
         self
     }
 
@@ -67,7 +64,7 @@ impl Point {
     /// assert_eq!(p.y(), 2.345);
     /// ```
     pub fn y(&self) -> f64 {
-        self.0.y
+        self.y
     }
 
     /// Sets the y/vertical component of the point.
@@ -81,7 +78,7 @@ impl Point {
     /// assert_eq!(p.y(), 9.876);
     /// ```
     pub fn set_y(&mut self, y: f64) -> &mut Point {
-        self.0.y = y;
+        self.y = y;
         self
     }
 
@@ -244,16 +241,8 @@ mod test {
 
     #[test]
     fn type_test() {
-        let c = Coordinate {
-            x: 40.02f64,
-            y: 116.34
-        };
-
-        let p = Point(c);
-
-        let Point(c2) = p;
-        assert_eq!(c, c2);
-        assert_eq!(c.x, c2.x);
-        assert_eq!(c.y, c2.y);
+        let p = Point::new(40.02, 116.34);
+        assert_eq!(p.x(), 40.02);
+        assert_eq!(p.y(), 116.34);
     }
 }


### PR DESCRIPTION
This simplifies the Point API and removes an unnecessary abstraction level.

Resolves #15