### PR TITLE
Add type Bbox and trait BoundingBox

### DIFF
--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -1,5 +1,5 @@
 use num::Float;
-use types::Polygon;
+use types::{Polygon, Bbox};
 
 /// Calculation of the area.
 
@@ -37,9 +37,17 @@ impl<T> Area<T> for Polygon<T>
     }
 }
 
+impl<T> Area<T> for Bbox<T>
+    where T: Float
+{
+    fn area(&self) -> T {
+        (self.xmax - self.xmin) * (self.ymax - self.ymin)
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use types::{Coordinate, Point, LineString, Polygon};
+    use types::{Coordinate, Point, LineString, Polygon, Bbox};
     use algorithm::area::Area;
     // Area of the polygon
     #[test]
@@ -59,5 +67,10 @@ mod test {
         let linestring = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
         let poly = Polygon(linestring, Vec::new());
         assert_eq!(poly.area(), 30.);
+    }
+    #[test]
+    fn bbox_test() {
+        let bbox = Bbox {xmin: 10., xmax: 20., ymin: 30., ymax: 40.};
+        assert_eq!(100., bbox.area());
     }
 }

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -1,6 +1,6 @@
 use num::{Float};
 
-use types::{Bbox, LineString, Polygon};
+use types::{Bbox, Point, LineString, Polygon};
 
 /// Calculation of the bounding box of a geometry.
 
@@ -25,10 +25,9 @@ pub trait BoundingBox<T: Float> {
     fn bbox(&self) -> Option<Bbox<T>>;
 }
 
-fn get_bbox<T>(line: &LineString<T>) -> Option<Bbox<T>>
+fn get_bbox<T>(vect: &Vec<Point<T>>) -> Option<Bbox<T>>
     where T: Float
 {
-    let vect = &line.0;
     if vect.is_empty() {
         return None;
     }
@@ -63,7 +62,7 @@ impl<T> BoundingBox<T> for LineString<T>
     /// Return the BoundingBox for a LineString
     ///
     fn bbox(&self) -> Option<Bbox<T>> {
-        get_bbox(&self)
+        get_bbox(&self.0)
     }
 }
 
@@ -75,7 +74,7 @@ impl<T> BoundingBox<T> for Polygon<T>
     ///
     fn bbox(&self) -> Option<Bbox<T>> {
         let line = &self.0;
-        get_bbox(&line)
+        get_bbox(&line.0)
     }
 }
 

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -99,36 +99,36 @@ mod test {
 
     #[test]
     fn empty_linestring_test() {
-        let vec : Vec<Point<f64>> = Vec::new();
-        let linestring : LineString<f64> = LineString(vec);
+        let vect = Vec::<Point<f64>>::new();
+        let linestring = LineString(vect);
         let bbox = linestring.bbox();
         assert!(bbox.is_none());
     }
     #[test]
     fn linestring_one_point_test() {
         let p = Point::new(40.02f64, 116.34);
-        let mut vect : Vec<Point<f64>> = Vec::new();
+        let mut vect = Vec::<Point<f64>>::new();
         vect.push(p);
-        let linestring : LineString<f64> = LineString(vect);
+        let linestring = LineString(vect);
         let bbox = Bbox{xmin: 40.02f64, ymax: 116.34, xmax: 40.02, ymin: 116.34};
         assert_eq!(bbox, linestring.bbox().unwrap());
     }
     #[test]
     fn linestring_test() {
-        let linestring : LineString<f64> = LineString(vec![Point::new(1., 1.),
-                                                           Point::new(2., -2.),
-                                                           Point::new(-3., -3.),
-                                                           Point::new(-4., 4.)]);
-        let bbox : Bbox<f64> = Bbox{xmin: -4., ymax: 4., xmax: 2., ymin: -3.};
+        let linestring = LineString(vec![Point::new(1., 1.),
+                                         Point::new(2., -2.),
+                                         Point::new(-3., -3.),
+                                         Point::new(-4., 4.)]);
+        let bbox = Bbox{xmin: -4., ymax: 4., xmax: 2., ymin: -3.};
         assert_eq!(bbox, linestring.bbox().unwrap());
     }
     #[test]
     fn multipoint_test() {
-        let multipoint : MultiPoint<f64> = MultiPoint(vec![Point::new(1., 1.),
-                                                           Point::new(2., -2.),
-                                                           Point::new(-3., -3.),
-                                                           Point::new(-4., 4.)]);
-        let bbox : Bbox<f64> = Bbox{xmin: -4., ymax: 4., xmax: 2., ymin: -3.};
+        let multipoint = MultiPoint(vec![Point::new(1., 1.),
+                                         Point::new(2., -2.),
+                                         Point::new(-3., -3.),
+                                         Point::new(-4., 4.)]);
+        let bbox = Bbox{xmin: -4., ymax: 4., xmax: 2., ymin: -3.};
         assert_eq!(bbox, multipoint.bbox().unwrap());
     }
     #[test]

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -8,7 +8,7 @@ pub trait BoundingBox<T: Float> {
     /// Return a Bounding Box of a geometry
     ///
     /// ```
-    /// use geo::{Point, LineString, Coordinate};
+    /// use geo::{Point, LineString};
     /// use geo::algorithm::boundingbox::BoundingBox;
     ///
     /// let mut vec = Vec::new();
@@ -18,8 +18,10 @@ pub trait BoundingBox<T: Float> {
     /// let linestring = LineString(vec);
     /// let bbox = linestring.bbox().unwrap();
     ///
-    /// println!("Bbox top left coordinates: {}, {}", bbox.xmin, bbox.ymax);
-    /// println!("Bbox bottom right coordinates: {}, {}", bbox.xmax, bbox.ymin);
+    /// assert_eq!(40.02f64, bbox.xmin);
+    /// assert_eq!(42.02f64, bbox.xmax);
+    /// assert_eq!(116.34, bbox.ymin);
+    /// assert_eq!(118.34, bbox.ymax);
     /// ```
     ///
     fn bbox(&self) -> Option<Bbox<T>>;

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -1,6 +1,6 @@
 use num::{Float};
 
-use types::{Bbox, Point, LineString, Polygon};
+use types::{Bbox, Point, MultiPoint, LineString, Polygon};
 
 /// Calculation of the bounding box of a geometry.
 
@@ -55,6 +55,17 @@ fn get_bbox<T>(vect: &Vec<Point<T>>) -> Option<Bbox<T>>
     }
 }
 
+impl<T> BoundingBox<T> for MultiPoint<T>
+    where T: Float
+{
+    ///
+    /// Return the BoundingBox for a MultiPoint
+    ///
+    fn bbox(&self) -> Option<Bbox<T>> {
+        get_bbox(&self.0)
+    }
+}
+
 impl<T> BoundingBox<T> for LineString<T>
     where T: Float
 {
@@ -79,9 +90,11 @@ impl<T> BoundingBox<T> for Polygon<T>
 }
 
 
+
+
 #[cfg(test)]
 mod test {
-    use types::{Bbox, Coordinate, Point, LineString, Polygon};
+    use types::{Bbox, Coordinate, Point, MultiPoint, LineString, Polygon};
     use algorithm::boundingbox::BoundingBox;
 
     #[test]
@@ -108,6 +121,15 @@ mod test {
                                                            Point::new(-4., 4.)]);
         let bbox : Bbox<f64> = Bbox{xmin: -4., ymax: 4., xmax: 2., ymin: -3.};
         assert_eq!(bbox, linestring.bbox().unwrap());
+    }
+    #[test]
+    fn multipoint_test() {
+        let multipoint : MultiPoint<f64> = MultiPoint(vec![Point::new(1., 1.),
+                                                           Point::new(2., -2.),
+                                                           Point::new(-3., -3.),
+                                                           Point::new(-4., 4.)]);
+        let bbox : Bbox<f64> = Bbox{xmin: -4., ymax: 4., xmax: 2., ymin: -3.};
+        assert_eq!(bbox, multipoint.bbox().unwrap());
     }
     #[test]
     fn polygon_test(){

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -34,21 +34,23 @@ fn get_min_max<T>(p: T, min: T, max: T) -> (T, T)
     if p > max {(min, p)} else if p < min {(p, max)} else {(min, max)}
 }
 
