### PR TITLE
Iterate over points using windows instead of zip

### DIFF
--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -25,7 +25,7 @@ fn get_linestring_area<T>(linestring: &LineString<T>) -> T where T: Float {
         return T::zero();
     }
     let mut tmp = T::zero();
-    for ps in linestring.0.windows(2).into_iter() {
+    for ps in linestring.0.windows(2) {
         tmp = tmp + (ps[0].x() * ps[1].y() - ps[1].x() * ps[0].y());
     }
     tmp / (T::one() + T::one())

--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -25,8 +25,8 @@ fn get_linestring_area<T>(linestring: &LineString<T>) -> T where T: Float {
         return T::zero();
     }
     let mut tmp = T::zero();
-    for (p1, p2) in linestring.0.iter().zip(linestring.0[1..].iter()) {
-        tmp = tmp + (p1.x() * p2.y() - p2.x() * p1.y());
+    for ps in linestring.0.windows(2).into_iter() {
+        tmp = tmp + (ps[0].x() * ps[1].y() - ps[1].x() * ps[0].y());
     }
     tmp / (T::one() + T::one())
 }

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -42,7 +42,7 @@ impl<T> Centroid<T> for LineString<T>
             let mut sum_x = T::zero();
             let mut sum_y = T::zero();
             let mut total_length = T::zero();
-            for ps in vect.windows(2).into_iter() {
+            for ps in vect.windows(2) {
                 let segment_len = ps[0].distance(&ps[1]);
                 let (x1, y1, x2, y2) = (ps[0].x(), ps[0].y(), ps[1].x(), ps[1].y());
                 total_length = total_length + segment_len;
@@ -74,7 +74,7 @@ impl<T> Centroid<T> for Polygon<T>
             let area = self.area();
             let mut sum_x = T::zero();
             let mut sum_y = T::zero();
-            for ps in vect.windows(2).into_iter() {
+            for ps in vect.windows(2) {
                 let tmp = ps[0].x() * ps[1].y() - ps[1].x() * ps[0].y();
                 sum_x = sum_x + ((ps[1].x() + ps[0].x()) * tmp);
                 sum_y = sum_y + ((ps[1].y() + ps[0].y()) * tmp);

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -42,9 +42,9 @@ impl<T> Centroid<T> for LineString<T>
             let mut sum_x = T::zero();
             let mut sum_y = T::zero();
             let mut total_length = T::zero();
-            for (p1, p2) in vect.iter().zip(vect[1..].iter()) {
-                let segment_len = p1.distance(&p2);
-                let (x1, y1, x2, y2) = (p1.x(), p1.y(), p2.x(), p2.y());
+            for ps in vect.windows(2).into_iter() {
+                let segment_len = ps[0].distance(&ps[1]);
+                let (x1, y1, x2, y2) = (ps[0].x(), ps[0].y(), ps[1].x(), ps[1].y());
                 total_length = total_length + segment_len;
                 sum_x = sum_x + segment_len * ((x1 + x2) / (T::one() + T::one()));
                 sum_y = sum_y + segment_len * ((y1 + y2) / (T::one() + T::one()));
@@ -74,10 +74,10 @@ impl<T> Centroid<T> for Polygon<T>
             let area = self.area();
             let mut sum_x = T::zero();
             let mut sum_y = T::zero();
-            for (p1, p2) in vect.iter().zip(vect[1..].iter()) {
-                let tmp = p1.x() * p2.y() - p2.x() * p1.y();
-                sum_x = sum_x + ((p2.x() + p1.x()) * tmp);
-                sum_y = sum_y + ((p2.y() + p1.y()) * tmp);
+            for ps in vect.windows(2).into_iter() {
+                let tmp = ps[0].x() * ps[1].y() - ps[1].x() * ps[0].y();
+                sum_x = sum_x + ((ps[1].x() + ps[0].x()) * tmp);
+                sum_y = sum_y + ((ps[1].y() + ps[0].y()) * tmp);
             }
             let six = T::from_i32(6).unwrap();
             Some(Point::new(sum_x / (six * area), sum_y / (six * area)))

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -57,13 +57,13 @@ impl<T> Contains<Point<T>> for LineString<T>
         if vect.contains(p) {
             return true;
         }
-        for (p1, p2) in vect.iter().zip(vect[1..].iter()) {
-            if ((p1.y() == p2.y()) && (p1.y() == p.y()) &&
-                (p.x() > p1.x().min(p2.x())) &&
-                (p.x() < p1.x().max(p2.x()))) ||
-               ((p1.x() == p2.x()) && (p1.x() == p.x()) &&
-                (p.y() > p1.y().min(p2.y())) &&
-                (p.y() < p1.y().max(p2.y()))) {
+        for ps in vect.windows(2).into_iter() {
+            if ((ps[0].y() == ps[1].y()) && (ps[0].y() == p.y()) &&
+                (p.x() > ps[0].x().min(ps[1].x())) &&
+                (p.x() < ps[0].x().max(ps[1].x()))) ||
+               ((ps[0].x() == ps[1].x()) && (ps[0].x() == p.x()) &&
+                (p.y() > ps[0].y().min(ps[1].y())) &&
+                (p.y() < ps[0].y().max(ps[1].y()))) {
                 return true;
             }
         }
@@ -97,15 +97,15 @@ fn get_position<T>(p: &Point<T>, linestring: &LineString<T>) -> PositionPoint
 
     let mut xints = T::zero();
     let mut crossings = 0;
-    for (p1, p2) in vect.iter().zip(vect[1..].iter()) {
-        if p.y() > p1.y().min(p2.y()) {
-            if p.y() <= p1.y().max(p2.y()) {
-                if p.x() <= p1.x().max(p2.x()) {
-                    if p1.y() != p2.y() {
-                        xints = (p.y() - p1.y()) * (p2.x() - p1.x()) /
-                                (p2.y() - p1.y()) + p1.x();
+    for ps in vect.windows(2).into_iter() {
+        if p.y() > ps[0].y().min(ps[1].y()) {
+            if p.y() <= ps[0].y().max(ps[1].y()) {
+                if p.x() <= ps[0].x().max(ps[1].x()) {
+                    if ps[0].y() != ps[1].y() {
+                        xints = (p.y() - ps[0].y()) * (ps[1].x() - ps[0].x()) /
+                                (ps[1].y() - ps[0].y()) + ps[0].x();
                     }
-                    if (p1.x() == p2.x()) || (p.x() <= xints) {
+                    if (ps[0].x() == ps[1].x()) || (p.x() <= xints) {
                         crossings += 1;
                     }
                 }

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -57,7 +57,7 @@ impl<T> Contains<Point<T>> for LineString<T>
         if vect.contains(p) {
             return true;
         }
-        for ps in vect.windows(2).into_iter() {
+        for ps in vect.windows(2) {
             if ((ps[0].y() == ps[1].y()) && (ps[0].y() == p.y()) &&
                 (p.x() > ps[0].x().min(ps[1].x())) &&
                 (p.x() < ps[0].x().max(ps[1].x()))) ||
@@ -97,7 +97,7 @@ fn get_position<T>(p: &Point<T>, linestring: &LineString<T>) -> PositionPoint
 
     let mut xints = T::zero();
     let mut crossings = 0;
-    for ps in vect.windows(2).into_iter() {
+    for ps in vect.windows(2) {
         if p.y() > ps[0].y().min(ps[1].y()) {
             if p.y() <= ps[0].y().max(ps[1].y()) {
                 if p.x() <= ps[0].x().max(ps[1].x()) {

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -32,8 +32,8 @@ impl<T> Intersects<LineString<T>> for LineString<T>
         if vect0.is_empty() || vect1.is_empty() {
             return false;
         }
-        for a in vect0.windows(2).into_iter() {
-            for b in vect1.windows(2).into_iter() {
+        for a in vect0.windows(2) {
+            for b in vect1.windows(2) {
                 let u_b = (b[1].y() - b[0].y()) * (a[1].x() - a[0].x()) -
                           (b[1].x() - b[0].x()) * (a[1].y() - a[0].y());
                 if u_b == T::zero() {

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -32,17 +32,17 @@ impl<T> Intersects<LineString<T>> for LineString<T>
         if vect0.is_empty() || vect1.is_empty() {
             return false;
         }
-        for (a1, a2) in vect0.iter().zip(vect0[1..].iter()) {
-            for (b1, b2) in vect1.iter().zip(vect1[1..].iter()) {
-                let u_b = (b2.y() - b1.y()) * (a2.x() - a1.x()) -
-                          (b2.x() - b1.x()) * (a2.y() - a1.y());
+        for a in vect0.windows(2).into_iter() {
+            for b in vect1.windows(2).into_iter() {
+                let u_b = (b[1].y() - b[0].y()) * (a[1].x() - a[0].x()) -
+                          (b[1].x() - b[0].x()) * (a[1].y() - a[0].y());
                 if u_b == T::zero() {
                     continue;
                 }
-                let ua_t = (b2.x() - b1.x()) * (a1.y() - b1.y()) -
-                           (b2.y() - b1.y()) * (a1.x() - b1.x());
-                let ub_t = (a2.x() - a1.x()) * (a1.y() - b1.y()) -
-                           (a2.y() - a1.y()) * (a1.x() - b1.x());
+                let ua_t = (b[1].x() - b[0].x()) * (a[0].y() - b[0].y()) -
+                           (b[1].y() - b[0].y()) * (a[0].x() - b[0].x());
+                let ub_t = (a[1].x() - a[0].x()) * (a[0].y() - b[0].y()) -
+                           (a[1].y() - a[0].y()) * (a[0].x() - b[0].x());
                 let u_a = ua_t / u_b;
                 let u_b = ub_t / u_b;
                 if (T::zero() <= u_a) && (u_a <= T::one()) && (T::zero() <= u_b) && (u_b <= T::one()) {

--- a/src/algorithm/length.rs
+++ b/src/algorithm/length.rs
@@ -27,7 +27,7 @@ impl<T> Length<T> for LineString<T>
     where T: Float
 {
     fn length(&self) -> T {
-        self.0.windows(2).into_iter()
+        self.0.windows(2)
               .fold(T::zero(), |total_length, p| total_length + p[0].distance(&p[1]))
     }
 }


### PR DESCRIPTION
Use windows instead of zip to iterate over points. It seems also slightly faster from my [bench](https://gist.github.com/zarch/3cda1ffda67e156d712f5c1b5a3d3d23).

```
running 2 tests
test bench_win ... bench: 154,231,376 ns/iter (+/- 9,710,675)
test bench_zip ... bench: 173,904,730 ns/iter (+/- 61,305,779)
```