### PR TITLE
Migrate from 'num' to 'num_traits' crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ documentation = "https://georust.github.io/rust-geo/"
 keywords = ["gis", "geo", "geography", "geospatial"]
 
 [dependencies]
-num = "0.1"
+num-traits = "0.1"

--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 use types::{LineString, Polygon, MultiPolygon, Bbox};
 
 /// Calculation of the area.
@@ -59,7 +59,7 @@ impl<T> Area<T> for Bbox<T>
 
 #[cfg(test)]
 mod test {
-    use num::Float;
+    use num_traits::Float;
     use types::{Coordinate, Point, LineString, Polygon, MultiPolygon, Bbox};
     use algorithm::area::Area;
     use test_helpers::within_epsilon;

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use types::{Bbox, Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon};
 

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -1,4 +1,4 @@
-use num::{Float, FromPrimitive};
+use num_traits::{Float, FromPrimitive};
 
 use types::{Point, LineString, Polygon, MultiPolygon, Bbox};
 use algorithm::area::Area;

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -1,4 +1,4 @@
-use num::{Float, ToPrimitive};
+use num_traits::{Float, ToPrimitive};
 
 use types::{COORD_PRECISION, Point, LineString, Polygon, MultiPolygon, Bbox};
 use algorithm::intersects::Intersects;

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -1,9 +1,9 @@
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
-use num::{Float, ToPrimitive};
+use num_traits::{Float, ToPrimitive};
 use types::{Point, LineString, Polygon};
 use algorithm::contains::Contains;
-use num::pow::pow;
+use num_traits::pow::pow;
 
 /// Returns the distance between two geometries.
 

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 use types::{LineString, Polygon, Bbox, Point};
 use algorithm::contains::Contains;
 

--- a/src/algorithm/length.rs
+++ b/src/algorithm/length.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use types::{LineString, MultiLineString};
 use algorithm::distance::Distance;

--- a/src/algorithm/simplify.rs
+++ b/src/algorithm/simplify.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 use types::{Point, LineString};
 use algorithm::distance::Distance;
 

--- a/src/algorithm/simplifyvw.rs
+++ b/src/algorithm/simplifyvw.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
-use num::Float;
+use num_traits::Float;
 use types::{Point, LineString};
 
 // A helper struct for `visvalingam`, defined out here because

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate num;
+extern crate num_traits;
 
 pub use traits::ToGeo;
 pub use types::*;

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 pub fn within_epsilon<F: Float>(x: F, y: F, epsilon: F) -> bool {
     let a = x.abs();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,6 @@
 pub use ::Geometry;
 
-use num::Float;
+use num_traits::Float;
 
 pub trait ToGeo<T: Float>
 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,7 @@ use std::ops::AddAssign;
 use std::ops::Neg;
 use std::ops::Sub;
 
-use num::{Float, ToPrimitive};
+use num_traits::{Float, ToPrimitive};
 
 pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
 


### PR DESCRIPTION
The 'num' crate is a meta-crate consisting of multiple librarie crates,
including 'num_traits'. We only need access to 'num_traits', we can just
depend on that.