### PR TITLE
Added destination trait.

### DIFF
--- a/src/algorithm/destination.rs
+++ b/src/algorithm/destination.rs
@@ -1,0 +1,62 @@
+use num_traits::{Float, FromPrimitive};
+use types::Point;
+
+/// Returns a new Point using the distance to the existing Point and a bearing for the direction
+
+pub trait Destination<T: Float> {
+    /// Returns a new Point using distance to the existing Point and a bearing for the direction
+    ///
+    /// ```
+    /// # extern crate geo;
+    /// # #[macro_use] extern crate approx;
+    /// #
+    /// use geo::Point;
+    /// use geo::algorithm::destination::Destination;
+    ///
+    /// # fn main() {
+    /// let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
+    /// let p_2 = p_1.destination(45., 10000.);
+    /// assert_eq!(p_2, Point::<f64>::new(9.274410083250379, 48.84033282787534))
+    /// # }
+    /// ```
+    fn destination(&self, bearing: T, distance: T) -> Point<T>;
+}
+
+impl<T> Destination<T> for Point<T>
+    where T: Float + FromPrimitive
+{
+    fn destination(&self, bearing: T, distance: T) -> Point<T> {
+        let center_lng = self.x().to_radians();
+        let center_lat = self.y().to_radians();
+        let bearing_rad = bearing.to_radians();
+
+        // WGS84 equatorial radius is 6378137.0
+        let rad = distance / T::from(6371000.0).unwrap();
+
+        let lat = {
+                center_lat.sin() * rad.cos() + center_lat.cos() * rad.sin() * bearing_rad.cos()
+            }
+            .asin();
+        let lng = {
+                bearing_rad.sin() * rad.sin() * center_lat.cos()
+            }
+            .atan2(rad.cos() - center_lat.sin() * lat.sin()) + center_lng;
+
+        Point::new(lng.to_degrees(), lat.to_degrees())
+    }
+}
+
+#[cfg(test)]
+mod destination {
+    use super::*;
+    use algorithm::haversine_distance::HaversineDistance;
+
+    #[test]
+    fn returns_a_new_point() {
+        let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
+        let p_2 = p_1.destination(45., 10000.);
+        assert_eq!(p_2, Point::<f64>::new(9.274410083250379, 48.84033282787534));
+        let distance = p_1.haversine_distance(&p_2);
+        assert_relative_eq!(distance, 10000., epsilon = 1.0e-6)
+    }
+}

--- a/src/algorithm/haversine_destination.rs
+++ b/src/algorithm/haversine_destination.rs
@@ -3,29 +3,24 @@ use types::Point;
 
 /// Returns a new Point using the distance to the existing Point and a bearing for the direction
 
-pub trait Destination<T: Float> {
+pub trait HaversineDestination<T: Float> {
     /// Returns a new Point using distance to the existing Point and a bearing for the direction
     ///
     /// ```
-    /// # extern crate geo;
-    /// # #[macro_use] extern crate approx;
-    /// #
     /// use geo::Point;
-    /// use geo::algorithm::destination::Destination;
+    /// use geo::algorithm::haversine_destination::HaversineDestination;
     ///
-    /// # fn main() {
     /// let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
-    /// let p_2 = p_1.destination(45., 10000.);
+    /// let p_2 = p_1.haversine_destination(45., 10000.);
     /// assert_eq!(p_2, Point::<f64>::new(9.274410083250379, 48.84033282787534))
-    /// # }
     /// ```
-    fn destination(&self, bearing: T, distance: T) -> Point<T>;
+    fn haversine_destination(&self, bearing: T, distance: T) -> Point<T>;
 }
 
-impl<T> Destination<T> for Point<T>
+impl<T> HaversineDestination<T> for Point<T>
     where T: Float + FromPrimitive
 {
-    fn destination(&self, bearing: T, distance: T) -> Point<T> {
+    fn haversine_destination(&self, bearing: T, distance: T) -> Point<T> {
         let center_lng = self.x().to_radians();
         let center_lat = self.y().to_radians();
         let bearing_rad = bearing.to_radians();
@@ -47,14 +42,14 @@ impl<T> Destination<T> for Point<T>
 }
 
 #[cfg(test)]
-mod destination {
+mod test {
     use super::*;
     use algorithm::haversine_distance::HaversineDistance;
 
     #[test]
     fn returns_a_new_point() {
         let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
-        let p_2 = p_1.destination(45., 10000.);
+        let p_2 = p_1.haversine_destination(45., 10000.);
         assert_eq!(p_2, Point::<f64>::new(9.274410083250379, 48.84033282787534));
         let distance = p_1.haversine_distance(&p_2);
         assert_relative_eq!(distance, 10000., epsilon = 1.0e-6)

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -11,7 +11,7 @@ pub mod length;
 /// Returns the Euclidean distance between two geometries.
 pub mod distance;
 /// Returns a new Point using distance and bearing.
-pub mod destination;
+pub mod haversine_destination;
 /// Returns the Haversine distance between two geometries.
 pub mod haversine_distance;
 /// Returns the Bbox of a geometry.

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -10,6 +10,8 @@ pub mod area;
 pub mod length;
 /// Returns the Euclidean distance between two geometries.
 pub mod distance;
+/// Returns a new Point using distance and bearing.
+pub mod destination;
 /// Returns the Haversine distance between two geometries.
 pub mod haversine_distance;
 /// Returns the Bbox of a geometry.
@@ -22,7 +24,7 @@ pub mod simplifyvw;
 pub mod convexhull;
 /// Orients a Polygon's exterior and interior rings.
 pub mod orient;
-/// Returns the extreme indices of a `Polygon`, `MultiPolygon`, or `MultiPoint`. 
+/// Returns the extreme indices of a `Polygon`, `MultiPolygon`, or `MultiPoint`.
 pub mod extremes;
 /// Rotates a geometry around either its centroid or a point by an angle, given in degrees.
 pub mod rotate;


### PR DESCRIPTION
The code is inspired from the turf.js equivalent fn in https://github.com/Turfjs/turf/tree/master/packages/turf-destination

It basically shoots a ray on the sphere using a distance and an angle from an existing point to create a new point.

This is useful when creating pseudo shapes like circles (split circle in _n_ angle angle slices, create _n_ new Points via `destination` from a circle center Point, then combine the new Points to a Polygon.