### PR TITLE
Add Point to Polygon and Point to LineString distance methods

### DIFF
--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -143,8 +143,8 @@ impl<T> Distance<T, Polygon<T>> for Point<T>
         for ring in &polygon.1 {
             dist_queue.push(Mindist { distance: self.distance(ring) })
         }
-        for chunk in ext_ring.chunks(2) {
-            let dist = line_segment_distance(self, &chunk[0], &chunk.last().unwrap_or(&chunk[0]));
+        for chunk in ext_ring.windows(2) {
+            let dist = line_segment_distance(self, &chunk[0], &chunk.last().unwrap());
             dist_queue.push(Mindist { distance: dist });
         }
         dist_queue.pop().unwrap().distance
@@ -164,8 +164,8 @@ impl<T> Distance<T, LineString<T>> for Point<T>
         let mut dist_queue: BinaryHeap<Mindist<T>> = BinaryHeap::new();
         // get points vector
         let points = &linestring.0;
-        for chunk in points.chunks(2) {
-            let dist = line_segment_distance(self, &chunk[0], &chunk.last().unwrap_or(&chunk[0]));
+        for chunk in points.windows(2) {
+            let dist = line_segment_distance(self, &chunk[0], &chunk.last().unwrap());
             dist_queue.push(Mindist { distance: dist });
         }
         dist_queue.pop().unwrap().distance
@@ -333,8 +333,7 @@ mod test {
         let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
         let p = Point::new(3.5, 2.5);
         let dist = p.distance(&ls);
-                      // 0.5 <-- Shapely
-        assert_eq!(dist, 0.5144957554275263);
+        assert_eq!(dist, 0.5);
     }
     #[test]
     // Point to LineString, empty LineString

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -216,7 +216,7 @@ mod test {
                           (6., 1.), (5., 1.)];
         let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
         let poly = Polygon(ls, vec![]);
-        // A Random point inside the octagon
+        // A point on the octagon
         let p = Point::new(5.0, 1.0);
         let dist = p.distance(&poly);
         assert_eq!(dist, 0.0);

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -88,7 +88,7 @@ fn line_segment_distance<T>(point: &Point<T>, start: &Point<T>, end: &Point<T>) 
 {
     let dist_squared = pow(start.distance(end), 2);
     // Implies that start == end
-    if dist_squared == T::zero() {
+    if dist_squared.is_zero() {
         return pow(point.distance(start), 2);
     }
     // Consider the line extending the segment, parameterized as start + t (end - start)
@@ -134,16 +134,14 @@ impl<T> Distance<T, Polygon<T>> for Point<T>
         // exterior ring as a LineString
         let ext_ring = &exterior.0;
         // No need to continue if the polygon contains the point, or is zero-length
-        if polygon.contains(self) || ext_ring.len() == 0 {
+        if polygon.contains(self) || ext_ring.is_empty() {
             return T::zero();
         }
         // minimum priority queue
         let mut dist_queue: BinaryHeap<Mindist<T>> = BinaryHeap::new();
         // we've got interior rings
-        if polygon.1.len() > 0 {
-            for ring in &polygon.1 {
-                dist_queue.push(Mindist { distance: self.distance(ring) })
-            }
+        for ring in &polygon.1 {
+            dist_queue.push(Mindist { distance: self.distance(ring) })
         }
         for chunk in ext_ring.chunks(2) {
             let dist = line_segment_distance(self, &chunk[0], &chunk.last().unwrap_or(&chunk[0]));

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -94,7 +94,7 @@ fn line_segment_distance<T>(point: &Point<T>, start: &Point<T>, end: &Point<T>) 
     // Consider the line extending the segment, parameterized as start + t (end - start)
     // We find the projection of the point onto the line
     // This falls where t = [(point - start) . (end - start)] / |end - start|^2, where . is the dot product
-    // We clamp t from [0.0, 1.0] to handle points outside the segment start, end
+    // We constrain t to a 0, 1 interval to handle points outside the segment start, end
     let t = T::zero().max(T::one().min((*point - *start).dot(&(*end - *start)) / dist_squared));
     let projected = Point::new(start.x() + t * (end.x() - start.x()),
                                start.y() + t * (end.y() - start.y()));

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -1,11 +1,12 @@
-use num::Float;
-use types::{Point};
+use num::{Float, ToPrimitive};
+use types::{Point, LineString};
+use num::pow::pow;
 
 /// Returns the distance between two geometries.
 
 pub trait Distance<T, Rhs = Self>
 {
-    /// Returns the distance between two points:
+    /// Returns the distance between two geometries:
     ///
     /// ```
     /// use geo::{COORD_PRECISION, Point};
@@ -27,10 +28,54 @@ impl<T> Distance<T, Point<T>> for Point<T>
     }
 }
 
+// Return minimum distance between a Point and a Line segment
+// This is a helper for Point-to-LineString and Point-to-Polygon distance
+// adapted from http://stackoverflow.com/a/1501725/416626
+fn line_segment_distance<T>(point: &Point<T>, start: &Point<T>, end: &Point<T>) -> T
+    where T: Float + ToPrimitive
+{
+    let dist_squared = pow(start.distance(end), 2);
+    // Implies that start == end 
+    if dist_squared == T::zero() {
+        return pow(point.distance(start), 2);
+    }
+    // Consider the line extending the segment, parameterized as start + t (end - start)
+    // We find the projection of the point onto the line
+    // This falls where t = [(point - start) . (end - start)] / |end - start|^2, where . is the dot product
+    // We clamp t from [0.0, 1.0] to handle points outside the segment start, end
+    let t = T::zero().max(T::one().min((*point - *start).dot(&(*end - *start)) / dist_squared));
+    let projected = Point::new(start.x() + t * (end.x() - start.x()),
+                               start.y() + t * (end.y() - start.y()));
+    point.distance(&projected)
+}
+
 #[cfg(test)]
 mod test {
     use types::{Point};
-    use algorithm::distance::{Distance};
+    use algorithm::distance::{Distance, line_segment_distance};
+    #[test]
+    fn line_segment_distance_test() {
+        let o1 = Point::new(8.0, 0.0);
+        let o2 = Point::new(5.5, 0.0);
+        let o3 = Point::new(5.0, 0.0);
+        let o4 = Point::new(4.5, 1.5);
+
+        let p1 = Point::new(7.2, 2.0);
+        let p2 = Point::new(6.0, 1.0);
+
+        let dist = line_segment_distance(&o1, &p1, &p2);
+        let dist2 = line_segment_distance(&o2, &p1, &p2);
+        let dist3 = line_segment_distance(&o3, &p1, &p2);
+        let dist4 = line_segment_distance(&o4, &p1, &p2);
+        // Results agree with Shapely
+        assert_eq!(dist, 2.048590078926335);
+        assert_eq!(dist2, 1.118033988749895);
+        assert_eq!(dist3, 1.4142135623730951);
+        assert_eq!(dist4, 1.5811388300841898);
+        // Point is on the line
+        let zero_dist = line_segment_distance(&p1, &p1, &p2);
+        assert_eq!(zero_dist, 0.0);
+    }
     #[test]
     fn distance1_test() {
         assert_eq!(Point::<f64>::new(0., 0.).distance(&Point::<f64>::new(1., 0.)), 1.);

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -117,7 +117,9 @@ impl<T> Distance<T, Polygon<T>> for Point<T>
 {
     fn distance(&self, polygon: &Polygon<T>) -> T {
         // No need to continue if the point is fully inside
-        if polygon.contains(self) { return T::zero() }
+        if polygon.contains(self) {
+            return T::zero();
+        }
         // minimum priority queue
         let mut dist_queue: BinaryHeap<Mindist<T>> = BinaryHeap::new();
         // get exterior ring
@@ -125,13 +127,7 @@ impl<T> Distance<T, Polygon<T>> for Point<T>
         // exterior ring as a LineString
         let ext_ring = &exterior.0;
         for chunk in ext_ring.chunks(2) {
-            let dist = match chunk.len() {
-                2 => line_segment_distance(self, chunk.first().unwrap(), chunk.last().unwrap()),
-                _ => {
-                    // final point in an odd-numbered exterior ring
-                    line_segment_distance(&self, chunk.first().unwrap(), chunk.first().unwrap())
-                }
-            };
+            let dist = line_segment_distance(self, &chunk[0], &chunk.last().unwrap_or(&chunk[0]));
             dist_queue.push(Mindist { distance: dist });
         }
         dist_queue.pop().unwrap().distance
@@ -144,19 +140,15 @@ impl<T> Distance<T, LineString<T>> for Point<T>
 {
     fn distance(&self, linestring: &LineString<T>) -> T {
         // No need to continue if the point is on the LineString
-        if linestring.contains(self) { return T::zero() }
+        if linestring.contains(self) {
+            return T::zero();
+        }
         // minimum priority queue
         let mut dist_queue: BinaryHeap<Mindist<T>> = BinaryHeap::new();
         // get points vector
         let points = &linestring.0;
         for chunk in points.chunks(2) {
-            let dist = match chunk.len() {
-                2 => line_segment_distance(self, chunk.first().unwrap(), chunk.last().unwrap()),
-                _ => {
-                    // final point in a LineString with an odd number of segments
-                    line_segment_distance(&self, chunk.first().unwrap(), chunk.first().unwrap())
-                }
-            };
+            let dist = line_segment_distance(self, &chunk[0], &chunk.last().unwrap_or(&chunk[0]));
             dist_queue.push(Mindist { distance: dist });
         }
         dist_queue.pop().unwrap().distance
@@ -194,17 +186,8 @@ mod test {
     // Point to Polygon, outside point
     fn point_polygon_distance_outside_test() {
         // an octagon
-        let points = vec![
-            (5., 1.),
-            (4., 2.),
-            (4., 3.),
-            (5., 4.),
-            (6., 4.),
-            (7., 3.),
-            (7., 2.),
-            (6., 1.),
-            (5., 1.)
-        ];
+        let points = vec![(5., 1.), (4., 2.), (4., 3.), (5., 4.), (6., 4.), (7., 3.), (7., 2.),
+                          (6., 1.), (5., 1.)];
         let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
         let poly = Polygon(ls, vec![]);
         // A Random point outside the octagon
@@ -216,17 +199,8 @@ mod test {
     // Point to Polygon, inside point
     fn point_polygon_distance_inside_test() {
         // an octagon
-        let points = vec![
-            (5., 1.),
-            (4., 2.),
-            (4., 3.),
-            (5., 4.),
-            (6., 4.),
-            (7., 3.),
-            (7., 2.),
-            (6., 1.),
-            (5., 1.)
-        ];
+        let points = vec![(5., 1.), (4., 2.), (4., 3.), (5., 4.), (6., 4.), (7., 3.), (7., 2.),
+                          (6., 1.), (5., 1.)];
         let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
         let poly = Polygon(ls, vec![]);
         // A Random point inside the octagon
@@ -238,17 +212,8 @@ mod test {
     // Point to Polygon, on boundary
     fn point_polygon_distance_boundary_test() {
         // an octagon
-        let points = vec![
-            (5., 1.),
-            (4., 2.),
-            (4., 3.),
-            (5., 4.),
-            (6., 4.),
-            (7., 3.),
-            (7., 2.),
-            (6., 1.),
-            (5., 1.)
-        ];
+        let points = vec![(5., 1.), (4., 2.), (4., 3.), (5., 4.), (6., 4.), (7., 3.), (7., 2.),
+                          (6., 1.), (5., 1.)];
         let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
         let poly = Polygon(ls, vec![]);
         // A Random point inside the octagon
@@ -298,7 +263,8 @@ mod test {
     }
     #[test]
     fn distance1_test() {
-        assert_eq!(Point::<f64>::new(0., 0.).distance(&Point::<f64>::new(1., 0.)), 1.);
+        assert_eq!(Point::<f64>::new(0., 0.).distance(&Point::<f64>::new(1., 0.)),
+                   1.);
     }
     #[test]
     fn distance2_test() {

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -11,12 +11,49 @@ pub trait Distance<T, Rhs = Self> {
     /// Returns the distance between two geometries:
     ///
     /// ```
-    /// use geo::{COORD_PRECISION, Point};
+    /// use geo::{COORD_PRECISION, Point, LineString, Polygon};
     /// use geo::algorithm::distance::Distance;
     ///
+    /// // Point to Point example
     /// let p = Point::new(-72.1235, 42.3521);
     /// let dist = p.distance(&Point::new(-72.1260, 42.45));
-    /// assert!(dist < COORD_PRECISION)
+    /// assert!(dist < COORD_PRECISION);
+    ///
+    /// // Point to Polygon example
+    /// let points = vec![
+    ///     (5., 1.),
+    ///     (4., 2.),
+    ///     (4., 3.),
+    ///     (5., 4.),
+    ///     (6., 4.),
+    ///     (7., 3.),
+    ///     (7., 2.),
+    ///     (6., 1.),
+    ///     (5., 1.)
+    /// ];
+    /// let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
+    /// let poly = Polygon(ls, vec![]);
+    /// // A Random point outside the polygon
+    /// let p = Point::new(2.5, 0.5);
+    /// let dist = p.distance(&poly);
+    /// assert_eq!(dist, 2.1213203435596424);
+    ///
+    /// // Point to LineString example
+    /// let points = vec![
+    ///     (5., 1.),
+    ///     (4., 2.),
+    ///     (4., 3.),
+    ///     (5., 4.),
+    ///     (6., 4.),
+    ///     (7., 3.),
+    ///     (7., 2.),
+    ///     (6., 1.),
+    /// ];
+    /// let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
+    /// // A Random point outside the LineString
+    /// let p = Point::new(5.5, 2.1);
+    /// let dist = p.distance(&ls);
+    /// assert_eq!(dist, 1.1313708498984758);
     /// ```
     fn distance(&self, rhs: &Rhs) -> T;
 }

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -144,7 +144,7 @@ impl<T> Distance<T, Polygon<T>> for Point<T>
             dist_queue.push(Mindist { distance: self.distance(ring) })
         }
         for chunk in ext_ring.windows(2) {
-            let dist = line_segment_distance(self, &chunk[0], &chunk.last().unwrap());
+            let dist = line_segment_distance(self, &chunk[0], &chunk[1]);
             dist_queue.push(Mindist { distance: dist });
         }
         dist_queue.pop().unwrap().distance
@@ -165,7 +165,7 @@ impl<T> Distance<T, LineString<T>> for Point<T>
         // get points vector
         let points = &linestring.0;
         for chunk in points.windows(2) {
-            let dist = line_segment_distance(self, &chunk[0], &chunk.last().unwrap());
+            let dist = line_segment_distance(self, &chunk[0], &chunk[1]);
             dist_queue.push(Mindist { distance: dist });
         }
         dist_queue.pop().unwrap().distance

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -334,7 +334,7 @@ mod test {
         let p = Point::new(3.5, 2.5);
         let dist = p.distance(&ls);
                       // 0.5 <-- Shapely
-        assert_eq!(dist, 0.5144957554275267);
+        assert_eq!(dist, 0.5144957554275263);
     }
     #[test]
     // Point to LineString, empty LineString

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -11,7 +11,7 @@ pub trait Distance<T, Rhs = Self> {
     /// Returns the distance between two geometries
     ///
     /// If a `Point` is contained by a `Polygon`, the distance is `0.0`  
-    /// If a `Point` lies on a `Polygon`'s exterior ring, the distance is `0.0`  
+    /// If a `Point` lies on a `Polygon`'s exterior or interior rings, the distance is `0.0`  
     /// If a `Point` lies on a `LineString`, the distance is `0.0`  
     /// The distance between a `Point` and an empty `LineString` is `0.0`  
     ///

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -182,7 +182,7 @@ mod test {
         let dist3 = line_segment_distance(&o3, &p1, &p2);
         let dist4 = line_segment_distance(&o4, &p1, &p2);
         // Results agree with Shapely
-        assert_eq!(dist, 2.048590078926335);
+        assert_eq!(dist, 2.0485900789263356);
         assert_eq!(dist2, 1.118033988749895);
         assert_eq!(dist3, 1.4142135623730951);
         assert_eq!(dist4, 1.5811388300841898);

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -280,6 +280,7 @@ mod test {
         // A point inside the cutout triangle
         let p = Point::new(3.5, 2.5);
         let dist = p.distance(&poly);
+                      // 0.41036467732879783 <-- Shapely
         assert_eq!(dist, 0.41036467732879767);
     }
     #[test]
@@ -321,6 +322,21 @@ mod test {
         let p = Point::new(5.0, 4.0);
         let dist = p.distance(&ls);
         assert_eq!(dist, 0.0);
+    }
+    #[test]
+    // Point to LineString, closed triangle
+    fn point_linestring_triangle_test() {
+        let points = vec![
+            (3.5, 3.5),
+            (4.4, 2.0),
+            (2.6, 2.0),
+            (3.5, 3.5)
+        ];
+        let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
+        let p = Point::new(3.5, 2.5);
+        let dist = p.distance(&ls);
+                      // 0.5 <-- Shapely
+        assert_eq!(dist, 0.5144957554275267);
     }
     #[test]
     // Point to LineString, empty LineString

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -74,7 +74,15 @@ impl<T> Distance<T, Point<T>> for Point<T>
 
 // Return minimum distance between a Point and a Line segment
 // This is a helper for Point-to-LineString and Point-to-Polygon distance
-// adapted from http://stackoverflow.com/a/1501725/416626
+// adapted from http://stackoverflow.com/a/1501725/416626. Quoting the author:
+//
+// The projection of point p onto a line is the point on the line closest to p.
+// (and a perpendicular to the line at the projection will pass through p).
+// The number t is how far along the line segment from start to end that the projection falls:
+// If t is 0, the projection falls right on start; if it's 1, it falls on end; if it's 0.5,
+// then it's halfway between. If t is less than 0 or greater than 1, it
+// falls on the line past one end or the other of the segment. In that case the
+// distance to the segment will be the distance to the nearer end
 fn line_segment_distance<T>(point: &Point<T>, start: &Point<T>, end: &Point<T>) -> T
     where T: Float + ToPrimitive
 {

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -8,7 +8,11 @@ use num::pow::pow;
 /// Returns the distance between two geometries.
 
 pub trait Distance<T, Rhs = Self> {
-    /// Returns the distance between two geometries:
+    /// Returns the distance between two geometries
+    ///
+    /// If a `Point` is contained by a `Polygon`, the distance is `0.0`  
+    /// If a `Point` lies on a `LineString`, the distance is `0.0`  
+    /// The distance between a `Point` and an empty `LineString` is `0.0`  
     ///
     /// ```
     /// use geo::{COORD_PRECISION, Point, LineString, Polygon};

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -11,6 +11,7 @@ pub trait Distance<T, Rhs = Self> {
     /// Returns the distance between two geometries
     ///
     /// If a `Point` is contained by a `Polygon`, the distance is `0.0`  
+    /// If a `Point` lies on a `Polygon`'s exterior ring, the distance is `0.0`  
     /// If a `Point` lies on a `LineString`, the distance is `0.0`  
     /// The distance between a `Point` and an empty `LineString` is `0.0`  
     ///


### PR DESCRIPTION
This PR adds distance methods from a `Point` to:
- a `LineString`
- a `Polygon`

To note:
- Points **inside a `Polygon`** return `0.0`
- Points on a **`Polygon` boundary** return `0.0`
- Points **on a `LineString`** return `0.0`
- distance to an **empty `LineString`** returns `0.0`
- distance to an **empty `Polygon`** (shouldn't be possible, but we're handling it for now) returns `0.0`
- I'm using a [`BinaryHeap`](https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html) implemented as a minimum priority queue with some floating-point-compatible comparator methods (see the `Ord` and `PartialOrd` `impl`s on `Mindist`) – I just adapted the linked example to use partial ordering. Please chime in if this is Bad, or if you can think of a better design.

Also WIP because:
- <s>no handling of empty geometries yet</s>
- <s>no docs / doctests yet</s>

This will close #59 if/when it merges.