### PR TITLE
Add contains point impl for bbox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["gis", "geo", "geography", "geospatial"]
 
 [dependencies]
 num-traits = "0.1"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "0.9"
+serde_derive = "0.9"
 
 [dev-dependencies]
 approx = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ keywords = ["gis", "geo", "geography", "geospatial"]
 
 [dependencies]
 num-traits = "0.1"
+serde = "1.0.2"
+serde_derive = "1.0.2"
 
 [dev-dependencies]
 approx = "0.1.1"

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -152,6 +152,15 @@ impl<T> Contains<LineString<T>> for Polygon<T>
     }
 }
 
+
+impl<T> Contains<Point<T>> for Bbox<T>
+    where T: Float
+{
+    fn contains(&self, p: &Point<T>) -> bool {
+        p.x() >= self.xmin && p.x() <= self.xmax && p.y() >= self.ymin && p.y() <= self.ymax
+    }
+}
+
 impl<T> Contains<Bbox<T>> for Bbox<T>
     where T: Float
 {
@@ -166,6 +175,7 @@ impl<T> Contains<Bbox<T>> for Bbox<T>
 mod test {
     use types::{Coordinate, Point, LineString, Polygon, MultiPolygon, Bbox};
     use algorithm::contains::Contains;
+        #[test]
     /// Tests: Point in LineString
     #[test]
     fn empty_linestring_test() {

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -73,7 +73,7 @@ impl<T> Intersects<Bbox<T>> for Bbox<T>
 {
     fn intersects(&self, bbox: &Bbox<T>) -> bool {
         // line intersects inner or outer polygon edge
-        if bbox.contains(&self) {
+        if bbox.contains(self) {
             return false
         } else {
             (self.xmin >= bbox.xmin && self.xmin <= bbox.xmax || self.xmax >= bbox.xmin && self.xmax <= bbox.xmax) &&

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
 extern crate num_traits;
 
 pub use traits::ToGeo;

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,7 @@ use num_traits::{Float, ToPrimitive};
 
 pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Coordinate<T>
     where T: Float
 {
@@ -15,7 +15,7 @@ pub struct Coordinate<T>
     pub y: T,
 }
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Bbox<T>
     where T: Float
 {
@@ -54,7 +54,7 @@ pub struct ExtremePoint<T>
     pub xmin: Point<T>,
 }
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Point<T> (pub Coordinate<T>) where T: Float;
 
 impl<T> Point<T>
@@ -318,13 +318,13 @@ impl<T> AddAssign for Bbox<T>
 #[derive(PartialEq, Clone, Debug)]
 pub struct MultiPoint<T>(pub Vec<Point<T>>) where T: Float;
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct LineString<T>(pub Vec<Point<T>>) where T: Float;
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct MultiLineString<T>(pub Vec<LineString<T>>) where T: Float;
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct Polygon<T>
     where T: Float
 {


### PR DESCRIPTION
This makes it quicker to parse shapefiles, there's usually a bbox associated with a polygon. The contains check is a lot faster for the bbox.