### PR TITLE
Add winding order for linestrings

### DIFF
--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -1,6 +1,8 @@
 use num_traits::Float;
 use types::{Line, LineString, Polygon, MultiPolygon, Bbox};
 
+use algorithm::shoelace_formula::twice_area;
+
 /// Calculation of the area.
 
 pub trait Area<T> where T: Float
@@ -21,14 +23,7 @@ pub trait Area<T> where T: Float
 }
 
 fn get_linestring_area<T>(linestring: &LineString<T>) -> T where T: Float {
-    if linestring.0.is_empty() || linestring.0.len() == 1 {
-        return T::zero();
-    }
-    let mut tmp = T::zero();
-    for ps in linestring.0.windows(2) {
-        tmp = tmp + (ps[0].x() * ps[1].y() - ps[1].x() * ps[0].y());
-    }
-    tmp / (T::one() + T::one())
+    twice_area(linestring) / (T::one() + T::one())
 }
 
 impl<T> Area<T> for Line<T>

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -30,3 +30,5 @@ pub mod extremes;
 pub mod rotate;
 /// Translates a geometry along the given offsets.
 pub mod translate;
+
+pub mod shoelace_formula;

--- a/src/algorithm/shoelace_formula.rs
+++ b/src/algorithm/shoelace_formula.rs
@@ -1,0 +1,14 @@
+use num_traits::Float;
+use types::LineString;
+
+pub fn twice_area<T>(linestring: &LineString<T>) -> T where T: Float {
+    if linestring.0.is_empty() || linestring.0.len() == 1 {
+        return T::zero();
+    }
+    let mut tmp = T::zero();
+    for ps in linestring.0.windows(2) {
+        tmp = tmp + (ps[0].x() * ps[1].y() - ps[1].x() * ps[0].y());
+    }
+
+    tmp
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,8 @@ use std::ops::Sub;
 
 use num_traits::{Float, ToPrimitive};
 
+use algorithm::shoelace_formula::twice_area;
+
 pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
 
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
@@ -348,8 +350,85 @@ impl<T> Line<T>
     }
 }
 
