### PR TITLE
Add geometry rotation

### DIFF
--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -160,6 +160,14 @@ impl<T> Centroid<T> for Bbox<T>
     }
 }
 
+impl<T> Centroid<T> for Point<T>
+    where T: Float
+{
+    fn centroid(&self) -> Option<Point<T>> {
+        Some(Point::new(self.x(), self.y()))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use types::{COORD_PRECISION, Coordinate, Point, LineString, Polygon, MultiPolygon, Bbox};

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -22,3 +22,5 @@ pub mod simplifyvw;
 pub mod convexhull;
 /// Orients a Polygon's exterior and interior rings
 pub mod orient;
+/// Rotates a geometry around either its centroid or a point by an angle, given in degrees.
+pub mod rotate;

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -23,6 +23,7 @@ fn rotation_matrix<T>(angle: T, origin: &Point<T>, points: &[Point<T>]) -> Vec<P
 
 pub trait Rotate<T> {
     /// Rotate a Geometry around a given origin by an angle, in degrees
+    /// Positive angles are counter-clockwise, and negative angles are clockwise rotations.
     ///
     /// ```
     /// use geo::{Point, LineString};

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -48,7 +48,7 @@ impl<T> Rotate<T> for Point<T>
     where T: Float
 {
     /// Rotate the Point about the origin by the given number of degrees
-    fn rotate(&self, angle: T, origin: &Point<T>) -> Point<T> {
+    fn rotate(&self, angle: T, origin: &Point<T>) -> Self {
         rotation_matrix(angle, origin, &[*self])[0]
     }
 }
@@ -57,7 +57,7 @@ impl<T> Rotate<T> for LineString<T>
     where T: Float
 {
     /// Rotate the LineString about the origin by the given number of degrees
-    fn rotate(&self, angle: T, origin: &Point<T>) -> LineString<T> {
+    fn rotate(&self, angle: T, origin: &Point<T>) -> Self {
         LineString(rotation_matrix(angle, origin, &self.0))
     }
 }
@@ -66,7 +66,7 @@ impl<T> Rotate<T> for Polygon<T>
     where T: Float
 {
     /// Rotate the Polygon about the origin by the given number of degrees
-    fn rotate(&self, angle: T, origin: &Point<T>) -> Polygon<T> {
+    fn rotate(&self, angle: T, origin: &Point<T>) -> Self {
         Polygon::new(LineString(rotation_matrix(angle, origin, &self.exterior.0)),
                      self.interiors
                          .iter()

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -1,0 +1,116 @@
+use num_traits::Float;
+use types::{Point, Polygon, MultiPolygon, LineString, MultiPoint, MultiLineString};
+
+// rotate a slice of points "angle" degrees about an origin
+// origin can be an arbitrary point, pass &Point::new(0., 0.)
+// for the actual origin
+fn rotation_matrix<T>(angle: T, origin: &Point<T>, points: &[Point<T>]) -> Vec<Point<T>>
+    where T: Float
+{
+    let cos_theta = angle.to_radians().cos();
+    let sin_theta = angle.to_radians().sin();
+    let x0 = origin.x();
+    let y0 = origin.y();
+    points.iter()
+        .map(|point| {
+                 let x = point.x() - x0;
+                 let y = point.y() - y0;
+                 Point::new(x * cos_theta - y * sin_theta + x0,
+                            x * sin_theta + y * cos_theta + y0)
+             })
+        .collect::<Vec<_>>()
+}
+
+pub trait Rotate<T> {
+    /// Rotate a Geometry around a given origin by an angle, in degrees
+    ///
+    /// ```
+    /// use geo::{Point, LineString};
+    /// use geo::algorithm::rotate::{Rotate};
+    ///
+    /// let mut vec = Vec::new();
+    /// vec.push(Point::new(0.0, 0.0));
+    /// vec.push(Point::new(5.0, 5.0));
+    /// vec.push(Point::new(10.0, 10.0));
+    /// let linestring = LineString(vec);
+    /// let rotated = linestring.rotate(-45.0, &Point::new(5.0, 5.0));
+    /// let mut correct = Vec::new();
+    /// correct.push(Point::new(-2.0710678118654755, 5.0));
+    /// correct.push(Point::new(5.0, 5.0));
+    /// correct.push(Point::new(12.071067811865476, 5.0));
+    /// let correct_ls = LineString(correct);
+    /// assert_eq!(rotated, correct_ls);
+    /// ```
+    fn rotate(&self, angle: T, origin: &Point<T>) -> Self where T: Float;
+}
+
+impl<T> Rotate<T> for LineString<T>
+    where T: Float
+{
+    fn rotate(&self, angle: T, origin: &Point<T>) -> LineString<T> {
+        LineString(rotation_matrix(angle, origin, &self.0))
+    }
+}
+
+impl<T> Rotate<T> for Polygon<T>
+    where T: Float
+{
+    fn rotate(&self, angle: T, origin: &Point<T>) -> Polygon<T> {
+        Polygon::new(LineString(rotation_matrix(angle, origin, &self.exterior.0)),
+                     self.interiors
+                         .iter()
+                         .map(|ring| ring.rotate(angle, origin))
+                         .collect())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use types::{Point, LineString, Polygon};
+    use super::*;
+    #[test]
+    // results agree with Shapely / GEOS
+    fn test_rotate_linestring() {
+        let mut vec = Vec::new();
+        vec.push(Point::new(0.0, 0.0));
+        vec.push(Point::new(5.0, 5.0));
+        vec.push(Point::new(10.0, 10.0));
+        let linestring = LineString(vec);
+        let rotated = linestring.rotate(-45.0, &Point::new(5.0, 5.0));
+        let mut correct = Vec::new();
+        correct.push(Point::new(-2.0710678118654755, 5.0));
+        correct.push(Point::new(5.0, 5.0));
+        correct.push(Point::new(12.071067811865476, 5.0));
+        let correct_ls = LineString(correct);
+        assert_eq!(rotated, correct_ls);
+    }
+    #[test]
+    // results agree with Shapely / GEOS
+    fn test_rotate_polygon() {
+        let points_raw = vec![(5., 1.), (4., 2.), (4., 3.), (5., 4.), (6., 4.), (7., 3.),
+                              (7., 2.), (6., 1.), (5., 1.)];
+        let mut points = points_raw.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
+        let interior = vec![(5., 1.3), (5.5, 2.0), (6.0, 1.3), (5., 1.3)];
+        let interior_points = interior.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
+        let poly1 = Polygon::new(LineString(points), vec![LineString(interior_points)]);
+        let rotated = poly1.rotate(-15.0, &Point::new(0.0, 0.0));
+        let correct_outside = vec![(5.088448176547862, -0.3281693992235354),
+                                   (4.381341395361314, 0.8965754721680537),
+                                   (4.640160440463836, 1.862501298457122),
+                                   (5.864905311855424, 2.5696080796436696),
+                                   (6.830831138144493, 2.310789034541149),
+                                   (7.53793791933104, 1.0860441631495599),
+                                   (7.279118874228519, 0.12011833686049145),
+                                   (6.054374002836931, -0.5869884443260561),
+                                   (5.088448176547862, -0.3281693992235354)];
+        let correct_inside = vec![(5.166093890078619, -0.03839165133681477),
+                                  (5.830230134794917, 0.5083469045142726),
+                                  (6.132019716367687, -0.2972106964393355),
+                                  (5.166093890078619, -0.03839165133681477)];
+        let correct = Polygon::new(
+            LineString(correct_outside.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>()),
+            vec![LineString(correct_inside.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>())]
+        );
+        assert_eq!(rotated, correct);
+    }
+}

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -25,6 +25,7 @@ fn rotation_matrix<T>(angle: T, origin: &Point<T>, points: &[Point<T>]) -> Vec<P
 
 pub trait Rotate<T> {
     /// Rotate a Geometry around its centroid by an angle, in degrees
+    ///
     /// Positive angles are counter-clockwise, and negative angles are clockwise rotations.
     ///
     /// ```
@@ -48,7 +49,8 @@ pub trait Rotate<T> {
 }
 
 pub trait RotatePoint<T> {
-    /// Rotate a Geometry around an arbitrary point by an angle, in degrees
+    /// Rotate a Geometry around an arbitrary point by an angle, given in degrees
+    ///
     /// Positive angles are counter-clockwise, and negative angles are clockwise rotations.
     ///
     /// ```

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -128,9 +128,7 @@ impl<T> RotatePoint<T> for Polygon<T>
 {
     /// Rotate the Polygon about a given point by the given number of degrees
     fn rotate_point(&self, angle: T, point: &Point<T>) -> Self {
-        Polygon::new(LineString(rotation_matrix(angle,
-                                                point,
-                                                &self.exterior.0)),
+        Polygon::new(LineString(rotation_matrix(angle, point, &self.exterior.0)),
                      self.interiors
                          .iter()
                          .map(|ring| ring.rotate_point(angle, point))

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -65,8 +65,8 @@ pub trait RotatePoint<T> {
     /// let rotated = linestring.rotate_point(-45.0, &Point::new(10.0, 0.0));
     /// let mut correct = Vec::new();
     /// correct.push(Point::new(2.9289321881345245, 7.071067811865475));
-    /// correct.push(Point::new(6.464466094067262, 3.5355339059327373));
-    /// correct.push(Point::new(10.0, 0.0));
+    /// correct.push(Point::new(10.0, 7.0710678118654755));
+    /// correct.push(Point::new(17.071067811865476, 7.0710678118654755));
     /// let correct_ls = LineString(correct);
     /// assert_eq!(rotated, correct_ls);
     /// ```

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -83,7 +83,6 @@ impl<T> Rotate<T> for Polygon<T>
 #[cfg(test)]
 mod test {
     use types::{Point, LineString, Polygon};
-    use algorithm::centroid::Centroid;
     use super::*;
     #[test]
     fn test_rotate_point() {

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -135,6 +135,42 @@ mod test {
         // results agree with Shapely / GEOS
         assert_eq!(rotated, correct);
     }
+    #[test]
+    fn test_rotate_polygon_holes() {
+        let ls1 = LineString(vec![Point::new(5.0, 1.0),
+                                  Point::new(4.0, 2.0),
+                                  Point::new(4.0, 3.0),
+                                  Point::new(5.0, 4.0),
+                                  Point::new(6.0, 4.0),
+                                  Point::new(7.0, 3.0),
+                                  Point::new(7.0, 2.0),
+                                  Point::new(6.0, 1.0),
+                                  Point::new(5.0, 1.0)]);
+
+        let ls2 = LineString(vec![Point::new(5.0, 1.3),
+                                  Point::new(5.5, 2.0),
+                                  Point::new(6.0, 1.3),
+                                  Point::new(5.0, 1.3)]);
+
+        let ls3 = LineString(vec![Point::new(5., 2.3),
+                                  Point::new(5.5, 3.0),
+                                  Point::new(6., 2.3),
+                                  Point::new(5., 2.3)]);
+
+        let poly1 = Polygon::new(ls1, vec![ls2, ls3]);
+        let rotated = poly1.rotate(-15.0);
+        let correct_outside = vec![(4.6288085192016855, 1.1805207831176578),
+                                   (3.921701738015137, 2.405265654509247),
+                                   (4.180520783117659, 3.3711914807983154),
+                                   (5.405265654509247, 4.0782982619848624),
+                                   (6.371191480798316, 3.819479216882342),
+                                   (7.0782982619848624, 2.594734345490753),
+                                   (6.819479216882343, 1.6288085192016848),
+                                   (5.594734345490753, 0.9217017380151372),
+                                   (4.6288085192016855, 1.1805207831176578)];
+
+        let correct = Polygon::new(LineString(correct_outside
+                                                  .iter()
                                                   .map(|e| Point::new(e.0, e.1))
                                                   .collect::<Vec<_>>()),
                                    vec![]);

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -25,8 +25,6 @@ fn rotation_matrix<T>(angle: T, origin: &Point<T>, points: &[Point<T>]) -> Vec<P
 pub trait Rotate<T> {
     /// Rotate a Geometry around its centroid by an angle, in degrees
     /// Positive angles are counter-clockwise, and negative angles are clockwise rotations.
-    /// 
-    /// Polygons to be rotated must be simple, i.e. without holes
     ///
     /// ```
     /// use geo::{Point, LineString};
@@ -115,7 +113,6 @@ mod test {
                               (7., 2.), (6., 1.), (5., 1.)];
         let points = points_raw.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
         let poly1 = Polygon::new(LineString(points), vec![]);
-        println!("Centroid: {:?}", poly1.centroid().unwrap());
         let rotated = poly1.rotate(-15.0);
         let correct_outside = vec![(4.628808519201685, 1.1805207831176578),
                                    (3.921701738015137, 2.405265654509247),

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -12,7 +12,8 @@ fn rotation_matrix<T>(angle: T, origin: &Point<T>, points: &[Point<T>]) -> Vec<P
     let sin_theta = angle.to_radians().sin();
     let x0 = origin.x();
     let y0 = origin.y();
-    points.iter()
+    points
+        .iter()
         .map(|point| {
                  let x = point.x() - x0;
                  let y = point.y() - y0;
@@ -111,7 +112,10 @@ mod test {
     fn test_rotate_polygon() {
         let points_raw = vec![(5., 1.), (4., 2.), (4., 3.), (5., 4.), (6., 4.), (7., 3.),
                               (7., 2.), (6., 1.), (5., 1.)];
-        let points = points_raw.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
+        let points = points_raw
+            .iter()
+            .map(|e| Point::new(e.0, e.1))
+            .collect::<Vec<_>>();
         let poly1 = Polygon::new(LineString(points), vec![]);
         let rotated = poly1.rotate(-15.0);
         let correct_outside = vec![(4.628808519201685, 1.1805207831176578),
@@ -123,7 +127,14 @@ mod test {
                                    (6.819479216882343, 1.6288085192016848),
                                    (5.594734345490753, 0.9217017380151371),
                                    (4.628808519201685, 1.1805207831176578)];
-        let correct = Polygon::new(LineString(correct_outside.iter()
+        let correct = Polygon::new(LineString(correct_outside
+                                                  .iter()
+                                                  .map(|e| Point::new(e.0, e.1))
+                                                  .collect::<Vec<_>>()),
+                                   vec![]);
+        // results agree with Shapely / GEOS
+        assert_eq!(rotated, correct);
+    }
                                                   .map(|e| Point::new(e.0, e.1))
                                                   .collect::<Vec<_>>()),
                                    vec![]);


### PR DESCRIPTION
This trait allows a geometry to be rotated about
a given origin by the given number of degrees,
using a transformation matrix