### PR TITLE
[wip] Initial pass at LineString constructor

### DIFF
--- a/src/algorithm/simplify.rs
+++ b/src/algorithm/simplify.rs
@@ -29,9 +29,7 @@ fn rdp<T>(points: &[Point<T>], epsilon: &T) -> Vec<Point<T>>
     let mut distance: T;
 
     for (i, _) in points.iter().enumerate().take(points.len() - 1).skip(1) {
-        distance = point_line_distance(&points[i],
-                                       &points[0],
-                                       &*points.last().unwrap());
+        distance = point_line_distance(&points[i], &points[0], &*points.last().unwrap());
         if distance > dmax {
             index = i;
             dmax = distance;
@@ -66,7 +64,7 @@ pub trait Simplify<T, Epsilon = T> {
     /// compare.push(Point::new(5.0, 4.0));
     /// compare.push(Point::new(11.0, 5.5));
     /// compare.push(Point::new(27.8, 0.1));
-    /// let ls_compare = LineString(compare);
+    /// let ls_compare = LineString::new(compare).unwrap();
     /// let simplified = linestring.simplify(&1.0);
     /// assert_eq!(simplified, ls_compare)
     /// ```
@@ -77,7 +75,8 @@ impl<T> Simplify<T> for LineString<T>
     where T: Float
 {
     fn simplify(&self, epsilon: &T) -> LineString<T> {
-        LineString(rdp(&self.0, epsilon))
+        // OK to use unwrap(), since rdp can't return an invalid LineString
+        LineString::new(rdp(&self.0, epsilon)).unwrap()
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -366,10 +366,19 @@ mod test {
     #[test]
     #[should_panic]
     // You can't construct a LineString with one point
-    fn linestring_constructor_test() {
+    fn invalid_linestring_constructor_test() {
         let mut v = vec![];
         let p = Point::new(1.0, 2.0);
         v.push(p);
+        let ls = LineString::new(v).unwrap();
+    }
+    #[test]
+    fn linestring_constructor_test() {
+        let mut v = vec![];
+        let p1 = Point::new(1.0, 2.0);
+        let p2 = Point::new(3.0, 4.0);
+        v.push(p1);
+        v.push(p2);
         let ls = LineString::new(v).unwrap();
     }
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -343,6 +343,26 @@ pub enum Geometry<T>
     GeometryCollection(GeometryCollection<T>)
 }
 
+impl<T> From<Vec<[T; 2]>> for LineString<T>
+    where T: Float
+{
+    fn from(v: Vec<[T; 2]>) -> Self
+    where T: Float
+    {
+        LineString::new(v.iter().map(|e| { Point::new(e[0], e[1]) }).collect()).unwrap()
+    }
+}
+
+impl<T> From<Vec<(T, T)>> for LineString<T>
+    where T: Float
+{
+    fn from(v: Vec<(T, T)>) -> Self 
+    where T: Float
+    {
+        LineString::new(v.iter().map(|e| { Point::new(e.0, e.1) }).collect()).unwrap()
+    }
+}
+
 // Empty LineStrings should be allowed, 1-element LineStrings should not
 impl<T> LineString<T>
     where T: Float
@@ -380,6 +400,24 @@ mod test {
         v.push(p1);
         v.push(p2);
         let ls = LineString::new(v).unwrap();
+    }
+    #[test]
+    fn into_test() {
+        let v1 = vec![(1.0, 2.0), (3.0, 4.0)];
+        let ls1 = LineString::from(v1);
+        let v2 = vec![[1.0, 2.0], [3.0, 4.0]];
+        let ls2 = LineString::from(v2);
+        let v3 = vec![(1.0, 2.0), (3.0, 4.0)];
+        let ls3: LineString<_> = v3.into();
+        let v4 = vec![[1.0, 2.0], [3.0, 4.0]];
+        let ls4: LineString<_> = v4.into();
+    }
+    #[test]
+    #[should_panic]
+    // 1-element LineStrings aren't allowed
+    fn into_test_bad() {
+        let v4 = vec![[1.0, 2.0]];
+        let ls4: LineString<_> = v4.into();
     }
     #[test]
     fn type_test() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -390,7 +390,7 @@ mod test {
         let mut v = vec![];
         let p = Point::new(1.0, 2.0);
         v.push(p);
-        let ls = LineString::new(v).unwrap();
+        let _ = LineString::new(v).unwrap();
     }
     #[test]
     fn linestring_constructor_test() {
@@ -399,25 +399,25 @@ mod test {
         let p2 = Point::new(3.0, 4.0);
         v.push(p1);
         v.push(p2);
-        let ls = LineString::new(v).unwrap();
+        let _ = LineString::new(v).unwrap();
     }
     #[test]
     fn into_test() {
         let v1 = vec![(1.0, 2.0), (3.0, 4.0)];
-        let ls1 = LineString::from(v1);
+        let _ = LineString::from(v1);
         let v2 = vec![[1.0, 2.0], [3.0, 4.0]];
-        let ls2 = LineString::from(v2);
+        let _ = LineString::from(v2);
         let v3 = vec![(1.0, 2.0), (3.0, 4.0)];
-        let ls3: LineString<_> = v3.into();
+        let _: LineString<_> = v3.into();
         let v4 = vec![[1.0, 2.0], [3.0, 4.0]];
-        let ls4: LineString<_> = v4.into();
+        let _: LineString<_> = v4.into();
     }
     #[test]
     #[should_panic]
     // 1-element LineStrings aren't allowed
     fn into_test_bad() {
         let v4 = vec![[1.0, 2.0]];
-        let ls4: LineString<_> = v4.into();
+        let _: LineString<_> = v4.into();
     }
     #[test]
     fn type_test() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -343,10 +343,35 @@ pub enum Geometry<T>
     GeometryCollection(GeometryCollection<T>)
 }
 
+// Empty LineStrings should be allowed, 1-element LineStrings should not
+impl<T> LineString<T>
+    where T: Float
+{
+    pub fn new(v: Vec<Point<T>>) -> Result<LineString<T>, String> {
+        Self::_new(v)
+    }
+
+    fn _new(v: Vec<Point<T>>) -> Result<LineString<T>, String> {
+        match v.len() {
+            1 => Err("A LineString must have at least two Points".to_string()),
+            _ => Ok(LineString(v)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use ::types::*;
 
+    #[test]
+    #[should_panic]
+    // You can't construct a LineString with one point
+    fn linestring_constructor_test() {
+        let mut v = vec![];
+        let p = Point::new(1.0, 2.0);
+        v.push(p);
+        let ls = LineString::new(v).unwrap();
+    }
     #[test]
     fn type_test() {
         let c = Coordinate {


### PR DESCRIPTION
Ref #56 
This checks whether the vector being used has one element, and fails if it does.
The error is currently just a `String`. Is this OK?
