### PR TITLE
add auto derive for serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["gis", "geo", "geography", "geospatial"]
 
 [dependencies]
 num-traits = "0.1"
-serde = "0.9"
-serde_derive = "0.9"
+serde = "1.0"
+serde_derive = "1.0"
 
 [dev-dependencies]
 approx = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ keywords = ["gis", "geo", "geography", "geospatial"]
 
 [dependencies]
 num-traits = "0.1"
+serde = "0.9"
+serde_derive = "0.9"
 
 [dev-dependencies]
 approx = "0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
 extern crate num_traits;
 
 pub use traits::ToGeo;

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,7 @@ use num_traits::{Float, ToPrimitive};
 
 pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Coordinate<T>
     where T: Float
 {
@@ -15,7 +15,7 @@ pub struct Coordinate<T>
     pub y: T,
 }
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Bbox<T>
     where T: Float
 {
@@ -25,7 +25,7 @@ pub struct Bbox<T>
     pub ymax: T,
 }
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Extremes {
     pub ymin: usize,
     pub xmax: usize,
@@ -44,7 +44,7 @@ impl From<Vec<usize>> for Extremes {
     }
 }
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct ExtremePoint<T>
     where T: Float
  {
@@ -54,7 +54,7 @@ pub struct ExtremePoint<T>
     pub xmin: Point<T>,
 }
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Point<T> (pub Coordinate<T>) where T: Float;
 
 impl<T> Point<T>
@@ -315,16 +315,16 @@ impl<T> AddAssign for Bbox<T>
 }
 
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct MultiPoint<T>(pub Vec<Point<T>>) where T: Float;
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct LineString<T>(pub Vec<Point<T>>) where T: Float;
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct MultiLineString<T>(pub Vec<LineString<T>>) where T: Float;
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct Polygon<T>
     where T: Float
 {
@@ -353,7 +353,7 @@ impl<T> Polygon<T>
     }
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct MultiPolygon<T>(pub Vec<Polygon<T>>) where T: Float;
 
 #[derive(PartialEq, Clone, Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -344,7 +344,7 @@ impl<T> Line<T>
     }
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct LineString<T>(pub Vec<Point<T>>) where T: Float;
 
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
I'm using rust-geo to parse a shapefile into country borders. I do this in the build.rs then include_bytes the resulting struct into the binary. Thought other people might be able to use a similar tactic. Example at https://github.com/etrombly/country_parser/blob/master/src/build.rs