+#[derive(PartialEq, Clone, Debug)]
+pub enum WindingOrder {
+    Clockwise,
+    CounterClockwise,
+}
+
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct LineString<T>(pub Vec<Point<T>>) where T: Float;
+
+impl<T: Float> LineString<T> {
+
+    /// Returns the winding order of this line
+    pub fn winding_order(&self) -> WindingOrder {
+        let shoelace = twice_area(self);
+        if shoelace < T::zero() {
+            WindingOrder::Clockwise
+        } else if shoelace > T::zero() {
+            WindingOrder::CounterClockwise
+        } else if shoelace == T::zero() {
+            // what should be done here?
+            panic!();
+        } else {
+            // make compiler stop complaining
+            unreachable!()
+        }
+    }
+
+    /// True iff this line is wound clockwise
+    pub fn is_cw(&self) -> bool {
+        self.winding_order() == WindingOrder::Clockwise
+    }
+
+    /// True iff this line is wound counterclockwise
+    pub fn is_ccw(&self) -> bool {
+        self.winding_order() == WindingOrder::CounterClockwise
+    }
+
+    /// Iterate over the points in a clockwise order
+    ///
+    /// The Linestring isn't changed, and the points are returned either in order, or in reverse
+    /// order, so that the resultant order makes it appear clockwise
+    pub fn points_clockwise<'a>(&'a self) -> Box<Iterator<Item=&'a Point<T>> + 'a> {
+        match self.winding_order() {
+            WindingOrder::Clockwise => Box::new(self.0.iter()),
+            WindingOrder::CounterClockwise => Box::new(self.0.iter().rev()),
+        }
+    }
+
+    /// Iterate over the points in a counter-clockwise order
+    ///
+    /// The Linestring isn't changed, and the points are returned either in order, or in reverse
+    /// order, so that the resultant order makes it appear counter-clockwise
+    pub fn points_counterclockwise<'a>(&'a self) -> Box<Iterator<Item=&'a Point<T>> + 'a> {
+        match self.winding_order() {
+            WindingOrder::Clockwise => Box::new(self.0.iter().rev()),
+            WindingOrder::CounterClockwise => Box::new(self.0.iter()),
+        }
+    }
+
+    /// Change this line's points so they are in clockwise winding order
+    pub fn make_clockwise_winding(&mut self) {
+        match self.winding_order() {
+            WindingOrder::Clockwise => {},
+            WindingOrder::CounterClockwise => {
+                self.0.reverse();
+            }
+        }
+    }
+
+    /// Change this line's points so they are in counterclockwise winding order
+    pub fn make_counterclockwise_winding(&mut self) {
+        match self.winding_order() {
+            WindingOrder::Clockwise => {
+                self.0.reverse();
+            },
+            WindingOrder::CounterClockwise => {}
+        }
+    }
+}
 
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct MultiLineString<T>(pub Vec<LineString<T>>) where T: Float;
@@ -445,5 +524,64 @@ mod test {
 
         assert_eq!(p.exterior, exterior);
         assert_eq!(p.interiors, interiors);
+        }
+
+    #[test]
+    fn winding_order() {
+        // 3 points forming a triangle
+        let a = Point::new(0., 0.);
+        let b = Point::new(2., 0.);
+        let c = Point::new(1., 2.);
+
+        // That triangle, but in clockwise ordering
+        let cw_line = LineString(vec![a, c, b, a].clone());
+        // That triangle, but in counterclockwise ordering
+        let ccw_line = LineString(vec![a, b, c, a].clone());
+
+        assert_eq!(cw_line.winding_order(), WindingOrder::Clockwise);
+        assert_eq!(cw_line.is_cw(), true);
+        assert_eq!(cw_line.is_ccw(), false);
+        assert_eq!(ccw_line.winding_order(), WindingOrder::CounterClockwise);
+        assert_eq!(ccw_line.is_cw(), false);
+        assert_eq!(ccw_line.is_ccw(), true);
+
+        let cw_points1: Vec<_> = cw_line.points_clockwise().cloned().collect();
+        assert_eq!(cw_points1.len(), 4);
+        assert_eq!(cw_points1[0], a);
+        assert_eq!(cw_points1[1], c);
+        assert_eq!(cw_points1[2], b);
+        assert_eq!(cw_points1[3], a);
+
+        let ccw_points1: Vec<_> = cw_line.points_counterclockwise().cloned().collect();
+        assert_eq!(ccw_points1.len(), 4);
+        assert_eq!(ccw_points1[0], a);
+        assert_eq!(ccw_points1[1], b);
+        assert_eq!(ccw_points1[2], c);
+        assert_eq!(ccw_points1[3], a);
+
+        assert_ne!(cw_points1, ccw_points1);
+
+        let cw_points2: Vec<_> = ccw_line.points_clockwise().cloned().collect();
+        let ccw_points2: Vec<_> = ccw_line.points_counterclockwise().cloned().collect();
+
+        // cw_line and ccw_line are wound differently, but the ordered winding iterator should have
+        // make them similar
+        assert_eq!(cw_points2, cw_points2);
+        assert_eq!(ccw_points2, ccw_points2);
+
+        // test make_clockwise_winding
+        let mut new_line1 = ccw_line.clone();
+        new_line1.make_clockwise_winding();
+        assert_eq!(new_line1.winding_order(), WindingOrder::Clockwise);
+        assert_eq!(new_line1, cw_line);
+        assert_ne!(new_line1, ccw_line);
+
+        // test make_counterclockwise_winding
+        let mut new_line2 = cw_line.clone();
+        new_line2.make_counterclockwise_winding();
+        assert_eq!(new_line2.winding_order(), WindingOrder::CounterClockwise);
+        assert_ne!(new_line2, cw_line);
+        assert_eq!(new_line2, ccw_line);
+
     }
 }


### PR DESCRIPTION
For some data formats (e.g. ESRI Shapefiles), rings in a polygon are stored in a specific winding order (clockwise for exterior ring, anti-clockwise for interior rings IIRC). So I added support to detect this, to make a linestring clockwise/counterclockwise, and to iterate over the points in that order.

The code is already there for the Area calculation. I split the shoelace formula code into it's own file, since it felt weird importing something from the `area` module into `types`. But I'm open to suggestions on this, because I'm not 100% sure it's the best approach.