### PR TITLE
Incorrect usage of `abs_sub`

### DIFF
--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -45,7 +45,7 @@ impl<T> Intersects<Point<T>> for Line<T>
                     t <= T::one()
             },
             (Some(t_x), Some(t_y)) => { // All other lines
-                t_x.abs_sub(t_y) <= T::epsilon()  &&
+                (t_x - t_y).abs() <= T::epsilon()  &&
                     T::zero() <= t_x &&
                     t_x <= T::one()
             }
@@ -442,6 +442,7 @@ mod test {
     #[test]
     fn point_intersects_line_test() {
         let p0 = Point::new(2., 4.);
+        let p1 = Point::new(0., 0.);
         // vertical line
         let line1 = Line::new(Point::new(2., 0.), Point::new(2., 5.));
         // point on line, but outside line segment
@@ -454,6 +455,7 @@ mod test {
         assert!(!p0.intersects(&line2));
         assert!(line3.intersects(&p0));
         assert!(p0.intersects(&line3));
+        assert!(!p1.intersects(&line3));
     }
     #[test]
     fn line_intersects_line_test() {

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -442,20 +442,34 @@ mod test {
     #[test]
     fn point_intersects_line_test() {
         let p0 = Point::new(2., 4.);
-        let p1 = Point::new(0., 0.);
         // vertical line
         let line1 = Line::new(Point::new(2., 0.), Point::new(2., 5.));
         // point on line, but outside line segment
         let line2 = Line::new(Point::new(0., 6.), Point::new(1.5, 4.5));
         // point on line
         let line3 = Line::new(Point::new(0., 6.), Point::new(3., 3.));
+        // point above line with positive slope
+        let line4 = Line::new(Point::new(1., 2.), Point::new(5., 3.));
+        // point below line with positive slope
+        let line5 = Line::new(Point::new(1., 5.), Point::new(5., 6.));
+        // point above line with negative slope
+        let line6 = Line::new(Point::new(1., 2.), Point::new(5., -3.));
+        // point below line with negative slope
+        let line7 = Line::new(Point::new(1., 6.), Point::new(5., 5.));
         assert!(line1.intersects(&p0));
         assert!(p0.intersects(&line1));
         assert!(!line2.intersects(&p0));
         assert!(!p0.intersects(&line2));
         assert!(line3.intersects(&p0));
         assert!(p0.intersects(&line3));
-        assert!(!p1.intersects(&line3));
+        assert!(!line4.intersects(&p0));
+        assert!(!p0.intersects(&line4));
+        assert!(!line5.intersects(&p0));
+        assert!(!p0.intersects(&line5));
+        assert!(!line6.intersects(&p0));
+        assert!(!p0.intersects(&line6));
+        assert!(!line7.intersects(&p0));
+        assert!(!p0.intersects(&line7));
     }
     #[test]
     fn line_intersects_line_test() {


### PR DESCRIPTION
`x.abs_sub(y)` is defined ([confusingly](https://github.com/rust-lang/rust/issues/30315)) as `max(x-y, 0)`, not `abs(x-y)`. This wasn't caught in tests since `t_x - t_y` in [src/algorithm/intersects.rs:48](https://github.com/georust/rust-geo/blob/master/src/algorithm/intersects.rs#L48) happens to be positive in all of the given examples so I've added a new example where `t_x - t_y` is negative.