### PR TITLE
Within Epsilon matcher

### DIFF
--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -59,31 +59,33 @@ impl<T> Area<T> for Bbox<T>
 
 #[cfg(test)]
 mod test {
+    use num::Float;
     use types::{Coordinate, Point, LineString, Polygon, MultiPolygon, Bbox};
     use algorithm::area::Area;
+    use test_helpers::within_epsilon;
     // Area of the polygon
     #[test]
     fn area_empty_polygon_test() {
         let poly = Polygon::<f64>::new(LineString(Vec::new()), Vec::new());
-        assert_eq!(poly.area(), 0.);
+        assert!(within_epsilon(poly.area(), 0., Float::epsilon()));
     }
 
     #[test]
     fn area_one_point_polygon_test() {
         let poly = Polygon::new(LineString(vec![Point::new(1., 0.)]), Vec::new());
-        assert_eq!(poly.area(), 0.);
+        assert!(within_epsilon(poly.area(), 0., Float::epsilon()));
     }
     #[test]
     fn area_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
         let poly = Polygon::new(linestring, Vec::new());
-        assert_eq!(poly.area(), 30.);
+        assert!(within_epsilon(poly.area(), 30., Float::epsilon()));
     }
     #[test]
     fn bbox_test() {
         let bbox = Bbox {xmin: 10., xmax: 20., ymin: 30., ymax: 40.};
-        assert_eq!(100., bbox.area());
+        assert!(within_epsilon(bbox.area(), 100., Float::epsilon()));
     }
     #[test]
     fn area_polygon_inner_test() {
@@ -92,7 +94,7 @@ mod test {
         let inner0 = LineString(vec![p(1., 1.), p(2., 1.), p(2., 2.), p(1., 2.), p(1., 1.)]);
         let inner1 = LineString(vec![p(5., 5.), p(6., 5.), p(6., 6.), p(5., 6.), p(5., 5.)]);
         let poly = Polygon::new(outer, vec![inner0, inner1]);
-        assert_eq!(poly.area(), 98.);
+        assert!(within_epsilon(poly.area(), 98., Float::epsilon()));
     }
     #[test]
     fn area_multipolygon_test() {
@@ -108,5 +110,6 @@ mod test {
                                  Vec::new());
         let mpoly = MultiPolygon(vec![poly0, poly1, poly2]);
         assert_eq!(mpoly.area(), 102.);
+        assert!(within_epsilon(mpoly.area(), 102., Float::epsilon()));
     }
 }

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -176,6 +176,8 @@ impl<T> Distance<T, LineString<T>> for Point<T>
 mod test {
     use types::{Point, LineString, Polygon};
     use algorithm::distance::{Distance, line_segment_distance};
+    use test_helpers::within_epsilon;
+
     #[test]
     fn line_segment_distance_test() {
         let o1 = Point::new(8.0, 0.0);
@@ -191,13 +193,13 @@ mod test {
         let dist3 = line_segment_distance(&o3, &p1, &p2);
         let dist4 = line_segment_distance(&o4, &p1, &p2);
         // Results agree with Shapely
-        assert_eq!(dist, 2.0485900789263356);
-        assert_eq!(dist2, 1.118033988749895);
-        assert_eq!(dist3, 1.4142135623730951);
-        assert_eq!(dist4, 1.5811388300841898);
+        assert!(within_epsilon(dist, 2.0485900789263356, 1.0e-15));
+        assert!(within_epsilon(dist2, 1.118033988749895, 1.0e-15));
+        assert!(within_epsilon(dist3, 1.4142135623730951, 1.0e-15));
+        assert!(within_epsilon(dist4, 1.5811388300841898, 1.0e-15));
         // Point is on the line
         let zero_dist = line_segment_distance(&p1, &p1, &p2);
-        assert_eq!(zero_dist, 0.0);
+        assert!(within_epsilon(zero_dist, 0.0, 1.0e-15));
     }
     #[test]
     // Point to Polygon, outside point
@@ -210,7 +212,7 @@ mod test {
         // A Random point outside the octagon
         let p = Point::new(2.5, 0.5);
         let dist = p.distance(&poly);
-        assert_eq!(dist, 2.1213203435596424);
+        assert!(within_epsilon(dist, 2.1213203435596424, 1.0e-15));
     }
     #[test]
     // Point to Polygon, inside point
@@ -223,7 +225,7 @@ mod test {
         // A Random point inside the octagon
         let p = Point::new(5.5, 2.1);
         let dist = p.distance(&poly);
-        assert_eq!(dist, 0.0);
+        assert!(within_epsilon(dist, 0.0, 1.0e-15));
     }
     #[test]
     // Point to Polygon, on boundary
@@ -236,7 +238,7 @@ mod test {
         // A point on the octagon
         let p = Point::new(5.0, 1.0);
         let dist = p.distance(&poly);
-        assert_eq!(dist, 0.0);
+        assert!(within_epsilon(dist, 0.0, 1.0e-15));
     }
     #[test]
     // Point to Polygon, empty Polygon
@@ -248,7 +250,7 @@ mod test {
         // A point on the octagon
         let p = Point::new(2.5, 0.5);
         let dist = p.distance(&poly);
-        assert_eq!(dist, 0.0);
+        assert!(within_epsilon(dist, 0.0, 1.0e-15));
     }
     #[test]
     // Point to Polygon with an interior ring
@@ -279,7 +281,7 @@ mod test {
         let p = Point::new(3.5, 2.5);
         let dist = p.distance(&poly);
                       // 0.41036467732879783 <-- Shapely
-        assert_eq!(dist, 0.41036467732879767);
+        assert!(within_epsilon(dist, 0.41036467732879767, 1.0e-15));
     }
     #[test]
     // Point to LineString
@@ -299,7 +301,7 @@ mod test {
         // A Random point "inside" the LineString
         let p = Point::new(5.5, 2.1);
         let dist = p.distance(&ls);
-        assert_eq!(dist, 1.1313708498984758);
+        assert!(within_epsilon(dist, 1.1313708498984758, 1.0e-15));
     }
     #[test]
     // Point to LineString, point lies on the LineString
@@ -319,7 +321,7 @@ mod test {
         // A point which lies on the LineString
         let p = Point::new(5.0, 4.0);
         let dist = p.distance(&ls);
-        assert_eq!(dist, 0.0);
+        assert!(within_epsilon(dist, 0.0, 1.0e-15));
     }
     #[test]
     // Point to LineString, closed triangle
@@ -333,7 +335,7 @@ mod test {
         let ls = LineString(points.iter().map(|e| Point::new(e.0, e.1)).collect());
         let p = Point::new(3.5, 2.5);
         let dist = p.distance(&ls);
-        assert_eq!(dist, 0.5);
+        assert!(within_epsilon(dist, 0.5, 1.0e-15));
     }
     #[test]
     // Point to LineString, empty LineString
@@ -342,7 +344,7 @@ mod test {
         let ls = LineString(points);
         let p = Point::new(5.0, 4.0);
         let dist = p.distance(&ls);
-        assert_eq!(dist, 0.0);
+        assert!(within_epsilon(dist, 0.0, 1.0e-15));
     }
     #[test]
     fn distance1_test() {

--- a/src/algorithm/simplify.rs
+++ b/src/algorithm/simplify.rs
@@ -85,13 +85,15 @@ impl<T> Simplify<T> for LineString<T>
 mod test {
     use types::{Point};
     use super::{point_line_distance, rdp};
+    use test_helpers::within_epsilon;
+
     #[test]
     fn perpdistance_test() {
         let start = Point::new(1.0, 2.0);
         let end = Point::new(3.0, 4.0);
         let p = Point::new(1.0, 1.0);
         let dist = point_line_distance(&p, &start, &end);
-        assert_eq!(dist, 0.7071067811865475);
+        assert!(within_epsilon(dist, 0.7071067811865475, 1.0e-15));
     }
     #[test]
     fn rdp_test() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,6 @@ mod traits;
 mod types;
 /// This module includes all the functions of geometric calculations
 pub mod algorithm;
+
+#[cfg(test)]
+mod test_helpers;

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,50 @@
+use num::Float;
+
+pub fn within_epsilon<F: Float>(x: F, y: F, epsilon: F) -> bool {
+    let a = x.abs();
+    let b = y.abs();
+    let delta = (a - b).abs();
+
+    if a.is_infinite() ||
+        a.is_nan() ||
+        b.is_infinite() ||
+        b.is_nan() {
+        false
+    } else if a == b {
+        true
+    } else if (a == F::zero()) || (b == F::zero()) {
+        delta <= epsilon
+    } else {
+        delta / b <= epsilon
+    }
+}
+
+#[test]
+fn within_epsilon_true_if_floats_equal() {
+    assert!(within_epsilon(1.0, 1.0, 0.0001));
+    assert!(within_epsilon(0.0, 0.0, 0.0001));
+}
+
+#[test]
+fn within_epsilon_true_if_floats_close() {
+    assert!(within_epsilon(1.00000001, 1.00000002, 0.01));
+    assert!(within_epsilon(0.0, 0.00000002, 0.01));
+    assert!(within_epsilon(0.00000001, 0.0, 0.01));
+    assert!(within_epsilon(0.0000001, -0.0000001, 0.00001));
+}
+
+#[test]
+fn within_epsilon_false_if_floats_far() {
+    assert!(!within_epsilon(1.0, 10.0, 0.1));
+    assert!(!within_epsilon(1.0, 0.0, 0.1));
+    assert!(!within_epsilon(0.0, 1.0, 0.1));
+}
+
+#[test]
+fn within_epsilon_false_if_floats_infinite_or_nan() {
+    assert!(!within_epsilon(Float::infinity(), Float::neg_infinity(), 0.1));
+    assert!(!within_epsilon(Float::infinity(), Float::infinity(), 0.1));
+    assert!(!within_epsilon(Float::infinity(), 1.0, 0.1));
+    assert!(!within_epsilon(Float::nan(), 1.0, 0.1));
+    assert!(!within_epsilon(1.0, Float::nan(), 0.1));
+}


### PR DESCRIPTION
For https://github.com/georust/rust-geo/issues/75

I couldn't get the `within_epsilon` in the doctest; I think it's because I have it set to compile in test only. 