### PR TITLE
Don't reexport core structs in submodule.

### DIFF
--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -1,5 +1,5 @@
 
-pub use types::{Coordinate, Point, LineString, Polygon};
+use types::{Coordinate, Point, LineString, Polygon};
 
 /// Calculation of the centroid.
 


### PR DESCRIPTION
Fixes https://github.com/georust/rust-geo/issues/28.