### PR TITLE
Add extreme point-finding

### DIFF
--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -109,19 +109,19 @@ pub trait ExtremePoints<T: Float> {
     /// let points = points_raw.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
     /// let poly = Polygon::new(LineString(points), vec![]);
     /// // Polygon is both convex and oriented counter-clockwise
-    /// let extremes = poly.extreme_points(true, true);
+    /// let extremes = poly.extreme_indices(true, true);
     /// assert_eq!(extremes.ymin, 0);
     /// assert_eq!(extremes.xmax, 1);
     /// assert_eq!(extremes.ymax, 2);
     /// assert_eq!(extremes.xmin, 3);
     /// ```
-    fn extreme_points(&self, convex: bool, oriented: bool) -> Extremes;
+    fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes;
 }
 
 impl<T> ExtremePoints<T> for Polygon<T>
     where T: Float
 {
-    fn extreme_points(&self, convex: bool, oriented: bool) -> Extremes {
+    fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes {
         find_extremes(polymax_naive, self, convex, oriented)
     }
 }
@@ -129,7 +129,7 @@ impl<T> ExtremePoints<T> for Polygon<T>
 impl<T> ExtremePoints<T> for MultiPolygon<T>
     where T: Float
 {
-    fn extreme_points(&self, convex: bool, oriented: bool) -> Extremes {
+    fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes {
         // we can disregard the input because convex-hull processing always orients
         find_extremes(polymax_naive, &self.convex_hull(), true, true)
     }
@@ -138,7 +138,7 @@ impl<T> ExtremePoints<T> for MultiPolygon<T>
 impl<T> ExtremePoints<T> for MultiPoint<T>
     where T: Float
 {
-    fn extreme_points(&self, convex: bool, oriented: bool) -> Extremes {
+    fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes {
         // we can disregard the input because convex-hull processing always orients
         find_extremes(polymax_naive, &self.convex_hull(), true, true)
     }

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -88,7 +88,7 @@ fn polymax_naive<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<usize, ()>
     return Ok(max);
 }
 
-pub trait ExtremePoints<T: Float> {
+pub trait ExtremeIndices<T: Float> {
     /// Find the extreme `x` and `y` indices of a Polygon
     ///
     /// The polygon must be convex and properly oriented; if you're unsure whether
@@ -103,7 +103,7 @@ pub trait ExtremePoints<T: Float> {
     ///
     /// ```
     /// use geo::{Point, LineString, Polygon};
-    /// use geo::extremes::ExtremePoints;
+    /// use geo::extremes::ExtremeIndices;
     /// // a diamond shape
     /// let points_raw = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
     /// let points = points_raw.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
@@ -118,7 +118,7 @@ pub trait ExtremePoints<T: Float> {
     fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes;
 }
 
-impl<T> ExtremePoints<T> for Polygon<T>
+impl<T> ExtremeIndices<T> for Polygon<T>
     where T: Float
 {
     fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes {
@@ -126,7 +126,7 @@ impl<T> ExtremePoints<T> for Polygon<T>
     }
 }
 
-impl<T> ExtremePoints<T> for MultiPolygon<T>
+impl<T> ExtremeIndices<T> for MultiPolygon<T>
     where T: Float
 {
     fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes {
@@ -135,7 +135,7 @@ impl<T> ExtremePoints<T> for MultiPolygon<T>
     }
 }
 
-impl<T> ExtremePoints<T> for MultiPoint<T>
+impl<T> ExtremeIndices<T> for MultiPoint<T>
     where T: Float
 {
     fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes {

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -73,7 +73,6 @@ fn find_extremes<T, F>(func: F, polygon: &Polygon<T>, convex: bool, oriented: bo
 
 // find a convex, counter-clockwise oriented polygon's maximum vertex in a specified direction
 // u: a direction vector. We're using a point to represent this, which is a hack but works fine
-// this is O(n) if the polygon is convex. 
 fn polymax_naive<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<usize, ()>
     where T: Float
 {

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -38,7 +38,7 @@ fn below<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> bool
 }
 
 // wrapper for extreme-finding function
-fn find_extremes<T, F>(func: F, polygon: &Polygon<T>, convex: bool, oriented: bool) -> Extremes
+fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>, convex: bool, oriented: bool) -> Extremes
     where T: Float,
           F: Fn(&Point<T>, &Polygon<T>) -> Result<usize, ()>
 {
@@ -73,7 +73,7 @@ fn find_extremes<T, F>(func: F, polygon: &Polygon<T>, convex: bool, oriented: bo
 
 // find a convex, counter-clockwise oriented polygon's maximum vertex in a specified direction
 // u: a direction vector. We're using a point to represent this, which is a hack but works fine
-fn polymax_naive<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<usize, ()>
+fn polymax_naive_indices<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<usize, ()>
     where T: Float
 {
     let vertices = &poly.exterior.0;
@@ -121,7 +121,7 @@ impl<T> ExtremeIndices<T> for Polygon<T>
     where T: Float
 {
     fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes {
-        find_extremes(polymax_naive, self, convex, oriented)
+        find_extreme_indices(polymax_naive_indices, self, convex, oriented)
     }
 }
 
@@ -130,7 +130,7 @@ impl<T> ExtremeIndices<T> for MultiPolygon<T>
 {
     fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes {
         // we can disregard the input because convex-hull processing always orients
-        find_extremes(polymax_naive, &self.convex_hull(), true, true)
+        find_extreme_indices(polymax_naive_indices, &self.convex_hull(), true, true)
     }
 }
 
@@ -139,7 +139,7 @@ impl<T> ExtremeIndices<T> for MultiPoint<T>
 {
     fn extreme_indices(&self, convex: bool, oriented: bool) -> Extremes {
         // we can disregard the input because convex-hull processing always orients
-        find_extremes(polymax_naive, &self.convex_hull(), true, true)
+        find_extreme_indices(polymax_naive_indices, &self.convex_hull(), true, true)
     }
 }
 
@@ -156,7 +156,7 @@ mod test {
             .map(|e| Point::new(e.0, e.1))
             .collect::<Vec<_>>();
         let poly1 = Polygon::new(LineString(points), vec![]);
-        let min_x = polymax_naive(&Point::new(-1., 0.), &poly1).unwrap();
+        let min_x = polymax_naive_indices(&Point::new(-1., 0.), &poly1).unwrap();
         let correct = 3_usize;
         assert_eq!(min_x, correct);
     }
@@ -175,7 +175,7 @@ mod test {
             .map(|e| Point::new(e.0, e.1))
             .collect::<Vec<_>>();
         let poly1 = Polygon::new(LineString(points), vec![]);
-        let extremes = find_extremes(polymax_naive, &poly1, false, false);
+        let extremes = find_extreme_indices(polymax_naive_indices, &poly1, false, false);
         let correct = Extremes {
             ymin: 0,
             xmax: 1,
@@ -197,7 +197,7 @@ mod test {
             .collect::<Vec<_>>();
         let poly1 = Polygon::new(LineString(points), vec![]);
         // specify convexity, wrong orientation
-        let extremes = find_extremes(polymax_naive, &poly1, true, false);
+        let extremes = find_extreme_indices(polymax_naive_indices, &poly1, true, false);
         let correct = Extremes {
             ymin: 0,
             xmax: 1,

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -1,5 +1,5 @@
 use num_traits::Float;
-use types::{Point, LineString, Polygon};
+use types::{Point, LineString, Polygon, MultiPoint, MultiPolygon};
 use algorithm::convexhull::ConvexHull;
 use algorithm::orient::{Orient, Direction};
 use types::Extremes;
@@ -73,7 +73,7 @@ fn find_extremes<T, F>(func: F, polygon: &Polygon<T>, convex: bool, oriented: bo
 
 // find a convex, counter-clockwise oriented polygon's maximum vertex in a specified direction
 // u: a direction vector. We're using a point to represent this, which is a hack but works fine
-// this is O(n), because polymax() can't yet calculate minimum x
+// this is O(n) if the polygon is convex. 
 fn polymax_naive<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<usize, ()>
     where T: Float
 {
@@ -123,6 +123,24 @@ impl<T> ExtremePoints<T> for Polygon<T>
 {
     fn extreme_points(&self, convex: bool, oriented: bool) -> Extremes {
         find_extremes(polymax_naive, self, convex, oriented)
+    }
+}
+
+impl<T> ExtremePoints<T> for MultiPolygon<T>
+    where T: Float
+{
+    fn extreme_points(&self, convex: bool, oriented: bool) -> Extremes {
+        // we can disregard the input because convex-hull processing always orients
+        find_extremes(polymax_naive, &self.convex_hull(), true, true)
+    }
+}
+
+impl<T> ExtremePoints<T> for MultiPoint<T>
+    where T: Float
+{
+    fn extreme_points(&self, convex: bool, oriented: bool) -> Extremes {
+        // we can disregard the input because convex-hull processing always orients
+        find_extremes(polymax_naive, &self.convex_hull(), true, true)
     }
 }
 

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -1,0 +1,265 @@
+use num_traits::Float;
+use types::{Point, LineString, Polygon};
+use algorithm::convexhull::ConvexHull;
+use types::Extremes;
+
+// Useful direction vectors:
+// 1., 0. = largest x
+// 0., 1. = largest y
+// 0., -1. = smallest y
+// -1, 0. = smallest x
+
+// various tests for vector orientation relative to a direction vector u
+fn up<T>(u: &Point<T>, v: &Point<T>) -> bool
+    where T: Float
+{
+    u.dot(v) > T::zero()
+}
+
+fn direction_sign<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> T
+    where T: Float
+{
+    u.dot(&(*vi - *vj))
+}
+
+// true if Vi is above Vj
+fn above<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> bool
+    where T: Float
+{
+    direction_sign(u, vi, vj) > T::zero()
+}
+
+// true if Vi is below Vj
+fn below<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> bool
+    where T: Float
+{
+    direction_sign(u, vi, vj) < T::zero()
+}
+
+// wrapper for extreme-finding function
+fn find_extremes<T, F>(func: F, polygon: &Polygon<T>, convex: bool, oriented: bool) -> Extremes<T>
+    where T: Float,
+          F: Fn(&Point<T>, &Polygon<T>) -> Result<Point<T>, ()>
+{
+    // TODO: we can't use this until Orient lands
+    // let mut processed = false;
+    // if !convex {
+    //     let mut poly = polygon.convex_hull();
+    //     let processed = true;
+    // }
+    // if !oriented and processed {
+    //    poly = poly.orient()
+    // } else if !oriented and !processed {
+    //     poly = polygon.orient();
+    // } else {
+    //    poly = polygon;
+    // }
+    let directions = vec![Point::new(T::zero(), -T::one()),
+                          Point::new(T::one(), T::zero()),
+                          Point::new(T::zero(), T::one()),
+                          Point::new(-T::one(), T::zero())];
+    directions
+        .iter()
+        .map(|p| func(&p, &polygon).unwrap())
+        .collect::<Vec<Point<T>>>()
+        .into()
+}
+
+// find a convex, counter-clockwise oriented polygon's maximum vertex in a specified direction
+// u: a direction vector. We're using a point to represent this, which is a hack tbh
+// this is O(n), because polymax() can't yet calculate minimum x
+fn polymax_naive<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<Point<T>, ()>
+    where T: Float
+{
+    let vertices = &poly.exterior.0;
+    let mut max: usize = 0;
+    for (i, _) in vertices.iter().enumerate() {
+        // if vertices[i] is above prior vertices[max]
+        if above(u, &vertices[i], &vertices[max]) {
+            max = i;
+        }
+    }
+    return Ok(vertices[max]);
+}
+
+// ported from a c++ implementation at
+// http://geomalgorithms.com/a14-_extreme_pts.html#polyMax_2D()
+// original copyright notice:
+// Copyright 2002 softSurfer, 2012-2013 Dan Sunday
+// This code may be freely used, distributed and modified for any
+// purpose providing that this copyright notice is included with it.
+// SoftSurfer makes no warranty for this code, and cannot be held
+// liable for any real or imagined damage resulting from its use.
+// Users of this code must verify correctness for their application.
+
+// Original implementation:
+// Joseph O'Rourke, Computational Geometry in C (2nd Edition),
+// Sect 7.9 "Extreme Point of Convex Polygon" (1998)
+
+// find a convex, counter-clockwise oriented polygon's maximum vertex in a specified direction
+// u: a direction vector. We're using a point to represent this, which is a hack tbh
+// this should run in O(log n) time.
+// This implementation can't calculate minimum x
+// see Section 5.1 at http://codeforces.com/blog/entry/48868 for a discussion
+fn polymax<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<Point<T>, ()>
+    where T: Float
+{
+    let vertices = &poly.exterior.0;
+    let n = vertices.len();
+    // these are used to divide the vertices slice
+    // start chain = [0, n] with vertices[n] = vertices[0]
+    let mut start: usize = 0;
+    let mut end: usize = n;
+    let mut mid: usize;
+
+    // edge vectors at vertices[a] and vertices[c]
+    let mut vec_c: Point<T>;
+    let vec_a = vertices[1] - vertices[0];
+    // test for "up" direction of vec_a
+    let mut up_a = up(u, &vec_a);
+
+    // test if vertices[0] is a local maximum
+    if !up_a && !above(u, &vertices[n - 1], &vertices[0]) {
+        return Ok(vertices[0]);
+    }
+    loop {
+        mid = (start + end) / 2;
+        vec_c = vertices[mid + 1] - vertices[mid];
+        let up_c = up(u, &vec_c);
+        if !up_c && !above(u, &vertices[mid - 1], &vertices[mid]) {
+            // vertices[mid] is a local maximum, thus it is a maximum
+            return Ok(vertices[mid]);
+        }
+        // no max yet, so continue with the binary search
+        // pick one of the two subchains [start, mid]  or [mid, end]
+        if up_a {
+            // vec_a points up
+            if !up_c {
+                // vec_c points down
+                end = mid; // select [start, mid]
+            } else {
+                // vec_c points up
+                if above(u, &vertices[start], &vertices[mid]) {
+                    // vertices[start] is above vertices[mid]
+                    end = mid; // select [start, mid]
+                } else {
+                    // vertices[start] is below vertices[mid]
+                    start = mid; // select [mid, end]
+                    up_a = up_c;
+                }
+            }
+        } else {
+            // vec_a points down
+            if up_c {
+                // vec_c points up
+                start = mid; // select [mid, end]
+                up_a = up_c;
+            } else {
+                // vec_c points down
+                if below(u, &vertices[start], &vertices[mid]) {
+                    // vertices[start] is below vertices[mid]
+                    end = mid; // select [start, mid]
+                } else {
+                    // vertices[start] is above vertices[mid]
+                    start = mid; // select [mid, end]
+                    up_a = up_c;
+                }
+            }
+        }
+        // something went really badly wrong
+        if end <= start + 1 {
+            return Err(());
+        }
+    }
+}
+
+pub trait ExtremePoints<T: Float> {
+    /// Find the extreme `x` and `y` points of a Polygon
+    ///
+    /// The polygon must be convex and properly oriented; if you're unsure whether
+    /// the polygon has these properties:
+    ///
+    /// - If you aren't sure whether the polygon is convex, choose `convex=false, oriented=false`
+    /// - If the polygon is convex but oriented clockwise, choose `convex=true, oriented=false`
+    ///
+    /// Convex-hull processing is `O(n log(n))` on average
+    /// and is thus an upper bound on point-finding, which is otherwise `O(n)` for a `Polygon`.
+    /// For a `MultiPolygon`, its convex hull must always be calculated first.
+    ///
+    /// ```
+    /// use geo::{Point, LineString, Polygon};
+    /// use geo::extremes::ExtremePoints;
+    /// // a diamond shape
+    /// let points_raw = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
+    /// let points = points_raw.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
+    /// let poly = Polygon::new(LineString(points), vec![]);
+    /// // Polygon is both convex and oriented counter-clockwise
+    /// let extremes = poly.extreme_points(true, true);
+    /// assert_eq!(extremes.ymin, Point::new(1.0, 0.0));
+    /// assert_eq!(extremes.xmax, Point::new(2.0, 1.0));
+    /// assert_eq!(extremes.ymax, Point::new(1.0, 2.0));
+    /// assert_eq!(extremes.xmin, Point::new(0.0, 1.0));
+    /// ```
+    fn extreme_points(&self, convex: bool, oriented: bool) -> Extremes<T>;
+}
+
+impl<T> ExtremePoints<T> for Polygon<T>
+    where T: Float
+{
+    fn extreme_points(&self, convex: bool, oriented: bool) -> Extremes<T> {
+        find_extremes(polymax_naive, self, convex, oriented)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use types::Point;
+    use super::*;
+    #[test]
+    fn test_polygon_extreme_x() {
+        // a diamond shape
+        let points_raw = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
+        let points = points_raw
+            .iter()
+            .map(|e| Point::new(e.0, e.1))
+            .collect::<Vec<_>>();
+        let poly1 = Polygon::new(LineString(points), vec![]);
+        let min_x = polymax_naive(&Point::new(-1., 0.), &poly1).unwrap();
+        let correct = Point::new(0., 1.);
+        assert_eq!(min_x, correct);
+    }
+    #[test]
+    #[should_panic]
+    // this test should panic, because the algorithm can't find minimum x
+    fn test_polygon_extreme_x_fast() {
+        // a diamond shape
+        let points_raw = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
+        let points = points_raw
+            .iter()
+            .map(|e| Point::new(e.0, e.1))
+            .collect::<Vec<_>>();
+        let poly1 = Polygon::new(LineString(points), vec![]);
+        let min_x = polymax(&Point::new(-1., 0.), &poly1).unwrap();
+        let correct = Point::new(0., 1.);
+        assert_eq!(min_x, correct);
+    }
+    #[test]
+    fn test_polygon_extreme_wrapper() {
+        // a diamond shape with a bump on the top-right edge
+        let points_raw =
+            vec![(1.0, 0.0), (2.0, 1.0), (1.75, 1.75), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
+        let points = points_raw
+            .iter()
+            .map(|e| Point::new(e.0, e.1))
+            .collect::<Vec<_>>();
+        let poly1 = Polygon::new(LineString(points), vec![]);
+        let extremes = find_extremes(polymax_naive, &poly1, true, true);
+        let correct = Extremes {
+            ymin: Point::new(1.0, 0.0),
+            xmax: Point::new(2.0, 1.0),
+            ymax: Point::new(1.0, 2.0),
+            xmin: Point::new(0.0, 1.0),
+        };
+        assert_eq!(extremes, correct);
+    }
+}

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -82,15 +82,15 @@ fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes,
         .iter()
         .enumerate()
         .map(|(idx, _)| {
-            // get previous and previous - 1 index offsets
             let prev_1 = polygon.previous_vertex(&idx);
             let prev_2 = polygon.previous_vertex(&prev_1);
-            // now make sure they're all positive or all negative, which implies convexity
             cross_prod(&polygon.exterior.0[prev_2],
                        &polygon.exterior.0[prev_1],
                        &polygon.exterior.0[idx])
         })
+        // accumulate and check cross-product result signs in a single pass
         // positive implies ccw convexity, negative implies cw convexity
+        // anything else implies non-convexity
         .fold(ListSign::Empty, |acc, n| {
             match (acc, n.is_positive()) {
                 (ListSign::Empty, true) | (ListSign::Positive, true) => ListSign::Positive,
@@ -106,10 +106,10 @@ fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes,
                           Point::new(T::zero(), T::one()),
                           Point::new(-T::one(), T::zero())];
     Ok(directions
-        .iter()
-        .map(|p| func(&p, &polygon).unwrap())
-        .collect::<Vec<usize>>()
-        .into())
+           .iter()
+           .map(|p| func(&p, &polygon).unwrap())
+           .collect::<Vec<usize>>()
+           .into())
 }
 
 // find a convex, counter-clockwise oriented polygon's maximum vertex in a specified direction

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -282,7 +282,7 @@ mod test {
     #[test]
     fn test_polygon_extreme_wrapper_convex() {
         // convex, with a bump on the top-right edge
-        let points_raw =
+        let mut points_raw =
             vec![(1.0, 0.0), (2.0, 1.0), (1.75, 1.75), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
         let points = points_raw
             .iter()

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -58,7 +58,7 @@ impl<T> Polygon<T>
 }
 
 // positive implies a -> b -> c is counter-clockwise, negative implies clockwise
-pub fn cross_prod<T>(p_a: &Point<T>, p_b: &Point<T>, p_c: &Point<T>) -> T
+fn cross_prod<T>(p_a: &Point<T>, p_b: &Point<T>, p_c: &Point<T>) -> T
     where T: Float
 {
     (p_b.x() - p_a.x()) * (p_c.y() - p_a.y()) - (p_b.y() - p_a.y()) * (p_c.x() - p_a.x())

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -22,3 +22,5 @@ pub mod simplifyvw;
 pub mod convexhull;
 /// Orients a Polygon's exterior and interior rings
 pub mod orient;
+/// calculate Polygon extremes
+pub mod extremes;

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -20,7 +20,7 @@ pub mod simplify;
 pub mod simplifyvw;
 /// Calculates the convex hull of a geometry.
 pub mod convexhull;
-/// Orients a Polygon's exterior and interior rings
+/// Orients a Polygon's exterior and interior rings.
 pub mod orient;
-/// calculate Polygon extremes
+/// Returns the extreme indices of a `Polygon`, `MultiPolygon`, or `MultiPoint`. 
 pub mod extremes;

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,8 +25,6 @@ pub struct Bbox<T>
     pub ymax: T,
 }
 
-/// Returns the extreme vertex indices (minimum `y`, maximum `x`, maximum `y`, minimum `x`)
-/// of a `Polygon` or `MultiPolygon`.
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub struct Extremes {
     pub ymin: usize,

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,6 +25,31 @@ pub struct Bbox<T>
     pub ymax: T,
 }
 
+/// Returns the extreme points (minimum `y`, maximum `x`, maximum `y`, minimum `x`)
+/// of a `Polygon` or `MultiPolygon`.
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub struct Extremes<T>
+    where T: Float
+{
+    pub ymin: Point<T>,
+    pub xmax: Point<T>,
+    pub ymax: Point<T>,
+    pub xmin: Point<T>,
+}
+
+impl<T> From<Vec<Point<T>>> for Extremes<T>
+    where T: Float
+{
+    fn from(original: Vec<Point<T>>) -> Extremes<T> {
+        Extremes {
+            ymin: original[0],
+            xmax: original[1],
+            ymax: original[2],
+            xmin: original[3],
+        }
+    }
+}
+
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub struct Point<T> (pub Coordinate<T>) where T: Float;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -45,6 +45,16 @@ impl From<Vec<usize>> for Extremes {
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
+pub struct ExtremePoint<T>
+    where T: Float
+ {
+    pub ymin: Point<T>,
+    pub xmax: Point<T>,
+    pub ymax: Point<T>,
+    pub xmin: Point<T>,
+}
+
+#[derive(PartialEq, Clone, Copy, Debug)]
 pub struct Point<T> (pub Coordinate<T>) where T: Float;
 
 impl<T> Point<T>

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,22 +25,18 @@ pub struct Bbox<T>
     pub ymax: T,
 }
 
-/// Returns the extreme points (minimum `y`, maximum `x`, maximum `y`, minimum `x`)
+/// Returns the extreme vertex indices (minimum `y`, maximum `x`, maximum `y`, minimum `x`)
 /// of a `Polygon` or `MultiPolygon`.
 #[derive(PartialEq, Clone, Copy, Debug)]
-pub struct Extremes<T>
-    where T: Float
-{
-    pub ymin: Point<T>,
-    pub xmax: Point<T>,
-    pub ymax: Point<T>,
-    pub xmin: Point<T>,
+pub struct Extremes {
+    pub ymin: usize,
+    pub xmax: usize,
+    pub ymax: usize,
+    pub xmin: usize,
 }
 
-impl<T> From<Vec<Point<T>>> for Extremes<T>
-    where T: Float
-{
-    fn from(original: Vec<Point<T>>) -> Extremes<T> {
+impl From<Vec<usize>> for Extremes {
+    fn from(original: Vec<usize>) -> Extremes {
         Extremes {
             ymin: original[0],
             xmax: original[1],


### PR DESCRIPTION
This PR allows the calculation of the indices containing the extreme (min and max) `x` and `y` values of a geometry (any geometry for which we can build a convex hull). There are some subtleties:

The algorithm is simple, and runs in `O(n)` time, but only works on convex geometries, which it expects to be oriented counter-clockwise. Since convex-hull processing using QuickHull is `O(n log n)` on average, that's the lower bound if the geometry needs to be processed first. However, if you know your geometries are convex and oriented, you can specify this, and get `O(n)` processing.

There's also a binary-search algorithm available, which cuts processing time to `O(log n)`, but I haven't been able to make it work. It's [available in a previous commit](https://github.com/urschrei/rust-geo/commit/4f71b24030a888cd95506747a0f1feaa3cce4201#diff-6128c8bf9f8def540989e4f8abf862c7L85) along with a link to the source, if anyone wants to have a look at it and figure out where the problem is – it incorrectly returns minimum `x`. The current algorithm is implemented using a wrapper function that allows the algorithms to be easily swapped out.

I've also defaulted to returning indices, not points, because this functionality is primarily intended as a helper for other algorithms.