-fn get_bbox<T>(vect: &Vec<Point<T>>) -> Option<Bbox<T>>
-    where T: Float
+fn get_bbox<'a, I, T>(collection: I) -> Option<Bbox<T>>
+    where T: 'a + Float,
+          I: 'a + IntoIterator<Item = &'a Point<T>>
 {
-    if vect.is_empty() {
-        return None;
+    let mut iter  = collection.into_iter();
+    if let Some(pnt) = iter.next() {
+        let mut xrange = (pnt.x(), pnt.x());
+        let mut yrange = (pnt.y(), pnt.y());
+        for pnt in iter {
+            let (px, py) = (pnt.x(), pnt.y());
+            xrange = get_min_max(px, xrange.0, xrange.1);
+            yrange = get_min_max(py, yrange.0, yrange.1);
+        }
+        return Some(Bbox{xmin: xrange.0, xmax: xrange.1,
+                         ymin: yrange.0, ymax: yrange.1})
     }
-    let mut xrange = (vect[0].x(), vect[0].x());
-    let mut yrange = (vect[0].y(), vect[0].y());
-    for pnt in vect[1..].iter() {
-        let (px, py) = (pnt.x(), pnt.y());
-        xrange = get_min_max(px, xrange.0, xrange.1);
-        yrange = get_min_max(py, yrange.0, yrange.1);
-    }
-    Some(Bbox{xmin: xrange.0, xmax: xrange.1,
-              ymin: yrange.0, ymax: yrange.1})
+    None
 }
 
 
@@ -97,6 +99,7 @@ impl<T> BoundingBox<T> for MultiLineString<T>
             }
             Some(bbox)
         }
