### PR TITLE
Use Angle trait for lat/lng Points

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["gis", "geo", "geography", "geospatial"]
 
 [dependencies]
 num-traits = "0.1"
+cgmath = "^0.12.0"
 
 [dev-dependencies]
 approx = "0.1.1"

--- a/src/algorithm/haversine_distance.rs
+++ b/src/algorithm/haversine_distance.rs
@@ -29,7 +29,7 @@ impl<T> HaversineDistance<T, Point<T>> for Point<T>
     fn haversine_distance(&self, rhs: &Point<T>) -> T {
         let (lhs_sin, lhs_cos) = self.y().to_radians().sin_cos();
         let (rhs_sin, rhs_cos) = rhs.y().to_radians().sin_cos();
-        let delta_lng = rhs.lng() - self.lng();
+        let delta_lng = rhs.x() - self.x();
 
         let a = (lhs_sin * rhs_sin) + (lhs_cos * rhs_cos) * delta_lng.to_radians().cos();
 

--- a/src/algorithm/haversine_distance.rs
+++ b/src/algorithm/haversine_distance.rs
@@ -4,8 +4,11 @@ use types::Point;
 
 /// Returns the distance between two geometries.
 
-pub trait HaversineDistance<T, Rhs = Self>
+pub trait HaversineDistance<RHS = Self>
 {
+    /// The resulting type after applying the Haversine algorithm
+    type Output;
+
     /// Returns the distance between two points:
     ///
     /// ```
@@ -23,20 +26,22 @@ pub trait HaversineDistance<T, Rhs = Self>
     /// assert_relative_eq!(dist, 10900.115612674515, epsilon = 1.0e-6)
     /// # }
     /// ```
-    fn haversine_distance(&self, rhs: &Rhs) -> T;
+    fn haversine_distance(&self, rhs: &RHS) -> Self::Output;
 }
 
-impl<T> HaversineDistance<T::Unitless, Point<T>> for Point<T>
+impl<T> HaversineDistance for Point<T>
     where T: Angle
 {
-    fn haversine_distance(&self, rhs: &Point<T>) -> T::Unitless {
+    type Output = T::Unitless;
+
+    fn haversine_distance(&self, rhs: &Point<T>) -> Self::Output {
         let (lhs_sin, lhs_cos) = self.lat().sin_cos();
         let (rhs_sin, rhs_cos) = rhs.lat().sin_cos();
         let delta_lng = rhs.lng() - self.lng();
 
         let a = (lhs_sin * rhs_sin) + (lhs_cos * rhs_cos) * delta_lng.cos();
 
-        cast::<u32, T::Unitless>(6378137).unwrap() * a.acos().min(T::Unitless::one())
+        cast::<u32, Self::Output>(6378137).unwrap() * a.acos().min(Self::Output::one())
     }
 }
 

--- a/src/algorithm/haversine_distance.rs
+++ b/src/algorithm/haversine_distance.rs
@@ -1,4 +1,5 @@
-use num_traits::{Float, FromPrimitive};
+use cgmath::Angle;
+use num_traits::{Float, One, cast};
 use types::Point;
 
 /// Returns the distance between two geometries.
@@ -9,50 +10,60 @@ pub trait HaversineDistance<T, Rhs = Self>
     ///
     /// ```
     /// # extern crate geo;
+    /// # extern crate cgmath;
     /// # #[macro_use] extern crate approx;
     /// #
     /// use geo::Point;
     /// use geo::algorithm::haversine_distance::HaversineDistance;
+    /// use cgmath::Deg;
     ///
     /// # fn main() {
-    /// let p = Point::new(-72.1235, 42.3521);
-    /// let dist = p.haversine_distance(&Point::new(-72.1260, 42.45));
+    /// let p = Point::new(Deg(-72.1235), Deg(42.3521));
+    /// let dist = p.haversine_distance(&Point::new(Deg(-72.1260), Deg(42.45)));
     /// assert_relative_eq!(dist, 10900.115612674515, epsilon = 1.0e-6)
     /// # }
     /// ```
     fn haversine_distance(&self, rhs: &Rhs) -> T;
 }
 
-impl<T> HaversineDistance<T, Point<T>> for Point<T>
-    where T: Float + FromPrimitive
+impl<T> HaversineDistance<T::Unitless, Point<T>> for Point<T>
+    where T: Angle
 {
-    fn haversine_distance(&self, rhs: &Point<T>) -> T {
-        let (lhs_sin, lhs_cos) = self.y().to_radians().sin_cos();
-        let (rhs_sin, rhs_cos) = rhs.y().to_radians().sin_cos();
-        let delta_lng = rhs.x() - self.x();
+    fn haversine_distance(&self, rhs: &Point<T>) -> T::Unitless {
+        let (lhs_sin, lhs_cos) = self.lat().sin_cos();
+        let (rhs_sin, rhs_cos) = rhs.lat().sin_cos();
+        let delta_lng = rhs.lng() - self.lng();
 
-        let a = (lhs_sin * rhs_sin) + (lhs_cos * rhs_cos) * delta_lng.to_radians().cos();
+        let a = (lhs_sin * rhs_sin) + (lhs_cos * rhs_cos) * delta_lng.cos();
 
-        T::from_i32(6378137).unwrap() * a.acos().min(T::one())
+        cast::<u32, T::Unitless>(6378137).unwrap() * a.acos().min(T::Unitless::one())
     }
 }
 
 #[cfg(test)]
 mod test {
+    use cgmath::{Deg, Rad};
     use types::Point;
     use algorithm::haversine_distance::HaversineDistance;
 
     #[test]
     fn distance1_test() {
-        let a = Point::<f64>::new(0., 0.);
-        let b = Point::<f64>::new(1., 0.);
+        let a = Point::new(Deg(0. as f64), Deg(0. as f64));
+        let b = Point::new(Deg(1. as f64), Deg(0. as f64));
         assert_relative_eq!(a.haversine_distance(&b), 111319.49079326246_f64, epsilon = 1.0e-6);
     }
 
     #[test]
     fn distance2_test() {
-        let a = Point::new(-72.1235, 42.3521);
-        let b = Point::new(72.1260, 70.612);
+        let a = Point::new(Deg(-72.1235), Deg(42.3521));
+        let b = Point::new(Deg(72.1260), Deg(70.612));
+        assert_relative_eq!(a.haversine_distance(&b), 6378137_f64, epsilon = 1.0e-6);
+    }
+
+    #[test]
+    fn rad_test() {
+        let a = Point::new(Rad(0. as f64), Rad(0. as f64));
+        let b = Point::new(Rad(1. as f64), Rad(0. as f64));
         assert_relative_eq!(a.haversine_distance(&b), 6378137_f64, epsilon = 1.0e-6);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate cgmath;
 extern crate num_traits;
 
 pub use traits::ToGeo;

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,7 @@ use std::ops::AddAssign;
 use std::ops::Neg;
 use std::ops::Sub;
 
+use cgmath::Angle;
 use num_traits::{Float, ToPrimitive};
 
 pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
@@ -24,9 +25,7 @@ pub struct Bbox<T> {
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub struct Point<T> (pub Coordinate<T>);
 
-impl<T> Point<T>
-    where T: Float + ToPrimitive
-{
+impl<T> Point<T> {
     /// Creates a new point.
     ///
     /// ```
@@ -40,7 +39,11 @@ impl<T> Point<T>
     pub fn new(x: T, y: T) -> Point<T> {
         Point(Coordinate { x: x, y: y })
     }
+}
 
+impl<T> Point<T>
+    where T: Float + ToPrimitive
+{
     /// Returns the x/horizontal component of the point.
     ///
     /// ```
@@ -97,60 +100,6 @@ impl<T> Point<T>
         self
     }
 
-    /// Returns the longitude/horizontal component of the point.
-    ///
-    /// ```
-    /// use geo::Point;
-    ///
-    /// let p = Point::new(1.234, 2.345);
-    ///
-    /// assert_eq!(p.lng(), 1.234);
-    /// ```
-    pub fn lng(&self) -> T {
-        self.x()
-    }
-
-    /// Sets the longitude/horizontal component of the point.
-    ///
-    /// ```
-    /// use geo::Point;
-    ///
-    /// let mut p = Point::new(1.234, 2.345);
-    /// p.set_lng(9.876);
-    ///
-    /// assert_eq!(p.lng(), 9.876);
-    /// ```
-    pub fn set_lng(&mut self, lng: T) -> &mut Point<T> {
-        self.set_x(lng)
-    }
-
-    /// Returns the latitude/vertical component of the point.
-    ///
-    /// ```
-    /// use geo::Point;
-    ///
-    /// let p = Point::new(1.234, 2.345);
-    ///
-    /// assert_eq!(p.lat(), 2.345);
-    /// ```
-    pub fn lat(&self) -> T {
-        self.y()
-    }
-
-    /// Sets the latitude/vertical component of the point.
-    ///
-    /// ```
-    /// use geo::Point;
-    ///
-    /// let mut p = Point::new(1.234, 2.345);
-    /// p.set_lat(9.876);
-    ///
-    /// assert_eq!(p.lat(), 9.876);
-    /// ```
-    pub fn set_lat(&mut self, lat: T) -> &mut Point<T> {
-        self.set_y(lat)
-    }
-
     /// Returns the dot product of the two points:
     /// `dot = x1 * x2 + y1 * y2`
     ///
@@ -164,6 +113,90 @@ impl<T> Point<T>
     /// ```
     pub fn dot(&self, point: &Point<T>) -> T {
         self.x() * point.x() + self.y() * point.y()
+    }
+}
+
+impl<T> Point<T>
+    where T: Angle
+{
+    /// Returns the longitude/horizontal component of the point.
+    ///
+    /// ```
+    /// # extern crate geo;
+    /// # extern crate cgmath;
+    /// #
+    /// use geo::Point;
+    /// use cgmath::Deg;
+    ///
+    /// # fn main() {
+    /// let p = Point::new(Deg(1.234), Deg(2.345));
+    ///
+    /// assert_eq!(p.lng(), Deg(1.234));
+    /// # }
+    /// ```
+    pub fn lng(&self) -> T {
+        self.0.x
+    }
+
+    /// Sets the longitude/horizontal component of the point.
+    ///
+    /// ```
+    /// # extern crate geo;
+    /// # extern crate cgmath;
+    /// #
+    /// use geo::Point;
+    /// use cgmath::Deg;
+    ///
+    /// # fn main() {
+    /// let mut p = Point::new(Deg(1.234), Deg(2.345));
+    /// p.set_lng(Deg(9.876));
+    ///
+    /// assert_eq!(p.lng(), Deg(9.876));
+    /// # }
+    /// ```
+    pub fn set_lng(&mut self, lng: T) -> &mut Point<T> {
+        self.0.x = lng;
+        self
+    }
+
+    /// Returns the latitude/vertical component of the point.
+    ///
+    /// ```
+    /// # extern crate geo;
+    /// # extern crate cgmath;
+    /// #
+    /// use geo::Point;
+    /// use cgmath::Deg;
+    ///
+    /// # fn main() {
+    /// let p = Point::new(Deg(1.234), Deg(2.345));
+    ///
+    /// assert_eq!(p.lat(), Deg(2.345));
+    /// # }
+    /// ```
+    pub fn lat(&self) -> T {
+        self.0.y
+    }
+
+    /// Sets the latitude/vertical component of the point.
+    ///
+    /// ```
+    /// # extern crate geo;
+    /// # extern crate cgmath;
+    /// #
+    /// use geo::Point;
+    /// use cgmath::Deg;
+    ///
+    /// # fn main() {
+    /// let mut p = Point::new(Deg(1.234), Deg(2.345));
+    /// p.set_lat(Deg(9.876));
+    ///
+    /// assert_eq!(p.lat(), Deg(9.876));
+    /// # }
+    /// ```
+    pub fn set_lat(&mut self, lat: T) -> &mut Point<T> {
+        self.0.y = lat;
+        self
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -201,11 +201,11 @@ impl<T> Point<T>
 }
 
 impl<T> Neg for Point<T>
-    where T: Float + Neg<Output = T> + ToPrimitive
+    where T: Neg
 {
-    type Output = Point<T>;
+    type Output = Point<T::Output>;
 
-    /// Returns a point with the x and y components negated.
+    /// Returns a point with the x and y components negated:
     ///
     /// ```
     /// use geo::Point;
@@ -215,15 +215,32 @@ impl<T> Neg for Point<T>
     /// assert_eq!(p.x(), 1.25);
     /// assert_eq!(p.y(), -2.5);
     /// ```
-    fn neg(self) -> Point<T> {
-        Point::new(-self.x(), -self.y())
+    ///
+    /// or using angles:
+    ///
+    /// ```
+    /// # extern crate geo;
+    /// # extern crate cgmath;
+    /// #
+    /// use geo::Point;
+    /// use cgmath::Deg;
+    ///
+    /// # fn main() {
+    /// let p = -Point::new(Deg(1.234), Deg(-2.345));
+    ///
+    /// assert_eq!(p.lng(), Deg(-1.234));
+    /// assert_eq!(p.lat(), Deg(2.345));
+    /// # }
+    /// ```
+    fn neg(self) -> Self::Output {
+        Point::new(-self.0.x, -self.0.y)
     }
 }
 
 impl<T> Add for Point<T>
-    where T: Float + ToPrimitive
+    where T: Add
 {
-    type Output = Point<T>;
+    type Output = Point<T::Output>;
 
     /// Add a point to the given point.
     ///
@@ -235,15 +252,32 @@ impl<T> Add for Point<T>
     /// assert_eq!(p.x(), 2.75);
     /// assert_eq!(p.y(), 5.0);
     /// ```
-    fn add(self, rhs: Point<T>) -> Point<T> {
-        Point::new(self.x() + rhs.x(), self.y() + rhs.y())
+    ///
+    /// or using angles:
+    ///
+    /// ```
+    /// # extern crate geo;
+    /// # extern crate cgmath;
+    /// #
+    /// use geo::Point;
+    /// use cgmath::Deg;
+    ///
+    /// # fn main() {
+    /// let p = Point::new(Deg(1.25), Deg(2.5)) + Point::new(Deg(1.5), Deg(2.5));
+    ///
+    /// assert_eq!(p.lng(), Deg(2.75));
+    /// assert_eq!(p.lat(), Deg(5.0));
+    /// # }
+    /// ```
+    fn add(self, rhs: Point<T>) -> Self::Output {
+        Point::new(self.0.x + rhs.0.x, self.0.y + rhs.0.y)
     }
 }
 
 impl<T> Sub for Point<T>
-    where T: Float + ToPrimitive
+    where T: Sub
 {
-    type Output = Point<T>;
+    type Output = Point<T::Output>;
 
     /// Subtract a point from the given point.
     ///
@@ -255,8 +289,26 @@ impl<T> Sub for Point<T>
     /// assert_eq!(p.x(), -0.25);
     /// assert_eq!(p.y(), 0.5);
     /// ```
-    fn sub(self, rhs: Point<T>) -> Point<T> {
-        Point::new(self.x() - rhs.x(), self.y() - rhs.y())
+    ///
+    /// or using angles:
+    ///
+    /// ```
+    /// # extern crate geo;
+    /// # extern crate cgmath;
+    /// #
+    /// use geo::Point;
+    /// use cgmath::Deg;
+    ///
+    /// # fn main() {
+    /// let p = Point::new(Deg(1.25), Deg(3.0)) - Point::new(Deg(1.5), Deg(2.5));
+    ///
+    /// assert_eq!(p.lng(), Deg(-0.25));
+    /// assert_eq!(p.lat(), Deg(0.5));
+    /// # }
+    /// ```
+    /// ```
+    fn sub(self, rhs: Point<T>) -> Self::Output {
+        Point::new(self.0.x - rhs.0.x, self.0.y - rhs.0.y)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -120,7 +120,7 @@ impl<T> Point<T>
     /// # }
     /// ```
     pub fn lng(&self) -> T {
-        self.0.x
+        self.x()
     }
 
     /// Sets the longitude/horizontal component of the point.
@@ -140,8 +140,7 @@ impl<T> Point<T>
     /// # }
     /// ```
     pub fn set_lng(&mut self, lng: T) -> &mut Point<T> {
-        self.0.x = lng;
-        self
+        self.set_x(lng)
     }
 
     /// Returns the latitude/vertical component of the point.
@@ -160,7 +159,7 @@ impl<T> Point<T>
     /// # }
     /// ```
     pub fn lat(&self) -> T {
-        self.0.y
+        self.y()
     }
 
     /// Sets the latitude/vertical component of the point.
@@ -180,8 +179,7 @@ impl<T> Point<T>
     /// # }
     /// ```
     pub fn set_lat(&mut self, lat: T) -> &mut Point<T> {
-        self.0.y = lat;
-        self
+        self.set_y(lat)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,7 +42,7 @@ impl<T> Point<T> {
 }
 
 impl<T> Point<T>
-    where T: Float + ToPrimitive
+    where T: Copy
 {
     /// Returns the x/horizontal component of the point.
     ///
@@ -99,7 +99,11 @@ impl<T> Point<T>
         self.0.y = y;
         self
     }
+}
 
+impl<T> Point<T>
+    where T: Float + ToPrimitive
+{
     /// Returns the dot product of the two points:
     /// `dot = x1 * x2 + y1 * y2`
     ///
@@ -201,7 +205,7 @@ impl<T> Point<T>
 }
 
 impl<T> Neg for Point<T>
-    where T: Neg
+    where T: Neg + Copy
 {
     type Output = Point<T::Output>;
 
@@ -233,12 +237,12 @@ impl<T> Neg for Point<T>
     /// # }
     /// ```
     fn neg(self) -> Self::Output {
-        Point::new(-self.0.x, -self.0.y)
+        Point::new(-self.x(), -self.y())
     }
 }
 
 impl<T> Add for Point<T>
-    where T: Add
+    where T: Add + Copy
 {
     type Output = Point<T::Output>;
 
@@ -270,12 +274,12 @@ impl<T> Add for Point<T>
     /// # }
     /// ```
     fn add(self, rhs: Point<T>) -> Self::Output {
-        Point::new(self.0.x + rhs.0.x, self.0.y + rhs.0.y)
+        Point::new(self.x() + rhs.x(), self.y() + rhs.y())
     }
 }
 
 impl<T> Sub for Point<T>
-    where T: Sub
+    where T: Sub + Copy
 {
     type Output = Point<T::Output>;
 
@@ -308,7 +312,7 @@ impl<T> Sub for Point<T>
     /// ```
     /// ```
     fn sub(self, rhs: Point<T>) -> Self::Output {
-        Point::new(self.0.x - rhs.0.x, self.0.y - rhs.0.y)
+        Point::new(self.x() - rhs.x(), self.y() - rhs.y())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -102,25 +102,6 @@ impl<T> Point<T>
 }
 
 impl<T> Point<T>
-    where T: Float + ToPrimitive
-{
-    /// Returns the dot product of the two points:
-    /// `dot = x1 * x2 + y1 * y2`
-    ///
-    /// ```
-    /// use geo::Point;
-    ///
-    /// let p = Point::new(1.5, 0.5);
-    /// let dot = p.dot(&Point::new(2.0, 4.5));
-    ///
-    /// assert_eq!(dot, 5.25);
-    /// ```
-    pub fn dot(&self, point: &Point<T>) -> T {
-        self.x() * point.x() + self.y() * point.y()
-    }
-}
-
-impl<T> Point<T>
     where T: Angle
 {
     /// Returns the longitude/horizontal component of the point.
@@ -201,6 +182,25 @@ impl<T> Point<T>
     pub fn set_lat(&mut self, lat: T) -> &mut Point<T> {
         self.0.y = lat;
         self
+    }
+}
+
+impl<T> Point<T>
+    where T: Float + ToPrimitive
+{
+    /// Returns the dot product of the two points:
+    /// `dot = x1 * x2 + y1 * y2`
+    ///
+    /// ```
+    /// use geo::Point;
+    ///
+    /// let p = Point::new(1.5, 0.5);
+    /// let dot = p.dot(&Point::new(2.0, 4.5));
+    ///
+    /// assert_eq!(dot, 5.25);
+    /// ```
+    pub fn dot(&self, point: &Point<T>) -> T {
+        self.x() * point.x() + self.y() * point.y()
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,17 +8,13 @@ use num_traits::{Float, ToPrimitive};
 pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
 
 #[derive(PartialEq, Clone, Copy, Debug)]
-pub struct Coordinate<T>
-    where T: Float
-{
+pub struct Coordinate<T> {
     pub x: T,
     pub y: T,
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
-pub struct Bbox<T>
-    where T: Float
-{
+pub struct Bbox<T> {
     pub xmin: T,
     pub xmax: T,
     pub ymin: T,
@@ -26,7 +22,7 @@ pub struct Bbox<T>
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
-pub struct Point<T> (pub Coordinate<T>) where T: Float;
+pub struct Point<T> (pub Coordinate<T>);
 
 impl<T> Point<T>
     where T: Float + ToPrimitive
@@ -287,18 +283,16 @@ impl<T> AddAssign for Bbox<T>
 
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct MultiPoint<T>(pub Vec<Point<T>>) where T: Float;
+pub struct MultiPoint<T>(pub Vec<Point<T>>);
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct LineString<T>(pub Vec<Point<T>>) where T: Float;
+pub struct LineString<T>(pub Vec<Point<T>>);
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct MultiLineString<T>(pub Vec<LineString<T>>) where T: Float;
+pub struct MultiLineString<T>(pub Vec<LineString<T>>);
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct Polygon<T>
-    where T: Float
-{
+pub struct Polygon<T> {
     pub exterior: LineString<T>,
     pub interiors: Vec<LineString<T>>
 }
@@ -325,15 +319,13 @@ impl<T> Polygon<T>
 }
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct MultiPolygon<T>(pub Vec<Polygon<T>>) where T: Float;
+pub struct MultiPolygon<T>(pub Vec<Polygon<T>>);
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct GeometryCollection<T>(pub Vec<Geometry<T>>) where T: Float;
+pub struct GeometryCollection<T>(pub Vec<Geometry<T>>);
 
 #[derive(PartialEq, Clone, Debug)]
-pub enum Geometry<T>
-    where T: Float
-{
+pub enum Geometry<T> {
     Point(Point<T>),
     LineString(LineString<T>),
     Polygon(Polygon<T>),


### PR DESCRIPTION
I've built an initial spike to use the `Angle` trait from the `cgmath` crate to represent lat/lng points.

/cc @tmcw @frewsxcv 

---

**Solved:** I'm flagging this as work-in-progress as I can't seem to be able to make `impl<T> Neg for Point<T> where T: Angle` work. It just fails to compile telling me ``conflicting implementations of trait `std::ops::Neg` for type `types::Point<_>` ``. It's been a long time since I last used Rust and if anyone has ideas on how to solve this I'd be happy to hear them.
