### PR TITLE
Bump version to 0.2.7.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/rust-geo"


### PR DESCRIPTION
Forgot to bump the version number in
https://github.com/georust/rust-geo/pull/72.