+        // get_bbox(&self.0.iter().flat_map(|line| line.0.iter()))
     }
 }
 

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -1,6 +1,6 @@
 use num::{Float};
 
-use types::{Bbox, LineString};
+use types::{Bbox, LineString, Polygon};
 
 /// Calculation of the bounding box of a geometry.
 
@@ -67,10 +67,22 @@ impl<T> BoundingBox<T> for LineString<T>
     }
 }
 
+impl<T> BoundingBox<T> for Polygon<T>
+    where T: Float
+{
+    ///
+    /// Return the BoundingBox for a Polygon
+    ///
+    fn bbox(&self) -> Option<Bbox<T>> {
+        let line = &self.0;
+        get_bbox(&line)
+    }
+}
+
 
 #[cfg(test)]
 mod test {
-    use types::{Point, LineString, Bbox};
+    use types::{Bbox, Coordinate, Point, LineString, Polygon};
     use algorithm::boundingbox::BoundingBox;
 
     #[test]
@@ -97,5 +109,13 @@ mod test {
                                                            Point::new(-4., 4.)]);
         let bbox : Bbox<f64> = Bbox{xmin: -4., ymax: 4., xmax: 2., ymin: -3.};
         assert_eq!(bbox, linestring.bbox().unwrap());
+    }
+    #[test]
+    fn polygon_test(){
+        let p = |x, y| Point(Coordinate { x: x, y: y });
+        let linestring = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
+        let line_bbox = linestring.bbox().unwrap();
+        let poly = Polygon(linestring, Vec::new());
+        assert_eq!(line_bbox, poly.bbox().unwrap());
     }
 }

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -1,0 +1,101 @@
+use num::{Float};
+
+use types::{Bbox, LineString};
+
+/// Calculation of the bounding box of a geometry.
+
+pub trait BoundingBox<T: Float> {
+    /// Return a Bounding Box of a geometry
+    ///
+    /// ```
+    /// use geo::{Point, LineString, Coordinate};
+    /// use geo::algorithm::boundingbox::BoundingBox;
+    ///
+    /// let mut vec = Vec::new();
+    /// vec.push(Point::new(40.02f64, 116.34));
+    /// vec.push(Point::new(42.02f64, 116.34));
+    /// vec.push(Point::new(42.02f64, 118.34));
+    /// let linestring = LineString(vec);
+    /// let bbox = linestring.bbox().unwrap();
+    ///
+    /// println!("Bbox top left coordinates: {}, {}", bbox.xmin, bbox.ymax);
+    /// println!("Bbox bottom right coordinates: {}, {}", bbox.xmax, bbox.ymin);
+    /// ```
+    ///
+    fn bbox(&self) -> Option<Bbox<T>>;
+}
+
+fn get_bbox<T>(line: &LineString<T>) -> Option<Bbox<T>>
+    where T: Float
+{
+    let vect = &line.0;
+    if vect.is_empty() {
+        return None;
+    }
+    if vect.len() == 1 {
+        return Some(Bbox{xmin: vect[0].x(), ymax: vect[0].y(),
+                         xmax: vect[0].x(), ymin: vect[0].y()})
+    } else {
+        let (mut xmax, mut xmin) = (T::neg_infinity(), T::infinity());
+        let (mut ymax, mut ymin) = (T::neg_infinity(), T::infinity());
+        for pnt in vect.iter() {
+            let (px, py) = (pnt.x(), pnt.y());
+            if px > xmax {
+                xmax = px;
+            } else if px < xmin {
+                xmin = px;
+            }
+            if py > ymax {
+                ymax = py;
+            } else if py < ymin {
+                ymin = py;
+            }
+        }
+        Some(Bbox{xmin: xmin, ymax: ymax,
+                  xmax: xmax, ymin: ymin})
+    }
+}
+
+impl<T> BoundingBox<T> for LineString<T>
+    where T: Float
+{
+    ///
+    /// Return the BoundingBox for a LineString
+    ///
+    fn bbox(&self) -> Option<Bbox<T>> {
+        get_bbox(&self)
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use types::{Point, LineString, Bbox};
+    use algorithm::boundingbox::BoundingBox;
+
+    #[test]
+    fn empty_linestring_test() {
+        let vec : Vec<Point<f64>> = Vec::new();
+        let linestring : LineString<f64> = LineString(vec);
+        let bbox = linestring.bbox();
+        assert!(bbox.is_none());
+    }
+    #[test]
+    fn linestring_one_point_test() {
+        let p = Point::new(40.02f64, 116.34);
+        let mut vect : Vec<Point<f64>> = Vec::new();
+        vect.push(p);
+        let linestring : LineString<f64> = LineString(vect);
+        let bbox = Bbox{xmin: 40.02f64, ymax: 116.34, xmax: 40.02, ymin: 116.34};
+        assert_eq!(bbox, linestring.bbox().unwrap());
+    }
+    #[test]
+    fn linestring_test() {
+        let linestring : LineString<f64> = LineString(vec![Point::new(1., 1.),
+                                                           Point::new(2., -2.),
+                                                           Point::new(-3., -3.),
+                                                           Point::new(-4., 4.)]);
+        let bbox : Bbox<f64> = Bbox{xmin: -4., ymax: 4., xmax: 2., ymin: -3.};
+        assert_eq!(bbox, linestring.bbox().unwrap());
+    }
+}

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -37,17 +37,16 @@ fn get_bbox<T>(vect: &Vec<Point<T>>) -> Option<Bbox<T>>
 {
     if vect.is_empty() {
         return None;
-    } else {
-        let mut xrange = (vect[0].x(), vect[0].x());
-        let mut yrange = (vect[0].y(), vect[0].y());
-        for pnt in vect[1..].iter() {
-            let (px, py) = (pnt.x(), pnt.y());
-            xrange = get_min_max(px, xrange.0, xrange.1);
-            yrange = get_min_max(py, yrange.0, yrange.1);
-        }
-        Some(Bbox{xmin: xrange.0, xmax: xrange.1,
-                  ymin: yrange.0, ymax: yrange.1})
     }
+    let mut xrange = (vect[0].x(), vect[0].x());
+    let mut yrange = (vect[0].y(), vect[0].y());
+    for pnt in vect[1..].iter() {
+        let (px, py) = (pnt.x(), pnt.y());
+        xrange = get_min_max(px, xrange.0, xrange.1);
+        yrange = get_min_max(py, yrange.0, yrange.1);
+    }
+    Some(Bbox{xmin: xrange.0, xmax: xrange.1,
+              ymin: yrange.0, ymax: yrange.1})
 }
 
 

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -83,23 +83,7 @@ impl<T> BoundingBox<T> for MultiLineString<T>
     /// Return the BoundingBox for a MultiLineString
     ///
     fn bbox(&self) -> Option<Bbox<T>> {
-        let vect = &self.0;
-        if vect.is_empty() {
-            return None;
-        }
-        if vect.len() == 1 {
-            return vect[0].bbox()
-        } else {
-            let mut bbox = vect[0].bbox().unwrap();
-            for geo in vect[1..].iter() {
-                let gopt = geo.bbox();
-                if gopt.is_some() {
-                    bbox += gopt.unwrap();
-                }
-            }
-            Some(bbox)
-        }
-        // get_bbox(&self.0.iter().flat_map(|line| line.0.iter()))
+        get_bbox(self.0.iter().flat_map(|line| line.0.iter()))
     }
 }
 
