### PR TITLE
Implement Point to multipart geometry distance methods

### DIFF
--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -168,7 +168,7 @@ impl<T> Distance<T, Polygon<T>> for Point<T>
 // Minimum distance from a Point to a MultiPolygon
 impl<T> Distance<T, MultiPolygon<T>> for Point<T>
     where T: Float
-{   
+{
     /// Minimum distance from a Point to a MultiPolygon
     fn distance(&self, mpolygon: &MultiPolygon<T>) -> T {
         let mut dist_queue: BinaryHeap<Mindist<T>> = BinaryHeap::new();
@@ -182,7 +182,7 @@ impl<T> Distance<T, MultiPolygon<T>> for Point<T>
 // Minimum distance from a Point to a MultiLineString
 impl<T> Distance<T, MultiLineString<T>> for Point<T>
     where T: Float
-{   
+{
     /// Minimum distance from a Point to a MultiLineString
     fn distance(&self, mls: &MultiLineString<T>) -> T {
         let mut dist_queue: BinaryHeap<Mindist<T>> = BinaryHeap::new();

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -75,6 +75,7 @@ impl<T> Distance<T, Point<T>> for Point<T>
 impl<T> Distance<T, MultiPoint<T>> for Point<T>
     where T: Float
 {
+    /// Minimum distance from a Point to a MultiPoint
     fn distance(&self, points: &MultiPoint<T>) -> T {
         let mut dist_queue: BinaryHeap<Mindist<T>> = BinaryHeap::new();
         for p in &points.0 {
@@ -167,7 +168,8 @@ impl<T> Distance<T, Polygon<T>> for Point<T>
 // Minimum distance from a Point to a MultiPolygon
 impl<T> Distance<T, MultiPolygon<T>> for Point<T>
     where T: Float
-{
+{   
+    /// Minimum distance from a Point to a MultiPolygon
     fn distance(&self, mpolygon: &MultiPolygon<T>) -> T {
         let mut dist_queue: BinaryHeap<Mindist<T>> = BinaryHeap::new();
         for poly in &mpolygon.0 {
@@ -180,7 +182,8 @@ impl<T> Distance<T, MultiPolygon<T>> for Point<T>
 // Minimum distance from a Point to a MultiLineString
 impl<T> Distance<T, MultiLineString<T>> for Point<T>
     where T: Float
-{
+{   
+    /// Minimum distance from a Point to a MultiLineString
     fn distance(&self, mls: &MultiLineString<T>) -> T {
         let mut dist_queue: BinaryHeap<Mindist<T>> = BinaryHeap::new();
         for ls in &mls.0 {


### PR DESCRIPTION
This adds distance methods and tests from Point to:
- MultiPoint
- MultiLineString
- MultiPolygon

For large MultiPolygons in particular, this could potentially be very slow. One approach would be the use of a spatial index storing the Polygon BoundingBoxes. Retrieving the closest one to the point, then calculating Point-to-Polygon distance would be much faster. There are a number of {quad-, r-, n-}tree implementations around in various states of maintenance, e.g. [acacia](https://github.com/aepsil0n/acacia), or (much heavier, extensively tested) [Spade](https://stoeoef.github.io/spade/spade/struct.RTree.html), so it'd be mostly a case of gluing things together.

(It might also be good to have a spatial index crate backed by one of those implementations in geo-rust, but that's a separate issue) 
