### PR TITLE
Document Polygon struct parameters

### DIFF
--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -14,7 +14,7 @@ pub trait Area<T> where T: Float
     /// let p = |x, y| Point(Coordinate { x: x, y: y });
     /// let v = Vec::new();
     /// let linestring = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
-    /// let poly = Polygon(linestring, v);
+    /// let poly = Polygon::new(linestring, v);
     /// assert_eq!(poly.area(), 30.);
     /// ```
     fn area(&self) -> T;
@@ -36,8 +36,8 @@ impl<T> Area<T> for Polygon<T>
     where T: Float
 {
     fn area(&self) -> T {
-        self.1.iter().fold(get_linestring_area(&self.0),
-                           |total, next| total - get_linestring_area(next))
+        self.interiors.iter().fold(get_linestring_area(&self.exterior),
+                                   |total, next| total - get_linestring_area(next))
     }
 }
 
@@ -64,20 +64,20 @@ mod test {
     // Area of the polygon
     #[test]
     fn area_empty_polygon_test() {
-        let poly = Polygon::<f64>(LineString(Vec::new()), Vec::new());
+        let poly = Polygon::<f64>::new(LineString(Vec::new()), Vec::new());
         assert_eq!(poly.area(), 0.);
     }
 
     #[test]
     fn area_one_point_polygon_test() {
-        let poly = Polygon(LineString(vec![Point::new(1., 0.)]), Vec::new());
+        let poly = Polygon::new(LineString(vec![Point::new(1., 0.)]), Vec::new());
         assert_eq!(poly.area(), 0.);
     }
     #[test]
     fn area_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
-        let poly = Polygon(linestring, Vec::new());
+        let poly = Polygon::new(linestring, Vec::new());
         assert_eq!(poly.area(), 30.);
     }
     #[test]
@@ -91,18 +91,21 @@ mod test {
         let outer = LineString(vec![p(0., 0.), p(10., 0.), p(10., 10.), p(0., 10.), p(0., 0.)]);
         let inner0 = LineString(vec![p(1., 1.), p(2., 1.), p(2., 2.), p(1., 2.), p(1., 1.)]);
         let inner1 = LineString(vec![p(5., 5.), p(6., 5.), p(6., 6.), p(5., 6.), p(5., 5.)]);
-        let poly = Polygon(outer, vec![inner0, inner1]);
+        let poly = Polygon::new(outer, vec![inner0, inner1]);
         assert_eq!(poly.area(), 98.);
     }
     #[test]
     fn area_multipolygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let poly0 = Polygon(LineString(vec![p(0., 0.), p(10., 0.), p(10., 10.), p(0., 10.), p(0., 0.)]),
-                            Vec::new());
-        let poly1 = Polygon(LineString(vec![p(1., 1.), p(2., 1.), p(2., 2.), p(1., 2.), p(1., 1.)]),
-                            Vec::new());
-        let poly2 = Polygon(LineString(vec![p(5., 5.), p(6., 5.), p(6., 6.), p(5., 6.), p(5., 5.)]),
-                            Vec::new());
+        let poly0 = Polygon::new(LineString(vec![p(0., 0.), p(10., 0.), p(10., 10.), p(0., 10.),
+                                                 p(0., 0.)]),
+                                 Vec::new());
+        let poly1 = Polygon::new(LineString(vec![p(1., 1.), p(2., 1.), p(2., 2.), p(1., 2.),
+                                                 p(1., 1.)]),
+                                 Vec::new());
+        let poly2 = Polygon::new(LineString(vec![p(5., 5.), p(6., 5.), p(6., 6.), p(5., 6.),
+                                                 p(5., 5.)]),
+                                 Vec::new());
         let mpoly = MultiPolygon(vec![poly0, poly1, poly2]);
         assert_eq!(mpoly.area(), 102.);
     }

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -94,7 +94,7 @@ impl<T> BoundingBox<T> for Polygon<T>
     /// Return the BoundingBox for a Polygon
     ///
     fn bbox(&self) -> Option<Bbox<T>> {
-        let line = &self.0;
+        let line = &self.exterior;
         get_bbox(&line.0)
     }
 }
