### PR TITLE
WIP line-line intersection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["gis", "geo", "geography", "geospatial"]
 
 [dependencies]
 num-traits = "0.1"
+float-ord = "0.1.1"
 
 [dev-dependencies]
 approx = "0.1.1"

--- a/src/algorithm/intersection.rs
+++ b/src/algorithm/intersection.rs
@@ -1,0 +1,157 @@
+use num_traits::{Float};
+use algorithm::intersects::Intersects;
+use types::{Point, Line};
+use std::fmt::Debug;
+
+pub trait Intersection<Rhs = Self> {
+    type OutputGeometry;
+
+    /// Constructs the intersection of two geometries
+    fn intersection(&self, rhs: &Rhs) -> Option<Self::OutputGeometry>;
+}
+
+#[derive(PartialEq, Debug)]
+pub enum LineIntersection<T>
+    where T: Float
+{
+    Point(Point<T>),
+    Line(Line<T>)
+}
+
+impl<T> Intersection<Line<T>> for Line<T>
+    where T: Float + Debug
+{
+    type OutputGeometry = LineIntersection<T>;
+    fn intersection(&self, line: &Line<T>) -> Option<LineIntersection<T>> {
+        match (degenerate(&self), degenerate(&line)) {
+            (true, true) => {
+                if self.start == line.start {
+                    Some(LineIntersection::Point(self.start))
+                } else {
+                    None
+                }
+            }
+            (true, false) => {
+                if self.start.intersects(&line) {
+                    Some(LineIntersection::Point(self.start))
+                } else {
+                    None
+                }
+            }
+            (false, true) => {
+                if line.start.intersects(&self) {
+                    Some(LineIntersection::Point(line.start))
+                } else {
+                    None
+                }
+            }
+            (false, false) => {
+                // Using Cramer's Rule:
+                // https://en.wikipedia.org/wiki/Intersection_%28Euclidean_geometry%29#Two_line_segments
+                let (x1, y1, x2, y2) = (self.start.x(), self.start.y(),
+                                        self.end.x(), self.end.y());
+                let (x3, y3, x4, y4) = (line.start.x(), line.start.y(),
+                                        line.end.x(), line.end.y());
+                // self: (x(s), y(s)) = (x1 + s * a1, y1 + s * a2)
+                // line: (x(t), y(t)) = (x4 + t * b1, y4 + t * b2)
+                let a1 = x2 - x1;
+                let a2 = y2 - y1;
+                let b1 = x3 - x4; // == -(x4 - x3)
+                let b2 = y3 - y4; // == -(y4 - y3)
+                let c1 = x3 - x1;
+                let c2 = y3 - y1;
+                let d = a1*b2 - a2*b1;
+                let u_s = c1*b2 - c2*b1;
+                let u_t = a1*c2 - a2*c1;
+                if d == T::zero() {
+                    // lines are parallel
+                    if u_s == T::zero() && u_t == T::zero() {
+                        // lines are co-linear
+                        let mut endpoints = vec![(self.start, 0), (self.end, 0),
+                                                 (line.start, 1), (line.end, 1)];
+                        endpoints.sort();
+                        let (_, l0) = endpoints[0];
+                        let (p1, l1) = endpoints[1];
+                        let (p2, _) = endpoints[2];
+                        if p1 == p2 {
+                            // Line segments overlap at their endpoints
+                            Some(LineIntersection::Point(p1))
+                        } else if l0 == l1 {
+                            // If the first two sorted endpoints belonged to the same line then there is no
+                            // overlap
+                            None
+                        } else {
+                            Some(LineIntersection::Line(Line::new(p1, p2)))
+                        }
+                    } else {
+                        // lines are parallel but not co-linear
+                        None
+                    }
+                } else {
+                    let s = u_s / d;
+                    let t = u_t / d;
+                    if (T::zero() <= s) && (s <= T::one()) &&
+                       (T::zero() <= t) && (t <= T::one()) {
+                        Some(LineIntersection::Point(Point::new(x1 + s * a1,
+                                                                y1 + s * a2)))
+                    } else {
+                        None
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn degenerate<T>(line: &Line<T>) -> bool
+    where T: Float
+{
+    line.start == line.end
+}
+
+#[cfg(test)]
+mod test {
+    use types::{Point, Line};
+    use algorithm::intersection::{Intersection, LineIntersection};
+
+    #[test]
+    fn test_line_line_intersection(){
+        let degenerate_line = Line::new(Point::new(0., 0.), Point::new(0., 0.));
+        let l0 = Line::new(Point::new(0., 0.), Point::new(8., 6.));
+        let l1 = Line::new(Point::new(0., 6.), Point::new(8., 0.));
+        let l2 = Line::new(Point::new(8., 0.), Point::new(8., 10.));
+        let l3 = Line::new(Point::new(0., 0.), Point::new(4., 3.));
+        let l4 = Line::new(Point::new(-2., -1.5), Point::new(2., 1.5));
+        assert_eq!(l0.intersection(&degenerate_line),
+                   Some(LineIntersection::Point(Point::new(0., 0.))));
+        assert_eq!(l0.intersection(&l0), Some(LineIntersection::Line(l0.clone())));
+        assert_eq!(l0.intersection(&l1), Some(LineIntersection::Point(Point::new(4., 3.))));
+        assert_eq!(l0.intersection(&l2), Some(LineIntersection::Point(Point::new(8., 6.))));
+        assert_eq!(l0.intersection(&l3), Some(LineIntersection::Line(l3.clone())));
+        assert_eq!(l0.intersection(&l4),
+                   Some(LineIntersection::Line(Line::new(Point::new(0., 0.), Point::new(2., 1.5)))));
+
+        assert_eq!(l1.intersection(&degenerate_line), None);
+        assert_eq!(l1.intersection(&l0), Some(LineIntersection::Point(Point::new(4., 3.))));
+        assert_eq!(l1.intersection(&l1), Some(LineIntersection::Line(l1.clone())));
+        assert_eq!(l1.intersection(&l2), Some(LineIntersection::Point(Point::new(8., 0.))));
+        assert_eq!(l1.intersection(&l3), Some(LineIntersection::Point(Point::new(4., 3.))));
+        assert_eq!(l1.intersection(&l4), None);
+
+        assert_eq!(l2.intersection(&degenerate_line), None);
+        assert_eq!(l2.intersection(&l0), Some(LineIntersection::Point(Point::new(8., 6.))));
+        assert_eq!(l2.intersection(&l1), Some(LineIntersection::Point(Point::new(8., 0.))));
+        assert_eq!(l2.intersection(&l2), Some(LineIntersection::Line(l2.clone())));
+        assert_eq!(l2.intersection(&l3), None);
+        assert_eq!(l2.intersection(&l4), None);
+
+        assert_eq!(l3.intersection(&degenerate_line),
+                   Some(LineIntersection::Point(Point::new(0., 0.))));
+        assert_eq!(l3.intersection(&l0), Some(LineIntersection::Line(l3.clone())));
+        assert_eq!(l3.intersection(&l1), Some(LineIntersection::Point(Point::new(4., 3.))));
+        assert_eq!(l3.intersection(&l2), None);
+        assert_eq!(l3.intersection(&l3), Some(LineIntersection::Line(l3.clone())));
+        assert_eq!(l3.intersection(&l4),
+                   Some(LineIntersection::Line(Line::new(Point::new(0., 0.), Point::new(2., 1.5)))));
+    }
+}

--- a/src/algorithm/intersection.rs
+++ b/src/algorithm/intersection.rs
@@ -116,42 +116,72 @@ mod test {
 
     #[test]
     fn test_line_line_intersection(){
-        let degenerate_line = Line::new(Point::new(0., 0.), Point::new(0., 0.));
-        let l0 = Line::new(Point::new(0., 0.), Point::new(8., 6.));
-        let l1 = Line::new(Point::new(0., 6.), Point::new(8., 0.));
-        let l2 = Line::new(Point::new(8., 0.), Point::new(8., 10.));
-        let l3 = Line::new(Point::new(0., 0.), Point::new(4., 3.));
-        let l4 = Line::new(Point::new(-2., -1.5), Point::new(2., 1.5));
-        assert_eq!(l0.intersection(&degenerate_line),
-                   Some(LineIntersection::Point(Point::new(0., 0.))));
-        assert_eq!(l0.intersection(&l0), Some(LineIntersection::Line(l0.clone())));
-        assert_eq!(l0.intersection(&l1), Some(LineIntersection::Point(Point::new(4., 3.))));
-        assert_eq!(l0.intersection(&l2), Some(LineIntersection::Point(Point::new(8., 6.))));
-        assert_eq!(l0.intersection(&l3), Some(LineIntersection::Line(l3.clone())));
-        assert_eq!(l0.intersection(&l4),
-                   Some(LineIntersection::Line(Line::new(Point::new(0., 0.), Point::new(2., 1.5)))));
+        // degenerate lines
+        let l0 = Line::new(Point::new(0., 0.), Point::new(0., 0.));
+        let l1 = Line::new(Point::new(4., 3.), Point::new(4., 3.));
+        // co-linear lines (along y = (4/3)x)
+        let l2 = Line::new(Point::new(0., 0.), Point::new(8., 6.));
+        let l3 = Line::new(Point::new(12., 9.), Point::new(8., 6.));
+        let l4 = Line::new(Point::new(2., 1.5), Point::new(4., 3.));
+        let l5 = Line::new(Point::new(4., 3.), Point::new(12., 9.));
+        // parallel to l2-l5
+        let l6 = Line::new(Point::new(12., 6.), Point::new(8., 3.));
+        // perpendicular to l2-l6
+        let l7 = Line::new(Point::new(0., 6.), Point::new(8., 0.));
 
-        assert_eq!(l1.intersection(&degenerate_line), None);
-        assert_eq!(l1.intersection(&l0), Some(LineIntersection::Point(Point::new(4., 3.))));
-        assert_eq!(l1.intersection(&l1), Some(LineIntersection::Line(l1.clone())));
-        assert_eq!(l1.intersection(&l2), Some(LineIntersection::Point(Point::new(8., 0.))));
-        assert_eq!(l1.intersection(&l3), Some(LineIntersection::Point(Point::new(4., 3.))));
-        assert_eq!(l1.intersection(&l4), None);
+        // degenerate intersection
+        assert_eq!(l0.intersection(&l0),
+                   Some(LineIntersection::Point(l0.start)));
 
-        assert_eq!(l2.intersection(&degenerate_line), None);
-        assert_eq!(l2.intersection(&l0), Some(LineIntersection::Point(Point::new(8., 6.))));
-        assert_eq!(l2.intersection(&l1), Some(LineIntersection::Point(Point::new(8., 0.))));
-        assert_eq!(l2.intersection(&l2), Some(LineIntersection::Line(l2.clone())));
-        assert_eq!(l2.intersection(&l3), None);
-        assert_eq!(l2.intersection(&l4), None);
+        assert_eq!(l0.intersection(&l1), None);
+        assert_eq!(l1.intersection(&l0), None);
 
-        assert_eq!(l3.intersection(&degenerate_line),
-                   Some(LineIntersection::Point(Point::new(0., 0.))));
-        assert_eq!(l3.intersection(&l0), Some(LineIntersection::Line(l3.clone())));
-        assert_eq!(l3.intersection(&l1), Some(LineIntersection::Point(Point::new(4., 3.))));
-        assert_eq!(l3.intersection(&l2), None);
-        assert_eq!(l3.intersection(&l3), Some(LineIntersection::Line(l3.clone())));
-        assert_eq!(l3.intersection(&l4),
-                   Some(LineIntersection::Line(Line::new(Point::new(0., 0.), Point::new(2., 1.5)))));
+        assert_eq!(l0.intersection(&l2),
+                   Some(LineIntersection::Point(l0.start)));
+        assert_eq!(l2.intersection(&l0),
+                   Some(LineIntersection::Point(l0.start)));
+
+        assert_eq!(l0.intersection(&l6), None);
+        assert_eq!(l6.intersection(&l0), None);
+
+        assert_eq!(l1.intersection(&l2),
+                   Some(LineIntersection::Point(l1.start.clone())));
+        assert_eq!(l2.intersection(&l1),
+                   Some(LineIntersection::Point(l1.start.clone())));
+
+        // co-linear intersection
+        assert_eq!(l2.intersection(&l2),
+                   Some(LineIntersection::Line(l2.clone())));
+
+        assert_eq!(l2.intersection(&l3),
+                   Some(LineIntersection::Point(Point::new(8., 6.))));
+        assert_eq!(l3.intersection(&l2),
+                   Some(LineIntersection::Point(Point::new(8., 6.))));
+
+        assert_eq!(l2.intersection(&l4),
+                   Some(LineIntersection::Line(l4.clone())));
+        assert_eq!(l4.intersection(&l2),
+                   Some(LineIntersection::Line(l4.clone())));
+
+        assert_eq!(l2.intersection(&l5),
+                   Some(LineIntersection::Line(Line::new(Point::new(4., 3.), Point::new(8., 6.)))));
+        assert_eq!(l5.intersection(&l2),
+                   Some(LineIntersection::Line(Line::new(Point::new(4., 3.), Point::new(8., 6.)))));
+
+        assert_eq!(l3.intersection(&l4), None);
+        assert_eq!(l4.intersection(&l3), None);
+
+        // parallel intersection
+        assert_eq!(l2.intersection(&l6), None);
+        assert_eq!(l6.intersection(&l2), None);
+
+        // interior intersection
+        assert_eq!(l2.intersection(&l7),
+                   Some(LineIntersection::Point(Point::new(4., 3.))));
+        assert_eq!(l7.intersection(&l2),
+                   Some(LineIntersection::Point(Point::new(4., 3.))));
+
+        assert_eq!(l7.intersection(&l6), None);
+        assert_eq!(l6.intersection(&l7), None);
     }
 }

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -4,6 +4,8 @@ pub mod centroid;
 pub mod contains;
 /// Checks if the geometry A intersects the geometry B.
 pub mod intersects;
+/// Implements total ordering on points
+pub mod point_ord;
 /// Returns the area of the surface of a geometry.
 pub mod area;
 /// Returns the length of a line.

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -4,6 +4,8 @@ pub mod centroid;
 pub mod contains;
 /// Checks if the geometry A intersects the geometry B.
 pub mod intersects;
+/// Construct the intersections of geometries.
+pub mod intersection;
 /// Implements total ordering on points
 pub mod point_ord;
 /// Returns the area of the surface of a geometry.

--- a/src/algorithm/point_ord.rs
+++ b/src/algorithm/point_ord.rs
@@ -1,0 +1,65 @@
+use types::Point;
+use float_ord::FloatOrd;
+use num_traits::{Float, ToPrimitive};
+use core::cmp::{Eq, Ord, Ordering, PartialOrd};
+
+/// Implement Ord for Point.
+/// This ordering is used by the line sweep algorithm to efficiently find intersections of a
+/// set of line of line segments. Points are jointly ordered (y DESC, x ASC) that is, from top left
+/// to bottom right.
+
+impl<T> Eq for Point<T> where T: Float {}
+
+fn to_float_ord<T>(x: T) -> FloatOrd<f64>
+    where T: Float + ToPrimitive
+{
+    FloatOrd(x.to_f64().unwrap())
+}
+
+impl<T> PartialOrd for Point<T>
+    where T: Float + ToPrimitive
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match to_float_ord(self.y()).partial_cmp(&to_float_ord(other.y()))
+                                    .map(|o| o.reverse())
+        {
+            Some(Ordering::Equal) => {
+                to_float_ord(self.x()).partial_cmp(&to_float_ord(other.x()))
+            },
+            value => value
+        }
+    }
+}
+
+impl<T> Ord for Point<T>
+    where T: Float + ToPrimitive
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        match to_float_ord(self.y()).cmp(&to_float_ord(other.y()))
+                                    .reverse()
+        {
+            Ordering::Equal => {
+                to_float_ord(self.x()).cmp(&to_float_ord(other.x()))
+            },
+            value => value
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use types::Point;
+    #[test]
+    fn test_point_ord() {
+        let a = Point::new(0., 0.);
+        let b = Point::new(0., 1.);
+        let c = Point::new(2., 1.);
+        let d = Point::new(2., 0.);
+        assert!(a == a);
+        assert!(b < d);
+        assert!(d > b);
+        assert!(b < c);
+        assert!(c < d);
+        assert!(a > c);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
+extern crate core;
 extern crate num_traits;
+extern crate float_ord;
 
 pub use traits::ToGeo;
 pub use types::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -318,7 +318,7 @@ impl<T> AddAssign for Bbox<T>
 #[derive(PartialEq, Clone, Debug)]
 pub struct MultiPoint<T>(pub Vec<Point<T>>) where T: Float;
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Line<T>
     where T: Float
 {
@@ -341,6 +341,15 @@ impl<T> Line<T>
     /// ```
     pub fn new(start: Point<T>, end: Point<T>) -> Line<T> {
         Line {start: start, end: end}
+    }
+}
+
+impl<T> PartialEq for Line<T>
+    where T: Float
+{
+    fn eq(&self, other: &Self) -> bool {
+        (self.start == other.start && self.end == other.end) ||
+            (self.start == other.end && self.end == other.start)
     }
 }
 
@@ -427,5 +436,17 @@ mod test {
 
         assert_eq!(p.exterior, exterior);
         assert_eq!(p.interiors, interiors);
+    }
+
+    #[test]
+    fn test_line_equality() {
+        let l0 = Line::new(Point::new(0., 0.), Point::new(1., 2.));
+        let l1 = Line::new(Point::new(0., 0.), Point::new(1., 2.));
+        let l2 = Line::new(Point::new(1., 2.), Point::new(0., 0.));
+        let l3 = Line::new(Point::new(0., 0.), Point::new(4., 5.));
+
+        assert_eq!(l0, l1);
+        assert_eq!(l0, l2);
+        assert_ne!(l0, l3);
     }
 }


### PR DESCRIPTION
This PR continues the work towards intersection operators for basic types (#80).

I'm marking this as WIP since I'm not wholly satisfied by a few of the details and would appreciate some feedback.

## The return type of `Intersection`

Two line segments can share nothing, a single point, or a line segment between them. Here, I've chosen to implement intersection to return `Option<LineIntersection>` where `LineIntersection` is an enum over the set {`Point`, `Line`}. 

go.geo side-steps this by returning [`NewPoint(math.Inf(1), math.Inf(1))`](https://github.com/paulmach/go.geo/blob/7c91620e5d753c84d6149b42d39ba6556e1a5f2f/line.go#L166) when the two lines are co-linear. I don't like this approach because I think this concept is much more easily expressed by the type system than by what amounts to the `NaN` of points. That said, I'm not wholly satisfied with `Option<LineIntersection>`: it's cumbersome to write and read, and we'd need one for almost every type. 

I considered defining `LineIntersection` like `{Empty, Point(Point), Line(Line)}`, but that doesn't change much.

I also considered using the `Geometry` enum instead of the specialized `LineIntersection`, this is basically how [PostGIS handles intersection](http://postgis.net/docs/ST_Intersection.html), but I decided against that first because of #119, and second because it over-specifies the types that can actually be returned. 

ArcGIS solves this problem by having separate [intersect and overlap](https://gis.stackexchange.com/questions/130034/what-is-the-difference-between-intersect-overlap-in-arcgis-server) methods.

## Handling degenerate lines

A `Valid` trait? Validating constructors? Should intersection return a `Result` or panic instead of handling various degeneracies or invalidities? Should we have a separate `Degeneracy` trait that repairs degeneracies (e.g. converts a degenerate `Line` to `Point`)?

## Project structure

For now, I added the point ordering as module directly under `algorithm`, but as I add more helper functions to support the line sweep it might make more sense to gather all of that code (trait, impls, and support) in a subdirectory just for intersection.
