### PR TITLE
Add `Line` type

### DIFF
--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -121,7 +121,7 @@ mod test {
     #[test]
     fn area_line_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let line1 = Line((p(0.0, 0.0), p(1.0, 1.0)));
+        let line1 = Line::new(p(0.0, 0.0), p(1.0, 1.0));
         assert_eq!(line1.area(), 0.);
     }
 }

--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -1,5 +1,5 @@
 use num_traits::Float;
-use types::{LineString, Polygon, MultiPolygon, Bbox};
+use types::{Line, LineString, Polygon, MultiPolygon, Bbox};
 
 /// Calculation of the area.
 
@@ -31,6 +31,13 @@ fn get_linestring_area<T>(linestring: &LineString<T>) -> T where T: Float {
     tmp / (T::one() + T::one())
 }
 
+impl<T> Area<T> for Line<T>
+    where T: Float
+{
+    fn area(&self) -> T {
+        T::zero()
+    }
+}
 
 impl<T> Area<T> for Polygon<T>
     where T: Float
@@ -59,7 +66,7 @@ impl<T> Area<T> for Bbox<T>
 
 #[cfg(test)]
 mod test {
-    use types::{Coordinate, Point, LineString, Polygon, MultiPolygon, Bbox};
+    use types::{Coordinate, Point, Line, LineString, Polygon, MultiPolygon, Bbox};
     use algorithm::area::Area;
 
     // Area of the polygon
@@ -110,5 +117,11 @@ mod test {
         let mpoly = MultiPolygon(vec![poly0, poly1, poly2]);
         assert_eq!(mpoly.area(), 102.);
         assert_relative_eq!(mpoly.area(), 102.);
+    }
+    #[test]
+    fn area_line_test() {
+        let p = |x, y| Point(Coordinate { x: x, y: y });
+        let line1 = Line((p(0.0, 0.0), p(1.0, 1.0)));
+        assert_eq!(line1.area(), 0.);
     }
 }

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -69,7 +69,8 @@ impl<T> BoundingBox<T> for Line<T>
     where T: Float
 {
     fn bbox(&self) -> Option<Bbox<T>> {
-        let (a, b) = self.0;
+        let a = self.start;
+        let b = self.end;
         let (xmin, xmax) = if a.x() <= b.x() {(a.x(), b.x())} else {(b.x(), a.x())};
         let (ymin, ymax) = if a.y() <= b.y() {(a.y(), b.y())} else {(b.y(), a.y())};
         Some(Bbox {xmin: xmin, xmax: xmax,
@@ -190,8 +191,8 @@ mod test {
     #[test]
     fn line_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let line1 = Line((p(0., 1.), p(2., 3.)));
-        let line2 = Line((p(2., 3.), p(0., 1.)));
+        let line1 = Line::new(p(0., 1.), p(2., 3.));
+        let line2 = Line::new(p(2., 3.), p(0., 1.));
         assert_eq!(line1.bbox().unwrap(),
                    Bbox {xmin: 0., xmax: 2., ymin: 1., ymax: 3.});
         assert_eq!(line2.bbox().unwrap(),

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -58,7 +58,7 @@ impl<T> Centroid<T> for Line<T>
     where T: Float
 {
     fn centroid(&self) -> Option<Point<T>> {
-        let (a, b) = self.0;
+        let (a, b) = (self.start, self.end);
         let two = T::one() + T::one();
         let x = (a.x() + b.x()) / two;
         let y = (a.y() + b.y()) / two;
@@ -308,7 +308,7 @@ mod test {
     #[test]
     fn line_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let line1 = Line((p(0., 1.), p(1., 3.)));
+        let line1 = Line::new(p(0., 1.), p(1., 3.));
         assert_eq!(line1.centroid(), Some(p(0.5, 2.)));
     }
 }

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -1,6 +1,6 @@
 use num_traits::{Float, FromPrimitive};
 
-use types::{Point, LineString, Polygon, MultiPolygon, Bbox};
+use types::{Point, Line, LineString, Polygon, MultiPolygon, Bbox};
 use algorithm::area::Area;
 use algorithm::distance::Distance;
 
@@ -52,6 +52,18 @@ fn simple_polygon_centroid<T>(poly_ext: &LineString<T>) -> Option<Point<T>>
     }
     let six = T::from_i32(6).unwrap();
     Some(Point::new(sum_x / (six * area), sum_y / (six * area)))
+}
+
+impl<T> Centroid<T> for Line<T>
+    where T: Float
+{
+    fn centroid(&self) -> Option<Point<T>> {
+        let (a, b) = self.0;
+        let two = T::one() + T::one();
+        let x = (a.x() + b.x()) / two;
+        let y = (a.y() + b.y()) / two;
+        Some(Point::new(x, y))
+    }
 }
 
 impl<T> Centroid<T> for LineString<T>
@@ -170,7 +182,7 @@ impl<T> Centroid<T> for Point<T>
 
 #[cfg(test)]
 mod test {
-    use types::{COORD_PRECISION, Coordinate, Point, LineString, Polygon, MultiPolygon, Bbox};
+    use types::{COORD_PRECISION, Coordinate, Point, Line, LineString, Polygon, MultiPolygon, Bbox};
     use algorithm::centroid::Centroid;
     use algorithm::distance::Distance;
     // Tests: Centroid of LineString
@@ -292,5 +304,11 @@ mod test {
         };
         let point = Point(Coordinate { x: 2., y: 75. });
         assert_eq!(point, bbox.centroid().unwrap());
+    }
+    #[test]
+    fn line_test() {
+        let p = |x, y| Point(Coordinate { x: x, y: y });
+        let line1 = Line((p(0., 1.), p(1., 3.)));
+        assert_eq!(line1.centroid(), Some(p(0.5, 2.)));
     }
 }

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -58,10 +58,9 @@ impl<T> Centroid<T> for Line<T>
     where T: Float
 {
     fn centroid(&self) -> Option<Point<T>> {
-        let (a, b) = (self.start, self.end);
         let two = T::one() + T::one();
-        let x = (a.x() + b.x()) / two;
-        let y = (a.y() + b.y()) / two;
+        let x = (self.start.x() + self.end.x()) / two;
+        let y = (self.start.y() + self.end.y()) / two;
         Some(Point::new(x, y))
     }
 }

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -366,12 +366,9 @@ mod test {
         let line2 = Line::new(p(0., 6.), p(1.5, 4.5));
         // point on line
         let line3 = Line::new(p(0., 6.), p(3., 3.));
-        // point within precision of line
-        let line4 = Line::new(p(0., 6.00001), p(3., 3.0001));
         assert!(line1.contains(&p0));
         assert!(!line2.contains(&p0));
         assert!(line3.contains(&p0));
-        assert!(line4.contains(&p0));
     }
     #[test]
     fn line_in_line_test() {
@@ -403,7 +400,6 @@ mod test {
         assert!(!line.contains(&linestring1));
         assert!(!line.contains(&linestring2));
         assert!(!line.contains(&linestring3));
-        println!("{:?}", linestring3.0);
     }
     #[test]
     fn line_in_polygon_test() {

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -76,21 +76,24 @@ impl<T> Contains<Point<T>> for Line<T>
     where T: Float
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        // if the point is not in the bounding box, it's not on the line
-        if !self.bbox().map_or(false, |b| b.contains(p)) {
-            return false;
-        }
-        let (a, b) = self.0;
-        // handle the special case where the line is vertical
-        if a.x() == b.x() {
-            return (p.x() - a.x()).to_f32().unwrap() <= COORD_PRECISION;
-        }
-        // solve a linear equation
-        let slope = (a.y() - b.y()) / (a.x() - b.x());
-        let intercept = a.y() - slope * a.x();
-        (p.y() - (slope * p.x() + intercept)).abs()
-                                             .to_f32()
-                                             .unwrap() <= COORD_PRECISION
+        self.intersects(p)
+    }
+}
+
+impl<T> Contains<Line<T>> for Line<T>
+    where T: Float
+{
+    fn contains(&self, line: &Line<T>) -> bool {
+        let (a, b) = (line.start, line.end);
+        self.contains(&a) & self.contains(&b)
+    }
+}
+
+impl<T> Contains<LineString<T>> for Line<T> 
+    where T: Float
+{
+    fn contains(&self, linestring: &LineString<T>) -> bool {
+        linestring.0.iter().all(|pt| self.contains(pt))
     }
 }
 
@@ -160,6 +163,14 @@ impl<T> Contains<Point<T>> for MultiPolygon<T>
 {
     fn contains(&self, p: &Point<T>) -> bool {
         self.0.iter().any(|poly| poly.contains(p))
+    }
+}
+
+impl<T> Contains<Line<T>> for Polygon<T>
+    where T: Float
+{
+    fn contains(&self, line: &Line<T>) -> bool {
+        false
     }
 }
 
@@ -350,16 +361,59 @@ mod test {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let p0 = p(2., 4.);
         // vertical line
-        let line1 = Line((p(2., 0.), p(2., 5.)));
+        let line1 = Line::new(p(2., 0.), p(2., 5.));
         // point on line, but outside line segment
-        let line2 = Line((p(0., 6.), p(1.5, 4.5)));
+        let line2 = Line::new(p(0., 6.), p(1.5, 4.5));
         // point on line
-        let line3 = Line((p(0., 6.), p(3., 3.)));
+        let line3 = Line::new(p(0., 6.), p(3., 3.));
         // point within precision of line
-        let line4 = Line((p(0., 6.00001), p(3., 3.0001)));
+        let line4 = Line::new(p(0., 6.00001), p(3., 3.0001));
         assert!(line1.contains(&p0));
         assert!(!line2.contains(&p0));
         assert!(line3.contains(&p0));
         assert!(line4.contains(&p0));
+    }
+    #[test]
+    fn line_in_line_test() {
+        let p = |x, y| Point(Coordinate { x: x, y: y });
+        let line0 = Line::new(p(0., 1.), p(3., 4.));
+        // first point on line0, second not
+        let line1 = Line::new(p(1., 2.), p(2., 2.));
+        // co-linear, but extends past the end of line0
+        let line2 = Line::new(p(1., 2.), p(4., 5.));
+        // contained in line0
+        let line3 = Line::new(p(1., 2.), p(3., 4.));
+        assert!(!line0.contains(&line1));
+        assert!(!line0.contains(&line2));
+        assert!(line0.contains(&line3));
+    }
+    #[test]
+    fn linestring_in_line_test() {
+        let p = |x, y| Point(Coordinate { x: x, y: y });
+        let line = Line::new(p(0., 1.), p(3., 4.));
+        // linestring0 in line
+        let linestring0 = LineString(vec![p(0.1, 1.1), p(1., 2.), p(1.5, 2.5)]);
+        // linestring1 starts and ends in line, but wanders in the middle
+        let linestring1 = LineString(vec![p(0.1, 1.1), p(2., 2.), p(1.5, 2.5)]);
+        // linestring2 is co-linear, but extends beyond line
+        let linestring2 = LineString(vec![p(0.1, 1.1), p(1., 2.), p(4., 5.)]);
+        // no part of linestring3 is contained in line
+        let linestring3 = LineString(vec![p(1.1, 1.1), p(2., 2.), p(2.5, 2.5)]);
+        assert!(line.contains(&linestring0));
+        assert!(!line.contains(&linestring1));
+        assert!(!line.contains(&linestring2));
+        assert!(!line.contains(&linestring3));
+        println!("{:?}", linestring3.0);
+    }
+    #[test]
+    fn line_in_polygon_test() {
+        let p = |x, y| Point(Coordinate { x: x, y: y });
+        let line = Line::new(p(0., 1.), p(3., 4.));
+        let linestring0 = LineString(vec![p(0., 0.), p(5., 0.), p(5., 5.), p(0., 5.), p(0., 0.)]);
+        let poly0 = Polygon::new(linestring0, Vec::new());
+        let linestring1 = LineString(vec![p(0., 0.), p(2., 0.), p(2., 2.), p(0., 2.), p(0., 0.)]);
+        let poly1 = Polygon::new(linestring1, Vec::new());
+        assert!(poly0.contains(&line));
+        assert!(!poly1.contains(&line));
     }
 }

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -204,7 +204,6 @@ impl<T> Contains<Line<T>> for Polygon<T>
     fn contains(&self, line: &Line<T>) -> bool {
         // both endpoints are contained in the polygon and the line
         // does NOT intersect the exterior or any of the interior boundaries
-        println!("contains end?: {}", self.contains(&line.end));
         self.contains(&line.start) &&
             self.contains(&line.end) &&
             !self.exterior.intersects(line) &&
@@ -224,7 +223,6 @@ impl<T> Contains<LineString<T>> for Polygon<T>
         }
     }
 }
-
 
 impl<T> Contains<Point<T>> for Bbox<T>
     where T: Float

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -1,7 +1,6 @@
 use num_traits::{Float, ToPrimitive};
 
 use types::{COORD_PRECISION, Point, Line, LineString, Polygon, MultiPolygon, Bbox};
-use algorithm::boundingbox::BoundingBox;
 use algorithm::intersects::Intersects;
 use algorithm::distance::Distance;
 

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use num_traits::{Float, ToPrimitive};
-use types::{Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon};
+use types::{Point, Line, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon};
 use algorithm::contains::Contains;
 use num_traits::pow::pow;
 
@@ -263,9 +263,26 @@ impl<T> Distance<T, Point<T>> for LineString<T>
     }
 }
 
