### PR TITLE
Fix intersection for parallel lines

### DIFF
--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -91,8 +91,8 @@ impl Centroid for MultiPolygon {
             let tmp = poly.area();
             total_area += poly.area();
             if let Some(p) = poly.centroid(){
-            	sum_x += tmp * p.lng();
-            	sum_y += tmp * p.lat();
+                sum_x += tmp * p.lng();
+                sum_y += tmp * p.lat();
             }
         }
         Some(Point::new(sum_x / total_area, sum_y / total_area))

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -20,7 +20,7 @@ pub trait Contains<RHS = Self> {
     /// //Point in Point
     /// assert!(p(2., 0.).contains(&p(2., 0.)));
     ///
-    /// //Point in Linstring
+    /// //Point in Linestring
     /// assert!(linestring.contains(&p(2., 0.)));
     ///
     /// //Point in Polygon
@@ -44,7 +44,7 @@ impl Contains<Point> for LineString {
         if vect.is_empty() {
             return false;
         }
-        // LinString with one point equal p
+        // LineString with one point equal p
         if vect.len() == 1 {
             return vect[0].contains(p);
         }
@@ -83,7 +83,7 @@ fn get_position(p: &Point, linestring: &LineString) -> PositionPoint {
     if vect.is_empty() {
         return PositionPoint::Outside;
     }
-    // Point is on linstring
+    // Point is on linestring
     if linestring.contains(p) {
         return PositionPoint::OnBoundary;
     }
@@ -260,7 +260,7 @@ mod test {
     }
     /// Tests: LineString in Polygon
     #[test]
-    fn linstring_in_polygon_with_linestring_is_boundary_test() {
+    fn linestring_in_polygon_with_linestring_is_boundary_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(0., 0.), p(2., 0.), p(2., 2.), p(0., 2.), p(0., 0.)]);
         let poly = Polygon(linestring.clone(), Vec::new());
@@ -270,7 +270,7 @@ mod test {
         assert!(!poly.contains(&LineString(vec![p(0., 2.), p(0., 0.)])));
     }
     #[test]
-    fn linstring_outside_polygon_test() {
+    fn linestring_outside_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(0., 0.), p(2., 0.), p(2., 2.), p(0., 2.), p(0., 0.)]);
         let poly = Polygon(linestring, Vec::new());
@@ -278,7 +278,7 @@ mod test {
         assert!(!poly.contains(&LineString(vec![p(3., 0.), p(5., 2.)])));
     }
     #[test]
-    fn linstring_in_inner_polygon_test() {
+    fn linestring_in_inner_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
 
         let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -74,8 +74,8 @@ enum PositionPoint {
 
 fn get_position(p: &Point, linestring: &LineString) -> PositionPoint {
     // See: http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
-    // 	 http://geospatialpython.com/search
-    // 		?updated-min=2011-01-01T00:00:00-06:00&updated-max=2012-01-01T00:00:00-06:00&max-results=19
+    //      http://geospatialpython.com/search
+    //         ?updated-min=2011-01-01T00:00:00-06:00&updated-max=2012-01-01T00:00:00-06:00&max-results=19
     // Return the position of the point relative to a linestring
 
     let vect = &linestring.0;
@@ -132,9 +132,9 @@ impl Contains<LineString> for Polygon {
     fn contains(&self, linestring: &LineString) -> bool {
         // All points of LineString must be in the polygon ?
         if linestring.0.iter().all(|point| self.contains(point)) {
-        	!self.intersects(linestring)
+            !self.intersects(linestring)
         } else {
-        	false
+            false
         }
     }
 }

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -217,6 +217,7 @@ mod test {
                                                p(0.0, 1.5),
                                                p(0.0, 0.0)]);
         let poly = Polygon(linestring, vec![inner_linestring]);
+        assert!(poly.contains(&p(0.25, 0.25)));
         assert!(!poly.contains(&p(1., 1.)));
         assert!(!poly.contains(&p(1.5, 1.5)));
         assert!(!poly.contains(&p(1.5, 1.)));

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -31,14 +31,14 @@ impl Intersects<LineString> for LineString {
         }
         for (a1, a2) in vect0.iter().zip(vect0[1..].iter()) {
             for (b1, b2) in vect1.iter().zip(vect1[1..].iter()) {
-                let u_b = (a2.y() - b1.y()) * (a2.x() - a1.x()) -
+                let u_b = (b2.y() - b1.y()) * (a2.x() - a1.x()) -
                           (b2.x() - b1.x()) * (a2.y() - a1.y());
                 if u_b == 0. {
                     // The point is on boundary
-                    return true;
+                    continue;
                 }
                 let ua_t = (b2.x() - b1.x()) * (a1.y() - b1.y()) -
-                           (a2.y() - b1.y()) * (a1.x() - b1.x());
+                           (b2.y() - b1.y()) * (a1.x() - b1.x());
                 let ub_t = (a2.x() - a1.x()) * (a1.y() - b1.y()) -
                            (a2.y() - a1.y()) * (a1.x() - b1.x());
                 let u_a = ua_t / u_b;

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -29,18 +29,18 @@ impl Intersects<LineString> for LineString {
         if vect0.is_empty() || vect1.is_empty() {
             return false;
         }
-        for (p01, p02) in vect0.iter().zip(vect0[1..].iter()) {
-            for (p11, p12) in vect1.iter().zip(vect1[1..].iter()) {
-                let u_b = (p02.lat() - p11.lat()) * (p02.lng() - p01.lng()) -
-                          (p12.lng() - p11.lng()) * (p02.lat() - p01.lat());
+        for (a1, a2) in vect0.iter().zip(vect0[1..].iter()) {
+            for (b1, b2) in vect1.iter().zip(vect1[1..].iter()) {
+                let u_b = (a2.y() - b1.y()) * (a2.x() - a1.x()) -
+                          (b2.x() - b1.x()) * (a2.y() - a1.y());
                 if u_b == 0. {
                     // The point is on boundary
                     return true;
                 }
-                let ua_t = (p12.lng() - p11.lng()) * (p01.lat() - p11.lat()) -
-                           (p02.lat() - p11.lat()) * (p01.lng() - p11.lng());
-                let ub_t = (p02.lng() - p01.lng()) * (p01.lat() - p11.lat()) -
-                           (p02.lat() - p01.lat()) * (p01.lng() - p11.lng());
+                let ua_t = (b2.x() - b1.x()) * (a1.y() - b1.y()) -
+                           (a2.y() - b1.y()) * (a1.x() - b1.x());
+                let ub_t = (a2.x() - a1.x()) * (a1.y() - b1.y()) -
+                           (a2.y() - a1.y()) * (a1.x() - b1.x());
                 let u_a = ua_t / u_b;
                 let u_b = ub_t / u_b;
                 if (0. <= u_a) && (u_a <= 1.) && (0. <= u_b) && (u_b <= 1.) {

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -53,13 +53,13 @@ impl Intersects<LineString> for LineString {
 }
 
 impl Intersects<LineString> for Polygon {
-    fn intersects(&self, linstring: &LineString) -> bool {
+    fn intersects(&self, linestring: &LineString) -> bool {
         // line intersects inner or outer polygon edge
-        if self.0.intersects(linstring) || self.1.iter().any(|inner| inner.intersects(linstring)) {
+        if self.0.intersects(linestring) || self.1.iter().any(|inner| inner.intersects(linestring)) {
             return true;
         } else {
             // or if it's contained in the polygon
-            return linstring.0.iter().any(|point| self.contains(point))
+            return linestring.0.iter().any(|point| self.contains(point))
         }
     }
 }
@@ -85,7 +85,7 @@ mod test {
         assert!(!LineString(Vec::new()).intersects(&LineString(Vec::new())));
     }
     #[test]
-    fn intersect_linstring_test() {
+    fn intersect_linestring_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(3., 2.), p(7., 6.)]);
         assert!(linestring.intersects(&LineString(vec![p(3., 4.), p(8., 4.)])));
@@ -98,14 +98,14 @@ mod test {
     }
     /// Tests: intersection LineString and Polygon
     #[test]
-    fn linstring_in_polygon_test() {
+    fn linestring_in_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
         let poly = Polygon(linestring, Vec::new());
         assert!(poly.intersects(&LineString(vec![p(2., 2.), p(3., 3.)])));
     }
     #[test]
-    fn linstring_on_boundary_polygon_test() {
+    fn linestring_on_boundary_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
                            Vec::new());
@@ -115,21 +115,21 @@ mod test {
         assert!(poly.intersects(&LineString(vec![p(0., 6.), p(0., 0.)])));
     }
     #[test]
-    fn intersect_linstring_polygon_test() {
+    fn intersect_linestring_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
                            Vec::new());
         assert!(poly.intersects(&LineString(vec![p(2., 2.), p(6., 6.)])));
     }
     #[test]
-    fn linstring_outside_polygon_test() {
+    fn linestring_outside_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
                            Vec::new());
         assert!(!poly.intersects(&LineString(vec![p(7., 2.), p(9., 4.)])));
     }
     #[test]
-    fn linstring_in_inner_polygon_test() {
+    fn linestring_in_inner_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let v = vec![LineString(vec![p(1., 1.), p(4., 1.), p(4., 4.), p(1., 4.), p(1., 1.)])];
         let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
@@ -138,7 +138,7 @@ mod test {
         assert!(poly.intersects(&LineString(vec![p(2., 2.), p(4., 4.)])));
     }
     #[test]
-    fn linstring_traverse_polygon_test() {
+    fn linestring_traverse_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let v = vec![LineString(vec![p(1., 1.), p(4., 1.), p(4., 4.), p(1., 4.), p(1., 1.)])];
         let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
@@ -146,7 +146,7 @@ mod test {
         assert!(poly.intersects(&LineString(vec![p(2., 0.5), p(2., 5.)])));
     }
     #[test]
-    fn linstring_in_inner_with_2_inner_polygon_test() {
+    fn linestring_in_inner_with_2_inner_polygon_test() {
         //                                        (8,9)
         //     (2,8)                                |                                      (14,8)
         //      ------------------------------------|------------------------------------------

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -22,8 +22,7 @@ pub trait Intersects<RHS = Self> {
 }
 
 impl Intersects<LineString> for LineString {
-    // See: https://github.com/brandonxiang/
-    // 		geojson-python-utils/blob/33b4c00c6cf27921fb296052d0c0341bd6ca1af2/geojson_utils.py
+    // See: https://github.com/brandonxiang/geojson-python-utils/blob/33b4c00c6cf27921fb296052d0c0341bd6ca1af2/geojson_utils.py
     fn intersects(&self, linestring: &LineString) -> bool {
         let vect0 = &self.0;
         let vect1 = &linestring.0;

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -54,16 +54,12 @@ impl Intersects<LineString> for LineString {
 
 impl Intersects<LineString> for Polygon {
     fn intersects(&self, linstring: &LineString) -> bool {
-        if self.0.intersects(linstring) {
+        // line intersects inner or outer polygon edge
+        if self.0.intersects(linstring) || self.1.iter().any(|inner| inner.intersects(linstring)) {
             return true;
         } else {
-            if self.1.is_empty() {
-                return true;
-            } else {
-                !self.1.iter().any(|ls| {
-                    linstring.0.iter().all(|point| Polygon(ls.clone(), Vec::new()).contains(point))
-                })
-            }
+            // or if it's contained in the polygon
+            return linstring.0.iter().any(|point| self.contains(point))
         }
     }
 }

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -54,8 +54,8 @@ impl Intersects<LineString> for LineString {
 
 impl Intersects<LineString> for Polygon {
     fn intersects(&self, linstring: &LineString) -> bool {
-        if !self.0.intersects(linstring) {
-            return false;
+        if self.0.intersects(linstring) {
+            return true;
         } else {
             if self.1.is_empty() {
                 return true;

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -94,6 +94,12 @@ mod test {
         let linestring = LineString(vec![p(3., 2.), p(7., 6.)]);
         assert!(linestring.intersects(&LineString(vec![p(3., 4.), p(8., 4.)])));
     }
+    #[test]
+    fn parallel_linestrings_test() {
+        let p = |x, y| Point(Coordinate { x: x, y: y });
+        let linestring = LineString(vec![p(3., 2.), p(7., 6.)]);
+        assert!(!linestring.intersects(&LineString(vec![p(3., 1.), p(7., 5.)])));
+    }
     /// Tests: intersection LineString and Polygon
     #[test]
     fn linstring_in_polygon_test() {


### PR DESCRIPTION
I was just backfilling a test for testing that parallel line strings don't intersect. This lead me to find a bug in the line segment intersection test. 

Fixing that, uncovered another bug in the poly.intersect(line_string) implementation.

I renamed the variables in the line segment algorithm to correspond to the transcribed algorithm for easier auditing. You can see just the linestring intersection bug fix here:
https://github.com/georust/rust-geo/commit/093bb9a6091b0fda6aaca26121d9866245b65b2a