@@ -106,7 +106,7 @@ impl<T> BoundingBox<T> for MultiPolygon<T>
     /// Return the BoundingBox for a MultiPolygon
     ///
     fn bbox(&self) -> Option<Bbox<T>> {
-        get_bbox(self.0.iter().flat_map(|poly| (poly.0).0.iter()))
+        get_bbox(self.0.iter().flat_map(|poly| (poly.exterior).0.iter()))
     }
 }
 
@@ -162,15 +162,15 @@ mod test {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
         let line_bbox = linestring.bbox().unwrap();
-        let poly = Polygon(linestring, Vec::new());
+        let poly = Polygon::new(linestring, Vec::new());
         assert_eq!(line_bbox, poly.bbox().unwrap());
     }
     #[test]
     fn multipolygon_test(){
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let mpoly = MultiPolygon(vec![Polygon(LineString(vec![p(0., 0.), p(50., 0.), p(0., -70.), p(0., 0.)]), Vec::new()),
-                                      Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(0., 80.), p(0., 0.)]), Vec::new()),
-                                      Polygon(LineString(vec![p(0., 0.), p(-60., 0.), p(0., 6.), p(0., 0.)]), Vec::new()),
+        let mpoly = MultiPolygon(vec![Polygon::new(LineString(vec![p(0., 0.), p(50., 0.), p(0., -70.), p(0., 0.)]), Vec::new()),
+                                      Polygon::new(LineString(vec![p(0., 0.), p(5., 0.), p(0., 80.), p(0., 0.)]), Vec::new()),
+                                      Polygon::new(LineString(vec![p(0., 0.), p(-60., 0.), p(0., 6.), p(0., 0.)]), Vec::new()),
                                       ]);
         let bbox = Bbox{xmin: -60., ymax: 80., xmax: 50., ymin: -70.};
         assert_eq!(bbox, mpoly.bbox().unwrap());

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -63,7 +63,7 @@ impl<T> Centroid<T> for Polygon<T>
     ///
     fn centroid(&self) -> Option<Point<T>> {
         // TODO: consideration of inner polygons;
-        let linestring = &self.0;
+        let linestring = &self.exterior;
         let vect = &linestring.0;
         if vect.is_empty() {
             return None;
@@ -156,7 +156,7 @@ mod test {
         let v1 = Vec::new();
         let v2 = Vec::new();
         let linestring = LineString::<f64>(v1);
-        let poly = Polygon(linestring, v2);
+        let poly = Polygon::new(linestring, v2);
         assert!(poly.centroid().is_none());
     }
     #[test]
@@ -164,7 +164,7 @@ mod test {
         let p = Point(Coordinate { x: 2., y: 1. });
         let v = Vec::new();
         let linestring = LineString(vec![p]);
-        let poly = Polygon(linestring, v);
+        let poly = Polygon::new(linestring, v);
         assert_eq!(poly.centroid(), Some(p));
     }
     #[test]
@@ -172,7 +172,7 @@ mod test {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let v = Vec::new();
         let linestring = LineString(vec![p(0., 0.), p(2., 0.), p(2., 2.), p(0., 2.), p(0., 0.)]);
-        let poly = Polygon(linestring, v);
+        let poly = Polygon::new(linestring, v);
         assert_eq!(poly.centroid(), Some(p(1., 1.)));
     }
     /// Tests: Centroid of MultiPolygon
@@ -184,16 +184,16 @@ mod test {
     fn multipolygon_one_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(0., 0.), p(2., 0.), p(2., 2.), p(0., 2.), p(0., 0.)]);
-        let poly = Polygon(linestring, Vec::new());
+        let poly = Polygon::new(linestring, Vec::new());
         assert_eq!(MultiPolygon(vec![poly]).centroid(), Some(p(1., 1.)));
     }
     #[test]
     fn multipolygon_two_polygons_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(2., 1.), p(5., 1.), p(5., 3.), p(2., 3.), p(2., 1.)]);
