### PR TITLE
Fix docstring for impl Neg

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -158,7 +158,7 @@ impl Point {
 impl Neg for Point {
     type Output = Point;
 
-    /// Add a point to the given point.
+    /// Returns a point with the x and y compontents negated.
     ///
     /// ```
     /// use geo::Point;


### PR DESCRIPTION
This PR changes "Add a point to the given point." to "Returns a point with the x and y compontents negated."