@@ -122,22 +106,7 @@ impl<T> BoundingBox<T> for MultiPolygon<T>
     /// Return the BoundingBox for a MultiPolygon
     ///
     fn bbox(&self) -> Option<Bbox<T>> {
-        let vect = &self.0;
-        if vect.is_empty() {
-            return None;
-        }
-        if vect.len() == 1 {
-            return vect[0].bbox()
-        } else {
-            let mut bbox = vect[0].bbox().unwrap();
-            for geo in vect[1..].iter() {
-                let gopt = geo.bbox();
-                if gopt.is_some() {
-                    bbox += gopt.unwrap();
-                }
-            }
-            Some(bbox)
-        }
+        get_bbox(self.0.iter().flat_map(|poly| (poly.0).0.iter()))
     }
 }
 

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -1,6 +1,6 @@
 use num::{Float, FromPrimitive};
 
-use types::{Point, LineString, Polygon, MultiPolygon};
+use types::{Point, LineString, Polygon, MultiPolygon, Bbox};
 use algorithm::area::Area;
 use algorithm::distance::Distance;
 
@@ -109,9 +109,21 @@ impl<T> Centroid<T> for MultiPolygon<T>
     }
 }
 
+impl<T> Centroid<T> for Bbox<T>
+    where T: Float
+{
+    ///
+    /// Centroid on a Bbox.
+    ///
+    fn centroid(&self) -> Option<Point<T>> {
+        let two = T::one() + T::one();
+        Some(Point::new((self.xmax + self.xmin)/two, (self.ymax + self.ymin)/two))
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use types::{COORD_PRECISION, Coordinate, Point, LineString, Polygon, MultiPolygon};
+    use types::{COORD_PRECISION, Coordinate, Point, LineString, Polygon, MultiPolygon, Bbox};
     use algorithm::centroid::Centroid;
     use algorithm::distance::Distance;
     /// Tests: Centroid of LineString
@@ -184,5 +196,11 @@ mod test {
         let poly2 = Polygon(linestring, Vec::new());
         let dist = MultiPolygon(vec![poly1, poly2]).centroid().unwrap().distance(&p(4.07142857142857, 1.92857142857143));
         assert!(dist < COORD_PRECISION);
+    }
+    #[test]
+    fn bbox_test() {
+        let bbox = Bbox{ xmax: 4., xmin: 0., ymax: 100., ymin: 50.};
+        let point = Point(Coordinate { x: 2., y: 75. });
+        assert_eq!(point, bbox.centroid().unwrap());
     }
 }

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -1,6 +1,6 @@
 use num::{Float, ToPrimitive};
 
-use types::{COORD_PRECISION, Point, LineString, Polygon, MultiPolygon};
+use types::{COORD_PRECISION, Point, LineString, Polygon, MultiPolygon, Bbox};
 use algorithm::intersects::Intersects;
 use algorithm::distance::Distance;
 
@@ -152,10 +152,19 @@ impl<T> Contains<LineString<T>> for Polygon<T>
     }
 }
 