-        let poly1 = Polygon(linestring, Vec::new());
+        let poly1 = Polygon::new(linestring, Vec::new());
         let linestring = LineString(vec![p(7., 1.), p(8., 1.), p(8., 2.), p(7., 2.), p(7., 1.)]);
-        let poly2 = Polygon(linestring, Vec::new());
+        let poly2 = Polygon::new(linestring, Vec::new());
         let dist = MultiPolygon(vec![poly1, poly2]).centroid().unwrap().distance(&p(4.07142857142857, 1.92857142857143));
         assert!(dist < COORD_PRECISION);
     }

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -37,7 +37,7 @@ pub trait Distance<T, Rhs = Self> {
     ///     (5., 1.)
     /// ];
     /// let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
-    /// let poly = Polygon(ls, vec![]);
+    /// let poly = Polygon::new(ls, vec![]);
     /// // A Random point outside the polygon
     /// let p = Point::new(2.5, 0.5);
     /// let dist = p.distance(&poly);
@@ -130,7 +130,7 @@ impl<T> Distance<T, Polygon<T>> for Point<T>
 {
     fn distance(&self, polygon: &Polygon<T>) -> T {
         // get exterior ring
-        let exterior = &polygon.0;
+        let exterior = &polygon.exterior;
         // exterior ring as a LineString
         let ext_ring = &exterior.0;
         // No need to continue if the polygon contains the point, or is zero-length
@@ -140,7 +140,7 @@ impl<T> Distance<T, Polygon<T>> for Point<T>
         // minimum priority queue
         let mut dist_queue: BinaryHeap<Mindist<T>> = BinaryHeap::new();
         // we've got interior rings
-        for ring in &polygon.1 {
+        for ring in &polygon.interiors {
             dist_queue.push(Mindist { distance: self.distance(ring) })
         }
         for chunk in ext_ring.windows(2) {
@@ -206,7 +206,7 @@ mod test {
         let points = vec![(5., 1.), (4., 2.), (4., 3.), (5., 4.), (6., 4.), (7., 3.), (7., 2.),
                           (6., 1.), (5., 1.)];
         let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
-        let poly = Polygon(ls, vec![]);
+        let poly = Polygon::new(ls, vec![]);
         // A Random point outside the octagon
         let p = Point::new(2.5, 0.5);
         let dist = p.distance(&poly);
@@ -219,7 +219,7 @@ mod test {
         let points = vec![(5., 1.), (4., 2.), (4., 3.), (5., 4.), (6., 4.), (7., 3.), (7., 2.),
                           (6., 1.), (5., 1.)];
         let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
-        let poly = Polygon(ls, vec![]);
+        let poly = Polygon::new(ls, vec![]);
         // A Random point inside the octagon
         let p = Point::new(5.5, 2.1);
         let dist = p.distance(&poly);
@@ -232,7 +232,7 @@ mod test {
         let points = vec![(5., 1.), (4., 2.), (4., 3.), (5., 4.), (6., 4.), (7., 3.), (7., 2.),
                           (6., 1.), (5., 1.)];
         let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
-        let poly = Polygon(ls, vec![]);
+        let poly = Polygon::new(ls, vec![]);
         // A point on the octagon
         let p = Point::new(5.0, 1.0);
         let dist = p.distance(&poly);
@@ -244,7 +244,7 @@ mod test {
         // an empty Polygon
         let points = vec![];
         let ls = LineString(points);
-        let poly = Polygon(ls, vec![]);
+        let poly = Polygon::new(ls, vec![]);
         // A point on the octagon
         let p = Point::new(2.5, 0.5);
         let dist = p.distance(&poly);
@@ -274,7 +274,7 @@ mod test {
         ];
         let ls_ext = LineString(ext_points.iter().map(|e| Point::new(e.0, e.1)).collect());
         let ls_int = LineString(int_points.iter().map(|e| Point::new(e.0, e.1)).collect());
-        let poly = Polygon(ls_ext, vec![ls_int]);
+        let poly = Polygon::new(ls_ext, vec![ls_int]);
         // A point inside the cutout triangle
         let p = Point::new(3.5, 2.5);
         let dist = p.distance(&poly);

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -59,7 +59,7 @@ impl<T> Intersects<LineString<T>> for Polygon<T>
 {
     fn intersects(&self, linestring: &LineString<T>) -> bool {
         // line intersects inner or outer polygon edge
-        if self.0.intersects(linestring) || self.1.iter().any(|inner| inner.intersects(linestring)) {
+        if self.exterior.intersects(linestring) || self.interiors.iter().any(|inner| inner.intersects(linestring)) {
             return true;
         } else {
             // or if it's contained in the polygon
@@ -119,14 +119,14 @@ mod test {
     fn linestring_in_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
-        let poly = Polygon(linestring, Vec::new());
+        let poly = Polygon::new(linestring, Vec::new());
         assert!(poly.intersects(&LineString(vec![p(2., 2.), p(3., 3.)])));
     }
     #[test]
     fn linestring_on_boundary_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
-                           Vec::new());
+        let poly = Polygon::new(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
+                                Vec::new());
         assert!(poly.intersects(&LineString(vec![p(0., 0.), p(5., 0.)])));
         assert!(poly.intersects(&LineString(vec![p(5., 0.), p(5., 6.)])));
         assert!(poly.intersects(&LineString(vec![p(5., 6.), p(0., 6.)])));
@@ -135,32 +135,32 @@ mod test {
     #[test]
     fn intersect_linestring_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
-                           Vec::new());
+        let poly = Polygon::new(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
+                                Vec::new());
         assert!(poly.intersects(&LineString(vec![p(2., 2.), p(6., 6.)])));
     }
     #[test]
     fn linestring_outside_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
-                           Vec::new());
+        let poly = Polygon::new(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
+                                Vec::new());
         assert!(!poly.intersects(&LineString(vec![p(7., 2.), p(9., 4.)])));
     }
     #[test]
     fn linestring_in_inner_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
+        let e = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
         let v = vec![LineString(vec![p(1., 1.), p(4., 1.), p(4., 4.), p(1., 4.), p(1., 1.)])];
-        let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
-                           v);
+        let poly = Polygon::new(e, v);
         assert!(!poly.intersects(&LineString(vec![p(2., 2.), p(3., 3.)])));
         assert!(poly.intersects(&LineString(vec![p(2., 2.), p(4., 4.)])));
     }
     #[test]
     fn linestring_traverse_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
+        let e = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
         let v = vec![LineString(vec![p(1., 1.), p(4., 1.), p(4., 4.), p(1., 4.), p(1., 1.)])];
-        let poly = Polygon(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
-                           v);
+        let poly = Polygon::new(e, v);
         assert!(poly.intersects(&LineString(vec![p(2., 0.5), p(2., 5.)])));
     }
     #[test]
@@ -190,11 +190,10 @@ mod test {
         //
         let p = |x, y| Point(Coordinate { x: x, y: y });
 
+        let e = LineString(vec![p(2., 2.), p(14., 2.), p(14., 8.), p(2., 8.), p(2., 2.)]);
         let v = vec![LineString(vec![p(4., 3.), p(7., 3.), p(7., 6.), p(4., 6.), p(4., 3.)]),
                      LineString(vec![p(9., 3.), p(12., 3.), p(12., 6.), p(9., 6.), p(9., 3.)])];
-        let poly = Polygon(LineString(vec![p(2., 2.), p(14., 2.), p(14., 8.), p(2., 8.),
-                                           p(2., 2.)]),
-                           v);
+        let poly = Polygon::new(e, v);
         assert!(!poly.intersects(&LineString(vec![p(5., 4.), p(6., 5.)])));
         assert!(poly.intersects(&LineString(vec![p(11., 2.5), p(11., 7.)])));
         assert!(poly.intersects(&LineString(vec![p(4., 7.), p(6., 7.)])));

--- a/src/types.rs
+++ b/src/types.rs
@@ -296,7 +296,32 @@ pub struct LineString<T>(pub Vec<Point<T>>) where T: Float;
 pub struct MultiLineString<T>(pub Vec<LineString<T>>) where T: Float;
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct Polygon<T>(pub LineString<T>, pub Vec<LineString<T>>) where T: Float;
+pub struct Polygon<T>
+    where T: Float
+{
+    pub exterior: LineString<T>,
+    pub interiors: Vec<LineString<T>>
+}
+
+impl<T> Polygon<T>
+    where T: Float
+{
+    /// Creates a new polygon.
+    ///
+    /// ```
+    /// use geo::Polygon;
+    ///
+    /// let exterior = LineString(vec![Point::new(0., 0.), Point::new(1., 1.),
+    ///                                Point::new(1., 0.), Point::new(0., 0.)]);
+    /// let interiors = vec![];
+    /// let p = Polygon::new(exterior.clone(), interiors.clone());
+    /// assert_eq!(p.exterior, exterior);
+    /// assert_eq!(p.interiors, interiors);
+    /// ```
+    pub fn new(exterior: LineString<T>, interiors: Vec<LineString<T>>) -> Polygon<T> {
+        Polygon { exterior: exterior, interiors: interiors }
+    }
+}
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct MultiPolygon<T>(pub Vec<Polygon<T>>) where T: Float;
@@ -334,5 +359,16 @@ mod test {
         assert_eq!(c, c2);
         assert_eq!(c.x, c2.x);
         assert_eq!(c.y, c2.y);
+    }
+
+    #[test]
+    fn polygon_new_test() {
+        let exterior = LineString(vec![Point::new(0., 0.), Point::new(1., 1.),
+                                       Point::new(1., 0.), Point::new(0., 0.)]);
+        let interiors = vec![];
+        let p = Polygon::new(exterior.clone(), interiors.clone());
+
+        assert_eq!(p.exterior, exterior);
+        assert_eq!(p.interiors, interiors);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -309,11 +309,12 @@ impl<T> Polygon<T>
     /// Creates a new polygon.
     ///
     /// ```
-    /// use geo::Polygon;
+    /// use geo::{Point, LineString, Polygon};
     ///
     /// let exterior = LineString(vec![Point::new(0., 0.), Point::new(1., 1.),
     ///                                Point::new(1., 0.), Point::new(0., 0.)]);
-    /// let interiors = vec![];
+    /// let interiors = vec![LineString(vec![Point::new(0.1, 0.1), Point::new(0.9, 0.9),
+    ///                                      Point::new(0.9, 0.1), Point::new(0.1, 0.1)])];
     /// let p = Polygon::new(exterior.clone(), interiors.clone());
     /// assert_eq!(p.exterior, exterior);
     /// assert_eq!(p.interiors, interiors);
@@ -365,7 +366,8 @@ mod test {
     fn polygon_new_test() {
         let exterior = LineString(vec![Point::new(0., 0.), Point::new(1., 1.),
                                        Point::new(1., 0.), Point::new(0., 0.)]);
-        let interiors = vec![];
+        let interiors = vec![LineString(vec![Point::new(0.1, 0.1), Point::new(0.9, 0.9),
+                                             Point::new(0.9, 0.1), Point::new(0.1, 0.1)])];
         let p = Polygon::new(exterior.clone(), interiors.clone());
 
         assert_eq!(p.exterior, exterior);


### PR DESCRIPTION
Addresses #60

Replaces the Polygon tuple struct with a regular struct:

```
pub struct Polygon<T>
    where T: Float
{
    pub exterior: LineString<T>,
    pub interiors: Vec<LineString<T>>
}
```

I'm new to rust and eager to learn so comment away!

This breaks the existing Polygon constructor since (correct me if
I'm wrong) structs must be instaniated with curly braces and named
arguments. To mitigate the effect of this change on existing code,
`Polygon` implements a `new` method that preserves the old interface:

`Polygon::new(exterior, interiors)`

I chose `exterior` and `interiors` over `outer` and `inners` as I
believe the former pair is more commonly used. I don't feel strongly
about this choice and will change it upon request.