### PR TITLE
Correctly calculate centroids for complex polygons.

### DIFF
--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -23,21 +23,47 @@ pub trait Centroid<T: Float> {
     fn centroid(&self) -> Option<Point<T>>;
 }
 
+// Calculation of simple (no interior holes) Polygon area
+fn simple_polygon_area<T>(linestring: &LineString<T>) -> T where T: Float {
+    if linestring.0.is_empty() || linestring.0.len() == 1 {
+        return T::zero();
+    }
+    let mut tmp = T::zero();
+    for ps in linestring.0.windows(2) {
+        tmp = tmp + (ps[0].x() * ps[1].y() - ps[1].x() * ps[0].y());
+    }
+    tmp / (T::one() + T::one())
+}
+
+// Calculation of a Polygon centroid without interior rings
+fn simple_polygon_centroid<T>(poly_ext: &LineString<T>) -> Option<Point<T>>
+    where T: Float + FromPrimitive
+{
+    let vect = &poly_ext.0;
+    let area = simple_polygon_area(poly_ext);
+    let mut sum_x = T::zero();
+    let mut sum_y = T::zero();
+    for ps in vect.windows(2) {
+        let tmp = ps[0].x() * ps[1].y() - ps[1].x() * ps[0].y();
+        sum_x = sum_x + ((ps[1].x() + ps[0].x()) * tmp);
+        sum_y = sum_y + ((ps[1].y() + ps[0].y()) * tmp);
+    }
+    let six = T::from_i32(6).unwrap();
+    Some(Point::new(sum_x / (six * area), sum_y / (six * area)))
+}
+
 impl<T> Centroid<T> for LineString<T>
     where T: Float
 {
-    ///
-    /// The Centroid of a LineString is the mean of the middle of the segment
-    /// weighted by the length of the segments.
-    ///
+    // The Centroid of a LineString is the mean of the middle of the segment
+    // weighted by the length of the segments.
     fn centroid(&self) -> Option<Point<T>> {
         let vect = &self.0;
         if vect.is_empty() {
             return None;
         }
         if vect.len() == 1 {
-            Some(Point::new(vect[0].x(),
-                            vect[0].y()))
+            Some(Point::new(vect[0].x(), vect[0].y()))
         } else {
             let mut sum_x = T::zero();
             let mut sum_y = T::zero();
@@ -57,12 +83,15 @@ impl<T> Centroid<T> for LineString<T>
 impl<T> Centroid<T> for Polygon<T>
     where T: Float + FromPrimitive
 {
-    ///
-    /// Centroid on a Polygon.
-    /// See: https://en.wikipedia.org/wiki/Centroid
-    ///
+    // Centroid of a Polygon.
+    // See: https://en.wikipedia.org/wiki/Centroid
+    // We distinguish between a simple polygon, which has no interior holes,
+    // and a complex polygon, which has one or more interior holes.
+    // A complex polygon's centroid is the weighted average of its
+    // exterior shell centroid and the centroids of the interior ring(s),
+    // which are treated as *polygons* for the purposes of this calculation.
+    // See here for a formula: http://math.stackexchange.com/a/623849
     fn centroid(&self) -> Option<Point<T>> {
-        // TODO: consideration of inner polygons;
         let linestring = &self.exterior;
         let vect = &linestring.0;
         if vect.is_empty() {
@@ -71,16 +100,27 @@ impl<T> Centroid<T> for Polygon<T>
         if vect.len() == 1 {
             Some(Point::new(vect[0].x(), vect[0].y()))
         } else {
-            let area = self.area();
-            let mut sum_x = T::zero();
-            let mut sum_y = T::zero();
-            for ps in vect.windows(2) {
-                let tmp = ps[0].x() * ps[1].y() - ps[1].x() * ps[0].y();
-                sum_x = sum_x + ((ps[1].x() + ps[0].x()) * tmp);
-                sum_y = sum_y + ((ps[1].y() + ps[0].y()) * tmp);
+            let external_centroid = simple_polygon_centroid(&self.exterior).unwrap();
+            if !self.interiors.is_empty() {
+                let external_area = simple_polygon_area(&self.exterior).abs();
+                // accumulate interior Polygons
+                let (totals_x, totals_y, internal_area) =
+                    self.interiors
+                        .iter()
+                        .map(|ring| {
+                                 let area = simple_polygon_area(ring).abs();
+                                 let centroid = simple_polygon_centroid(ring).unwrap();
+                                 ((centroid.x() * area), (centroid.y() * area), area)
+                             })
+                        .fold((T::zero(), T::zero(), T::zero()),
+                              |accum, val| (accum.0 + val.0, accum.1 + val.1, accum.2 + val.2));
+                let centroid_x = ((external_centroid.x() * external_area) - totals_x) /
+                                 (external_area - internal_area);
+                let centroid_y = ((external_centroid.y() * external_area) - totals_y) /
+                                 (external_area - internal_area);
+                return Some(Point::new(centroid_x, centroid_y));
             }
-            let six = T::from_i32(6).unwrap();
-            Some(Point::new(sum_x / (six * area), sum_y / (six * area)))
+            Some(external_centroid)
         }
     }
 }
@@ -118,7 +158,7 @@ impl<T> Centroid<T> for Bbox<T>
     ///
     fn centroid(&self) -> Option<Point<T>> {
         let two = T::one() + T::one();
-        Some(Point::new((self.xmax + self.xmin)/two, (self.ymax + self.ymin)/two))
+        Some(Point::new((self.xmax + self.xmin) / two, (self.ymax + self.ymin) / two))
     }
 }
 
@@ -176,6 +216,26 @@ mod test {
         let poly = Polygon::new(linestring, v);
         assert_eq!(poly.centroid(), Some(p(1., 1.)));
     }
+    #[test]
+    fn polygon_hole_test() {
+        let ls1 = LineString(vec![Point::new(5.0, 1.0),
+                                  Point::new(4.0, 2.0),
+                                  Point::new(4.0, 3.0),
+                                  Point::new(5.0, 4.0),
+                                  Point::new(6.0, 4.0),
+                                  Point::new(7.0, 3.0),
+                                  Point::new(7.0, 2.0),
+                                  Point::new(6.0, 1.0),
+                                  Point::new(5.0, 1.0)]);
+
+        let ls2 = LineString(vec![Point::new(5.0, 1.3),
+                                  Point::new(5.5, 2.0),
+                                  Point::new(6.0, 1.3),
+                                  Point::new(5.0, 1.3)]);
+        let p1 = Polygon::new(ls1, vec![ls2]);
+        let centroid = p1.centroid().unwrap();
+        assert_eq!(centroid, Point::new(5.5, 2.550877192982456));
+    }
     /// Tests: Centroid of MultiPolygon
     #[test]
     fn empty_multipolygon_polygon_test() {
@@ -195,7 +255,10 @@ mod test {
         let poly1 = Polygon::new(linestring, Vec::new());
         let linestring = LineString(vec![p(7., 1.), p(8., 1.), p(8., 2.), p(7., 2.), p(7., 1.)]);
         let poly2 = Polygon::new(linestring, Vec::new());
-        let dist = MultiPolygon(vec![poly1, poly2]).centroid().unwrap().distance(&p(4.07142857142857, 1.92857142857143));
+        let dist = MultiPolygon(vec![poly1, poly2])
+            .centroid()
+            .unwrap()
+            .distance(&p(4.07142857142857, 1.92857142857143));
         assert!(dist < COORD_PRECISION);
     }
     #[test]
@@ -209,7 +272,12 @@ mod test {
     }
     #[test]
     fn bbox_test() {
-        let bbox = Bbox{ xmax: 4., xmin: 0., ymax: 100., ymin: 50.};
+        let bbox = Bbox {
+            xmax: 4.,
+            xmin: 0.,
+            ymax: 100.,
+            ymin: 50.,
+        };
         let point = Point(Coordinate { x: 2., y: 75. });
         assert_eq!(point, bbox.centroid().unwrap());
     }

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -9,15 +9,15 @@ pub trait Centroid<T: Float> {
     /// Calculation of the centroid, see: https://en.wikipedia.org/wiki/Centroid
     ///
     /// ```
-    /// use geo::{Point, LineString, Coordinate};
+    /// use geo::{Point, LineString};
     /// use geo::algorithm::centroid::Centroid;
     ///
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(40.02f64, 116.34));
-    /// vec.push(Point::new(40.02f64, 116.34));
+    /// vec.push(Point::new(40.02f64, 118.23));
     /// let linestring = LineString(vec);
     ///
-    /// println!("Centroid {:?}", linestring.centroid());
+    /// assert_eq!(linestring.centroid().unwrap(), Point::new(40.02, 117.285));
     /// ```
     ///
     fn centroid(&self) -> Option<Point<T>>;

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -6,7 +6,7 @@ use algorithm::distance::Distance;
 
 /// Calculation of the centroid.
 pub trait Centroid<T: Float> {
-    /// Calculation of the centroid, see: https://en.wikipedia.org/wiki/Centroid
+    /// See: https://en.wikipedia.org/wiki/Centroid
     ///
     /// ```
     /// use geo::{Point, LineString};
@@ -85,14 +85,15 @@ impl<T> Centroid<T> for LineString<T>
 impl<T> Centroid<T> for Polygon<T>
     where T: Float + FromPrimitive
 {
-    // Centroid of a Polygon.
-    // See: https://en.wikipedia.org/wiki/Centroid
+    // Calculate the centroid of a Polygon.
     // We distinguish between a simple polygon, which has no interior holes,
     // and a complex polygon, which has one or more interior holes.
     // A complex polygon's centroid is the weighted average of its
     // exterior shell centroid and the centroids of the interior ring(s),
-    // which are treated as *polygons* for the purposes of this calculation.
+    // which are both considered as as * simple polygons* for the purposes of
+    // this calculation.
     // See here for a formula: http://math.stackexchange.com/a/623849
+    // See here for detail on alternative methods: See: https://fotino.me/calculating-centroids/
     fn centroid(&self) -> Option<Point<T>> {
         let linestring = &self.exterior;
         let vect = &linestring.0;
@@ -129,7 +130,6 @@ impl<T> Centroid<T> for Polygon<T>
 impl<T> Centroid<T> for MultiPolygon<T>
     where T: Float + FromPrimitive
 {
-    // See: https://fotino.me/calculating-centroids/
     fn centroid(&self) -> Option<Point<T>> {
         let mut sum_x = T::zero();
         let mut sum_y = T::zero();
@@ -154,9 +154,6 @@ impl<T> Centroid<T> for MultiPolygon<T>
 impl<T> Centroid<T> for Bbox<T>
     where T: Float
 {
-    ///
-    /// Calculate the Centroid of a Bbox.
-    ///
     fn centroid(&self) -> Option<Point<T>> {
         let two = T::one() + T::one();
         Some(Point::new((self.xmax + self.xmin) / two, (self.ymax + self.ymin) / two))
@@ -168,7 +165,7 @@ mod test {
     use types::{COORD_PRECISION, Coordinate, Point, LineString, Polygon, MultiPolygon, Bbox};
     use algorithm::centroid::Centroid;
     use algorithm::distance::Distance;
-    /// Tests: Centroid of LineString
+    // Tests: Centroid of LineString
     #[test]
     fn empty_linestring_test() {
         let vec = Vec::<Point<f64>>::new();
@@ -192,7 +189,7 @@ mod test {
         assert_eq!(linestring.centroid(),
                    Some(Point(Coordinate { x: 6., y: 1. })));
     }
-    /// Tests: Centroid of Polygon
+    // Tests: Centroid of Polygon
     #[test]
     fn empty_polygon_test() {
         let v1 = Vec::new();
@@ -243,7 +240,7 @@ mod test {
         let centroid = p1.centroid().unwrap();
         assert_eq!(centroid, Point::new(5.5, 2.5518518518518514));
     }
-    /// Tests: Centroid of MultiPolygon
+    // Tests: Centroid of MultiPolygon
     #[test]
     fn empty_multipolygon_polygon_test() {
         assert!(MultiPolygon::<f64>(Vec::new()).centroid().is_none());

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -24,7 +24,9 @@ pub trait Centroid<T: Float> {
 }
 
 // Calculation of simple (no interior holes) Polygon area
-fn simple_polygon_area<T>(linestring: &LineString<T>) -> T where T: Float {
+fn simple_polygon_area<T>(linestring: &LineString<T>) -> T
+    where T: Float
+{
     if linestring.0.is_empty() || linestring.0.len() == 1 {
         return T::zero();
     }
@@ -232,9 +234,15 @@ mod test {
                                   Point::new(5.5, 2.0),
                                   Point::new(6.0, 1.3),
                                   Point::new(5.0, 1.3)]);
-        let p1 = Polygon::new(ls1, vec![ls2]);
+
+        let ls3 = LineString(vec![Point::new(5., 2.3),
+                                  Point::new(5.5, 3.0),
+                                  Point::new(6., 2.3),
+                                  Point::new(5., 2.3)]);
+
+        let p1 = Polygon::new(ls1, vec![ls2, ls3]);
         let centroid = p1.centroid().unwrap();
-        assert_eq!(centroid, Point::new(5.5, 2.550877192982456));
+        assert_eq!(centroid, Point::new(5.5, 2.5518518518518514));
     }
     /// Tests: Centroid of MultiPolygon
     #[test]

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -116,11 +116,10 @@ impl<T> Centroid<T> for Polygon<T>
                              })
                         .fold((T::zero(), T::zero(), T::zero()),
                               |accum, val| (accum.0 + val.0, accum.1 + val.1, accum.2 + val.2));
-                let centroid_x = ((external_centroid.x() * external_area) - totals_x) /
-                                 (external_area - internal_area);
-                let centroid_y = ((external_centroid.y() * external_area) - totals_y) /
-                                 (external_area - internal_area);
-                return Some(Point::new(centroid_x, centroid_y));
+                return Some(Point::new(((external_centroid.x() * external_area) - totals_x) /
+                                       (external_area - internal_area),
+                                       ((external_centroid.y() * external_area) - totals_y) /
+                                       (external_area - internal_area)));
             }
             Some(external_centroid)
         }

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -90,10 +90,10 @@ impl<T> Centroid<T> for Polygon<T>
     // and a complex polygon, which has one or more interior holes.
     // A complex polygon's centroid is the weighted average of its
     // exterior shell centroid and the centroids of the interior ring(s),
-    // which are both considered as as * simple polygons* for the purposes of
+    // which are both considered simple polygons for the purposes of
     // this calculation.
     // See here for a formula: http://math.stackexchange.com/a/623849
-    // See here for detail on alternative methods: See: https://fotino.me/calculating-centroids/
+    // See here for detail on alternative methods: https://fotino.me/calculating-centroids/
     fn centroid(&self) -> Option<Point<T>> {
         let linestring = &self.exterior;
         let vect = &linestring.0;


### PR DESCRIPTION
This PR closes #111. I've added helper functions for calculation of a simple polygon centroid, and for simple polygon area. The latter is functionally identical to `get_linestring_area()`, but we can't use that since it's a private function in a public module.