+impl<T> Contains<Bbox<T>> for Bbox<T>
+    where T: Float
+{
+    fn contains(&self, bbox: &Bbox<T>) -> bool {
+        // All points of LineString must be in the polygon ?
+        self.xmin <= bbox.xmin && self.xmax >= bbox.xmax && self.ymin <= bbox.ymin && self.ymax >= bbox.ymax
+    }
+}
+
 
 #[cfg(test)]
 mod test {
-    use types::{Coordinate, Point, LineString, Polygon, MultiPolygon};
+    use types::{Coordinate, Point, LineString, Polygon, MultiPolygon, Bbox};
     use algorithm::contains::Contains;
     /// Tests: Point in LineString
     #[test]
@@ -300,5 +309,12 @@ mod test {
         assert!(!poly.contains(&LineString(vec![p(2., 2.), p(3., 3.)])));
         assert!(!poly.contains(&LineString(vec![p(2., 2.), p(2., 5.)])));
         assert!(!poly.contains(&LineString(vec![p(3., 0.5), p(3., 5.)])));
+    }
+    #[test]
+    fn bbox_in_inner_bbox_test() {
+        let bbox_xl = Bbox { xmin: -100., xmax: 100., ymin: -200., ymax: 200.};
+        let bbox_sm = Bbox { xmin: -10., xmax: 10., ymin: -20., ymax: 20.};
+        assert_eq!(true, bbox_xl.contains(&bbox_sm));
+        assert_eq!(false, bbox_sm.contains(&bbox_xl));
     }
 }

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -8,3 +8,5 @@ pub mod intersects;
 pub mod area;
 /// Returns the distance between two geometries.
 pub mod distance;
