### PR TITLE
Fix docstring for impl Neg

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -158,7 +158,7 @@ impl Point {
 impl Neg for Point {
     type Output = Point;
 
-    /// Add a point to the given point.
+    /// Returns a point with the x and y components negated.
     ///
     /// ```
     /// use geo::Point;


### PR DESCRIPTION
This commit changes the docstring for Point.neg() to
be "Returns a point with the x and y compontents negated",
instead of being the clone of Point.add(), e.g.
"Add a point to the given point."