+impl<T> Distance<T, Point<T>> for Line<T>
+    where T: Float
+{
+    /// Minimum distance from a Lined to a Point
+    fn distance(&self, point: &Point<T>) -> T {
+        line_segment_distance(point, &self.start, &self.end)
+    }
+}
+impl<T> Distance<T, Line<T>> for Point<T>
+    where T: Float
+{
+    /// Minimum distance from a Line to a Point
+    fn distance(&self, line: &Line<T>) -> T {
+        line.distance(self)
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use types::{Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon};
+    use types::{Point, Line, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon};
     use algorithm::distance::{Distance, line_segment_distance};
 
     #[test]
@@ -456,5 +473,20 @@ mod test {
         let mp = MultiPoint(v);
         let p = Point::new(50.0, 50.0);
         assert_eq!(p.distance(&mp), 64.03124237432849)
+    }
+    #[test]
+    fn distance_line_test() {
+        let line0 = Line::new(Point::new(0., 0.), Point::new(5., 0.));
+        let p0 = Point::new(2., 3.);
+        let p1 = Point::new(3., 0.);
+        let p2 = Point::new(6., 0.);
+        assert_eq!(line0.distance(&p0), 3.);
+        assert_eq!(p0.distance(&line0), 3.);
+
+        assert_eq!(line0.distance(&p1), 0.);
+        assert_eq!(p1.distance(&line0), 0.);
+
+        assert_eq!(line0.distance(&p2), 1.);
+        assert_eq!(p2.distance(&line0), 1.);
     }
 }

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -266,7 +266,7 @@ impl<T> Distance<T, Point<T>> for LineString<T>
 impl<T> Distance<T, Point<T>> for Line<T>
     where T: Float
 {
-    /// Minimum distance from a Lined to a Point
+    /// Minimum distance from a Line to a Point
     fn distance(&self, point: &Point<T>) -> T {
         line_segment_distance(point, &self.start, &self.end)
     }

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -23,21 +23,48 @@ pub trait Intersects<Rhs = Self> {
     fn intersects(&self, rhs: &Rhs) -> bool;
 }
 
+/// Compute the slope of the line segment.
+///
+/// ```
+/// use geo::{Point, Line}
+///
+/// let line = Line::new(Point::new(0., 0.), Point::new(1., 2.));
+/// let vline = Line::new(Point::new(0., 0.), Point::new(0., 3.));
+///
+/// assert_eq!(slope(&line), Some(2.));
+/// assert_eq!(slope(&vline), None);
+/// ```
+fn slope<T: Float>(line: &Line<T>) -> Option<T> {
+    if line.start.x() == line.end.x() {
+        None // Vertical lines do not have slope
+    } else {
+        Some((line.start.y() - line.end.y()) /
+             (line.start.x() - line.end.x()))
+    }
+}
+
 impl<T> Intersects<Point<T>> for Line<T>
     where T: Float
 {
     fn intersects(&self, p: &Point<T>) -> bool {
-        // if the point is not in the bounding box, it's not on the line
-        if !self.bbox().map_or(false, |b| b.contains(p)) {
-            println!("NOT IN BBOX");
-            return false;
-        }
-        match self.slope() {
-            None => p.x() - self.start.x(),
-            Some(m) => {
-                p.y() - ((m * (p.x() - self.start.x()) + self.start.y()))
+        let (ymin, ymax) = if self.start.y() < self.end.y() {
+                (self.start.y(), self.end.y())
+             } else {
+                (self.end.y(), self.start.y())
+         };
+        (p.y() >= ymin) & (p.y() <= ymax) &
+            match slope(self) {
+                None => p.x() == self.start.x(),
+                Some(m) => p.y() == m * (p.x() - self.start.x()) + self.start.y()
             }
-        }.abs().to_f32().unwrap() <= COORD_PRECISION
+    }
+}
+
+impl<T> Intersects<Line<T>> for Point<T>
+    where T: Float
+{
+    fn intersects(&self, line: &Line<T>) -> bool {
+        line.intersects(self)
     }
 }
 
@@ -45,8 +72,69 @@ impl<T> Intersects<Line<T>> for Line<T>
     where T: Float
 {
     fn intersects(&self, line: &Line<T>) -> bool {
-        false
+        // Using Cramer's Rule:
+        // https://en.wikipedia.org/wiki/Intersection_%28Euclidean_geometry%29#Two_line_segments
+        let (x1, y1, x2, y2) = (self.start.x(), self.start.y(),
+                                self.end.x(), self.end.y());
+        let (x3, y3, x4, y4) = (line.start.x(), line.start.y(),
+                                line.end.x(), line.end.y());
+        let a1 = x2 - x1;
+        let a2 = y2 - y1;
+        let b1 = x3 - x4; // == -(x4 - x3)
+        let b2 = y3 - y4; // == -(y4 - y3)
+        let c1 = x3 - x1;
+        let c2 = y3 - y1;
 
+        let d = a1*b2 - a2*b1;
+        if d == T::zero() {
+            // lines are parallel
+            // return true iff line and self are co-linear
+            self.start.intersects(&line) | self.end.intersects(&line) |
+            line.start.intersects(&self) | line.end.intersects(&self)
+        } else {
+            let s = (c1*b2 - c2*b1) / d;
+            let t = (a1*c2 - a2*c1) / d;
+            (T::zero() <= s) & (s <= T::one()) &
+                (T::zero() <= t) & (t <= T::one())
+        }
+    }
+}
+
+impl<T> Intersects<LineString<T>> for Line<T>
+    where T: Float
+{
+    fn intersects(&self, linestring: &LineString<T>) -> bool {
+        linestring.0
+                  .windows(2)
+                  .map(|pts| Line::new(pts[0], pts[1]))
+                  .any(|line| self.intersects(&line))
+    }
+}
+
+impl<T> Intersects<Line<T>> for LineString<T>
+    where T: Float
+{
+    fn intersects(&self, line: &Line<T>) -> bool {
+        line.intersects(self)
+    }
+}
+
+impl<T> Intersects<Polygon<T>> for Line<T>
+    where T: Float
+{
+    fn intersects(&self, p: &Polygon<T>) -> bool {
+        p.exterior.intersects(self) ||
+            p.interiors.iter().any(|inner| inner.intersects(self)) ||
+            p.contains(&self.start) ||
+            p.contains(&self.end)
+    }
+}
+
+impl<T> Intersects<Line<T>> for Polygon<T>
+    where T: Float
+{
+    fn intersects(&self, line: &Line<T>) -> bool {
+        line.intersects(self)
     }
 }
 
@@ -146,7 +234,7 @@ impl<T> Intersects<Polygon<T>> for Polygon<T>
 
 #[cfg(test)]
 mod test {
-    use types::{Coordinate, Point, LineString, Polygon, Bbox};
+    use types::{Coordinate, Point, Line, LineString, Polygon, Bbox};
     use algorithm::intersects::Intersects;
     /// Tests: intersection LineString and LineString
     #[test]
@@ -357,5 +445,86 @@ mod test {
         assert_eq!(false, bbox_sm.intersects(&bbox_xl));
         assert_eq!(true, bbox_sm.intersects(&bbox_s2));
         assert_eq!(true, bbox_s2.intersects(&bbox_sm));
+    }
+    #[test]
+    fn point_intersects_line_test() {
+        let p0 = Point::new(2., 4.);
+        // vertical line
+        let line1 = Line::new(Point::new(2., 0.), Point::new(2., 5.));
+        // point on line, but outside line segment
+        let line2 = Line::new(Point::new(0., 6.), Point::new(1.5, 4.5));
+        // point on line
+        let line3 = Line::new(Point::new(0., 6.), Point::new(3., 3.));
+        assert!(line1.intersects(&p0));
+        assert!(p0.intersects(&line1));
+        assert!(!line2.intersects(&p0));
+        assert!(!p0.intersects(&line2));
+        assert!(line3.intersects(&p0));
+        assert!(p0.intersects(&line3));
+    }
+    #[test]
+    fn line_intersects_line_test() {
+        let line0 = Line::new(Point::new(0., 0.), Point::new(3., 4.));
+        let line1 = Line::new(Point::new(2., 0.), Point::new(2., 5.));
+        let line2 = Line::new(Point::new(0., 7.), Point::new(5., 4.));
+        let line3 = Line::new(Point::new(0., 0.), Point::new(-3., -4.));
+        assert!(line0.intersects(&line0));
+        assert!(line0.intersects(&line1));
+        assert!(!line0.intersects(&line2));
+        assert!(line0.intersects(&line3));
+
+        assert!(line1.intersects(&line0));
+        assert!(line1.intersects(&line1));
+        assert!(!line1.intersects(&line2));
+        assert!(!line1.intersects(&line3));
+
+        assert!(!line2.intersects(&line0));
+        assert!(!line2.intersects(&line1));
+        assert!(line2.intersects(&line2));
+        assert!(!line1.intersects(&line3));
+    }
+    #[test]
+    fn line_intersects_linestring_test() {
+        let line0 = Line::new(Point::new(0., 0.), Point::new(3., 4.));
+        let linestring0 = LineString(
+            vec![Point::new(0., 1.), Point::new(1., 0.), Point::new(2., 0.)]
+        );
+        let linestring1 = LineString(
+            vec![Point::new(0.5, 0.2), Point::new(1., 0.), Point::new(2., 0.)]
+        );
+        assert!(line0.intersects(&linestring0));
+        assert!(!line0.intersects(&linestring1));
+        assert!(linestring0.intersects(&line0));
+        assert!(!linestring1.intersects(&line0));
+    }
+    #[test]
+    fn line_intersects_polygon_test() {
+        let line0 = Line::new(Point::new(0.5, 0.5), Point::new(2., 1.));
+        let poly0 = Polygon::new(
+            LineString(vec![Point::new(0.,0.), Point::new(1., 2.),
+                            Point::new(1., 0.), Point::new(0., 0.)]),
+            vec![]
+        );
+        let poly1 = Polygon::new(
+            LineString(vec![Point::new(1., -1.), Point::new(2., -1.),
+                            Point::new(2., -2.), Point::new(1., -1.)]),
+            vec![]
+        );
+        // line contained in the hole
+        let poly2 = Polygon::new(
+            LineString(vec![Point::new(-1., -1.), Point::new(-1., 10.),
+                            Point::new(10., -1.), Point::new(-1., -1.)]),
+            vec![LineString(vec![Point::new(0., 0.), Point::new(3., 4.),
+                                 Point::new(3., 0.), Point::new(0., 0.)])]
+        );
+        assert!(line0.intersects(&poly0));
+        assert!(poly0.intersects(&line0));
+
+        assert!(!line0.intersects(&poly1));
+        assert!(!poly1.intersects(&line0));
+
+        println!("line0 intersects poly2");
+        assert!(!line0.intersects(&poly2));
+        assert!(!poly2.intersects(&line0));
     }
 }

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -518,7 +518,6 @@ mod test {
         assert!(!line0.intersects(&poly1));
         assert!(!poly1.intersects(&line0));
 
-        println!("line0 intersects poly2");
         assert!(!line0.intersects(&poly2));
         assert!(!poly2.intersects(&line0));
     }

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -1,5 +1,6 @@
 use num_traits::Float;
-use types::{LineString, Polygon, Bbox, Point};
+use types::{COORD_PRECISION, Line, LineString, Polygon, Bbox, Point};
+use algorithm::boundingbox::BoundingBox;
 use algorithm::contains::Contains;
 
 /// Checks if the geometry A intersects the geometry B.
@@ -20,6 +21,33 @@ pub trait Intersects<Rhs = Self> {
     /// ```
     ///
     fn intersects(&self, rhs: &Rhs) -> bool;
+}
+
+impl<T> Intersects<Point<T>> for Line<T>
+    where T: Float
+{
+    fn intersects(&self, p: &Point<T>) -> bool {
+        // if the point is not in the bounding box, it's not on the line
+        if !self.bbox().map_or(false, |b| b.contains(p)) {
+            println!("NOT IN BBOX");
+            return false;
+        }
+        match self.slope() {
+            None => p.x() - self.start.x(),
+            Some(m) => {
+                p.y() - ((m * (p.x() - self.start.x()) + self.start.y()))
+            }
+        }.abs().to_f32().unwrap() <= COORD_PRECISION
+    }
+}
+
+impl<T> Intersects<Line<T>> for Line<T> 
+    where T: Float
+{
+    fn intersects(&self, line: &Line<T>) -> bool {
+        false
+
+    }
 }
 
 impl<T> Intersects<LineString<T>> for LineString<T>

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -32,17 +32,14 @@ impl<T> Intersects<Point<T>> for Line<T>
         let ty = if dy == T::zero() {None} else {Some((p.y() - self.start.y()) / dy)};
         match (tx, ty) {
             (None, None) => { // Degenerate line
-                println!("degenerate");
                 *p == self.start
             },
             (Some(t), None) => { // Horizontal line
-                println!("horizontal");
                 p.y() == self.start.y() &&
                     T::zero() <= t &&
                     t <= T::one()
             },
             (None, Some(t)) => { // Vertical line
-                println!("vertical");
                 p.x() == self.start.x() &&
                     T::zero() <= t &&
                     t <= T::one()
@@ -84,14 +81,14 @@ impl<T> Intersects<Line<T>> for Line<T>
         let d = a1*b2 - a2*b1;
         if d == T::zero() {
             // lines are parallel
-            // return true iff line and self are co-linear
-            self.start.intersects(&line) | self.end.intersects(&line) |
-            line.start.intersects(&self) | line.end.intersects(&self)
+            // return true iff at least one endpoint intersects the other line
+            self.start.intersects(&line) || self.end.intersects(&line) ||
+            line.start.intersects(&self) || line.end.intersects(&self)
         } else {
             let s = (c1*b2 - c2*b1) / d;
             let t = (a1*c2 - a2*c1) / d;
-            (T::zero() <= s) & (s <= T::one()) &
-                (T::zero() <= t) & (t <= T::one())
+            (T::zero() <= s) && (s <= T::one()) &&
+                (T::zero() <= t) && (t <= T::one())
         }
     }
 }

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -23,17 +23,6 @@ pub trait Intersects<Rhs = Self> {
     fn intersects(&self, rhs: &Rhs) -> bool;
 }
 
-/// Compute the slope of the line segment.
-///
-/// ```
-/// use geo::{Point, Line}
-///
-/// let line = Line::new(Point::new(0., 0.), Point::new(1., 2.));
-/// let vline = Line::new(Point::new(0., 0.), Point::new(0., 3.));
-///
-/// assert_eq!(slope(&line), Some(2.));
-/// assert_eq!(slope(&vline), None);
-/// ```
 fn slope<T: Float>(line: &Line<T>) -> Option<T> {
     if line.start.x() == line.end.x() {
         None // Vertical lines do not have slope
@@ -235,7 +224,14 @@ impl<T> Intersects<Polygon<T>> for Polygon<T>
 #[cfg(test)]
 mod test {
     use types::{Coordinate, Point, Line, LineString, Polygon, Bbox};
-    use algorithm::intersects::Intersects;
+    use algorithm::intersects::{Intersects, slope};
+    #[test]
+    fn slope_test() {
+        let line = Line::new(Point::new(0., 0.), Point::new(1., 2.));
+        let vline = Line::new(Point::new(0., 0.), Point::new(0., 3.));
+        assert_eq!(slope(&line), Some(2.));
+        assert_eq!(slope(&vline), None);
+    }
     /// Tests: intersection LineString and LineString
     #[test]
     fn empty_linestring1_test() {

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -1,6 +1,5 @@
 use num_traits::Float;
-use types::{COORD_PRECISION, Line, LineString, Polygon, Bbox, Point};
-use algorithm::boundingbox::BoundingBox;
+use types::{Line, LineString, Polygon, Bbox, Point};
 use algorithm::contains::Contains;
 
 /// Checks if the geometry A intersects the geometry B.

--- a/src/algorithm/length.rs
+++ b/src/algorithm/length.rs
@@ -1,6 +1,6 @@
 use num_traits::Float;
 
-use types::{LineString, MultiLineString};
+use types::{Line, LineString, MultiLineString};
 use algorithm::distance::Distance;
 
 /// Calculation of the length
@@ -23,6 +23,14 @@ pub trait Length<T, RHS = Self> {
     fn length(&self) -> T;
 }
 
+impl<T> Length<T> for Line<T>
+    where T: Float
+{
+    fn length(&self) -> T {
+        self.start.distance(&self.end)
+    }
+}
+
 impl<T> Length<T> for LineString<T>
     where T: Float
 {
@@ -42,7 +50,7 @@ impl<T> Length<T> for MultiLineString<T>
 
 #[cfg(test)]
 mod test {
-    use types::{Coordinate, Point, LineString, MultiLineString};
+    use types::{Coordinate, Point, Line, LineString, MultiLineString};
     use algorithm::length::Length;
 
     #[test]
@@ -67,5 +75,12 @@ mod test {
         let mline = MultiLineString(vec![LineString(vec![p(1., 0.), p(7., 0.), p(8., 0.), p(9., 0.), p(10., 0.), p(11., 0.)]),
                                          LineString(vec![p(0., 0.), p(0., 5.)])]);
         assert_eq!(15.0_f64, mline.length());
+    }
+    #[test]
+    fn line_test() {
+        let line0 = Line::new(Point::new(0., 0.), Point::new(0., 1.));
+        let line1 = Line::new(Point::new(0., 0.), Point::new(3., 4.));
+        assert_eq!(line0.length(), 1.);
+        assert_eq!(line1.length(), 5.);
     }
 }

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -109,7 +109,6 @@ impl<T> RotatePoint<T> for Line<T>
         let pts = vec![self.start, self.end];
         let rotated = rotation_matrix(angle, point, &pts);
         Line::new(rotated[0], rotated[1])
-
     }
 }
 

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -1,5 +1,5 @@
 use num_traits::{Float, FromPrimitive};
-use types::{Point, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString};
+use types::{Point, Line, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString};
 use algorithm::centroid::Centroid;
 
 // rotate a slice of points "angle" degrees about an origin
@@ -89,6 +89,27 @@ impl<T> RotatePoint<T> for Point<T>
     /// Rotate the Point about another point by the given number of degrees
     fn rotate_around_point(&self, angle: T, point: &Point<T>) -> Self {
         rotation_matrix(angle, point, &[*self])[0]
+    }
+}
+
+impl<T> Rotate<T> for Line<T>
+    where T: Float
+{
+    fn rotate(&self, angle: T) -> Self {
+        let pts = vec![self.start, self.end];
+        let rotated = rotation_matrix(angle, &self.centroid().unwrap(), &pts);
+        Line::new(rotated[0], rotated[1])
+    }
+}
+
+impl<T> RotatePoint<T> for Line<T>
+    where T: Float
+{
+    fn rotate_around_point(&self, angle: T, point: &Point<T>) -> Self {
+        let pts = vec![self.start, self.end];
+        let rotated = rotation_matrix(angle, point, &pts);
+        Line::new(rotated[0], rotated[1])
+
     }
 }
 
@@ -311,5 +332,17 @@ mod test {
         let p = Point::new(5.0, 10.0);
         let rotated = p.rotate_around_point(-45., &Point::new(10., 34.));
         assert_eq!(rotated, Point::new(-10.506096654409877, 20.564971157455595));
+    }
+    #[test]
+    fn test_rotate_line() {
+        let line0 = Line::new(Point::new(0., 0.), Point::new(0., 2.));
+        let line1 = Line::new(Point::new(1., 0.9999999999999999), Point::new(-1., 1.));
+        assert_eq!(line0.rotate(90.), line1);
+    }
+    #[test]
+    fn test_rotate_line_around_point() {
+        let line0 = Line::new(Point::new(0., 0.), Point::new(0., 2.));
+        let line1 = Line::new(Point::new(0., 0.), Point::new(-2., 0.00000000000000012246467991473532));
+        assert_eq!(line0.rotate_around_point(90., &Point::new(0., 0.)), line1);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -342,26 +342,6 @@ impl<T> Line<T>
     pub fn new(start: Point<T>, end: Point<T>) -> Line<T> {
         Line {start: start, end: end}
     }
-
-    /// Compute the slope of the line segment.
-    ///
-    /// ```
-    /// use geo::{Point, Line}
-    ///
-    /// let line = Line::new(Point::new(0., 0.), Point::new(1., 2.));
-    /// let vline = Line::new(Point::new(0., 0.), Point::new(0., 3.));
-    ///
-    /// assert_eq!(line.slope(), Some(2.));
-    /// assert_eq!(vline.slope(), None);
-    /// ```
-    pub fn slope(&self) -> Option<T> {
-        if self.start.x() == self.end.x() {
-            None // Vertical lines do not have slope
-        } else {
-            Some((self.start.y() - self.end.y()) /
-                 (self.start.x() - self.end.x()))
-        }
-    }
 }
 
 #[derive(PartialEq, Clone, Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -319,7 +319,50 @@ impl<T> AddAssign for Bbox<T>
 pub struct MultiPoint<T>(pub Vec<Point<T>>) where T: Float;
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct Line<T>(pub (Point<T>, Point<T>)) where T: Float;
+pub struct Line<T>
+    where T: Float
+{
+    pub start: Point<T>,
+    pub end: Point<T>
+}
+
+impl<T> Line<T>
+    where T: Float
+{
+    /// Creates a new line segment.
+    ///
+    /// ```
+    /// use geo::{Point, Line};
+    ///
+    /// let line = Line::new(Point::new(0., 0.), Point::new(1., 2.));
+    ///
+    /// assert_eq!(line.start, Point::new(0., 0.));
+    /// assert_eq!(line.end, Point::new(1., 2.));
+    /// ```
+    pub fn new(start: Point<T>, end: Point<T>) -> Line<T> {
+        Line {start: start, end: end}
+    }
+
+    /// Compute the slope of the line segment.
+    ///
+    /// ```
+    /// use geo::{Point, Line}
+    ///
+    /// let line = Line::new(Point::new(0., 0.), Point::new(1., 2.));
+    /// let vline = Line::new(Point::new(0., 0.), Point::new(0., 3.));
+    ///
+    /// assert_eq!(line.slope(), Some(2.));
+    /// assert_eq!(vline.slope(), None);
+    /// ```
+    pub fn slope(&self) -> Option<T> {
+        if self.start.x() == self.end.x() {
+            None // Vertical lines do not have slope
+        } else {
+            Some((self.start.y() - self.end.y()) /
+                 (self.start.x() - self.end.x()))
+        }
+    }
+}
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct LineString<T>(pub Vec<Point<T>>) where T: Float;

--- a/src/types.rs
+++ b/src/types.rs
@@ -319,6 +319,9 @@ impl<T> AddAssign for Bbox<T>
 pub struct MultiPoint<T>(pub Vec<Point<T>>) where T: Float;
 
 #[derive(PartialEq, Clone, Debug)]
+pub struct Line<T>(pub (Point<T>, Point<T>)) where T: Float;
+
+#[derive(PartialEq, Clone, Debug)]
 pub struct LineString<T>(pub Vec<Point<T>>) where T: Float;
 
 #[derive(PartialEq, Clone, Debug)]


### PR DESCRIPTION
Adds a `Line` type to represent a line segment by its two endpoints.

This PR is the first step to implementing Union/Intersection traits as outlined in #80 (See also #81). Additionally, it addresses #99.

Implements the following (with converse operations where applicable) for `Line`:
- `Length`
- `Area`
- `BoundingBox`
- `Centroid`
- `Rotate`
- `Contains` (`Point`, `Line`, `LineString`)
- `Intersects` (`Point`, `Line`, `LineString`, `Polygon`)
- `Distance` (`Point`)

I wanted to get this up sooner rather than later, and it's already on the large side so there are a few things left unimplemented (operations on `Multi*` geometries for example). Additionally, several operations on `LineString` (`Length` for example) could be nicely expressed as operations on an `Line` iterator. As a result, there is some redundancy that could be resolved in subsequent PRs. 