+/// Returns the Bbox of a geometry.
+pub mod boundingbox;

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,6 +16,16 @@ pub struct Coordinate<T>
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
+pub struct Bbox<T>
+    where T: Float
+{
+    pub xmin: T,
+    pub xmax: T,
+    pub ymin: T,
+    pub ymax: T,
+}
+
+#[derive(PartialEq, Clone, Copy, Debug)]
 pub struct Point<T> (pub Coordinate<T>) where T: Float;
 
 impl<T> Point<T>

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use std::ops::Add;
+use std::ops::AddAssign;
 use std::ops::Neg;
 use std::ops::Sub;
 
@@ -257,6 +258,31 @@ impl<T> Add for Bbox<T>
             ymin: if self.ymin <= rhs.ymin {self.ymin} else {rhs.ymin},
             ymax: if self.ymax >= rhs.ymax {self.ymax} else {rhs.ymax},
         }
+    }
+}
+
+impl<T> AddAssign for Bbox<T>
+    where T: Float + ToPrimitive
+{
+    /// Add a boundingox to the given boundingbox.
+    ///
+    /// ```
+    /// use geo::Bbox;
+    ///
+    /// let mut bbox0 = Bbox{xmin: 0.,  xmax: 10000., ymin: 10., ymax: 100.};
+    /// let bbox1 = Bbox{xmin: 100., xmax: 1000.,  ymin: 100.,  ymax: 1000.};
+    /// bbox0 += bbox1;
+    ///
+    /// assert_eq!(0., bbox0.xmin);
+    /// assert_eq!(10000., bbox0.xmax);
+    /// assert_eq!(10., bbox0.ymin);
+    /// assert_eq!(1000., bbox0.ymax);
+    /// ```
+    fn add_assign(&mut self, rhs: Bbox<T>){
+        self.xmin = if self.xmin <= rhs.xmin {self.xmin} else {rhs.xmin};
+        self.xmax = if self.xmax >= rhs.xmax {self.xmax} else {rhs.xmax};
+        self.ymin = if self.ymin <= rhs.ymin {self.ymin} else {rhs.ymin};
+        self.ymax = if self.ymax >= rhs.ymax {self.ymax} else {rhs.ymax};
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -231,6 +231,36 @@ impl<T> Sub for Point<T>
     }
 }
 
+impl<T> Add for Bbox<T>
+    where T: Float + ToPrimitive
+{
+    type Output = Bbox<T>;
+
+    /// Add a boundingox to the given boundingbox.
+    ///
+    /// ```
+    /// use geo::Bbox;
+    ///
+    /// let bbox0 = Bbox{xmin: 0.,  xmax: 10000., ymin: 10., ymax: 100.};
+    /// let bbox1 = Bbox{xmin: 100., xmax: 1000.,  ymin: 100.,  ymax: 1000.};
+    /// let bbox = bbox0 + bbox1;
+    ///
+    /// assert_eq!(0., bbox.xmin);
+    /// assert_eq!(10000., bbox.xmax);
+    /// assert_eq!(10., bbox.ymin);
+    /// assert_eq!(1000., bbox.ymax);
+    /// ```
+    fn add(self, rhs: Bbox<T>) -> Bbox<T> {
+        Bbox{
+            xmin: if self.xmin <= rhs.xmin {self.xmin} else {rhs.xmin},
+            xmax: if self.xmax >= rhs.xmax {self.xmax} else {rhs.xmax},
+            ymin: if self.ymin <= rhs.ymin {self.ymin} else {rhs.ymin},
+            ymax: if self.ymax >= rhs.ymax {self.ymax} else {rhs.ymax},
+        }
+    }
+}
+
+
 #[derive(PartialEq, Clone, Debug)]
 pub struct MultiPoint<T>(pub Vec<Point<T>>) where T: Float;
 


### PR DESCRIPTION
I'm not sure that it is right to add the BoundingBox at the rust-geo project, since the boundingbox is not a geometry, but on the other hand it seems a sort of characteristic of the geometry.

What do you think?

Concerning the implementation I don't like too much how the trait BoundingBox is implemented (see: src/algorithm/boundingbox.rs) for MultiLineString and MultiPolygon, because the code is duplicated. I would like to move the code into a private function and call this function from the method, but I was not able to say at the function to take a parameter that can accept only MultiLineString or MultiPolygon. Any ideas on how I can implement this?

Do you see other improvements? 