### PR TITLE
Implement Simplification traits for more things

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -16,9 +16,9 @@ pub mod haversine_destination;
 pub mod haversine_distance;
 /// Returns the Bbox of a geometry.
 pub mod boundingbox;
-/// Simplifies a `LineString` using the Ramer-Douglas-Peucker algorithm.
+/// Simplifies geometries using the Ramer-Douglas-Peucker algorithm.
 pub mod simplify;
-/// Simplifies a `LineString` using the Visvalingam-Whyatt algorithm.
+/// Simplifies geometries using the Visvalingam-Whyatt algorithm.
 pub mod simplifyvw;
 /// Calculates the convex hull of a geometry.
 pub mod convexhull;

--- a/src/algorithm/simplify.rs
+++ b/src/algorithm/simplify.rs
@@ -47,8 +47,16 @@ fn rdp<T>(points: &[Point<T>], epsilon: &T) -> Vec<Point<T>>
     }
 }
 
+/// Simplifies a geometry.
+///
+/// The [Ramer–Douglas–Peucker
+/// algorithm](https://en.wikipedia.org/wiki/Ramer–Douglas–Peucker_algorithm) simplifes a
+/// linestring. Polygons are simplified by running the RDP algorithm on all their constituent
+/// rings. This may result in invalid Polygons, and has no guarantee of preserving topology.
+///
+/// Multi* objects are simplified by simplifing all their constituent geometries individually.
 pub trait Simplify<T, Epsilon = T> {
-    /// Returns the simplified representation of a LineString, using the [Ramer–Douglas–Peucker](https://en.wikipedia.org/wiki/Ramer–Douglas–Peucker_algorithm) algorithm
+    /// Returns the simplified representation of a geometry, using the [Ramer–Douglas–Peucker](https://en.wikipedia.org/wiki/Ramer–Douglas–Peucker_algorithm) algorithm
     ///
     /// ```
     /// use geo::{Point, LineString};

--- a/src/algorithm/simplify.rs
+++ b/src/algorithm/simplify.rs
@@ -1,5 +1,5 @@
 use num_traits::Float;
-use types::{Point, LineString, MultiLineString};
+use types::{Point, LineString, Polygon, MultiLineString};
 use algorithm::distance::Distance;
 
 // perpendicular distance from a point to a line
@@ -89,9 +89,17 @@ impl<T> Simplify<T> for MultiLineString<T>
     }
 }
 
+impl<T> Simplify<T> for Polygon<T>
+    where T: Float
+{
+    fn simplify(&self, epsilon: &T) -> Polygon<T> {
+        Polygon::new(self.exterior.simplify(epsilon), self.interiors.iter().map(|l| l.simplify(epsilon)).collect())
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use types::{Point, LineString, MultiLineString};
+    use types::{Point, LineString, Polygon, MultiLineString};
     use super::{point_line_distance, rdp, Simplify};
 
     #[test]
@@ -155,5 +163,28 @@ mod test {
             Point::new(11.0, 5.5),
             Point::new(27.8, 0.1),
         ])]));
+    }
+
+    #[test]
+    fn polygon() {
+        let poly = Polygon::new(LineString(vec![
+            Point::new(0., 0.),
+            Point::new(0., 10.),
+            Point::new(5., 11.),
+            Point::new(10., 10.),
+            Point::new(10., 0.),
+            Point::new(0., 0.),
+        ]), vec![]);
+
+        let poly2 = poly.simplify(&2.);
+
+        assert_eq!(poly2, Polygon::new(LineString(vec![
+            Point::new(0., 0.),
+            Point::new(0., 10.),
+            Point::new(10., 10.),
+            Point::new(10., 0.),
+            Point::new(0., 0.),
+              ]), vec![])
+        );
     }
 }

--- a/src/algorithm/simplify.rs
+++ b/src/algorithm/simplify.rs
@@ -1,5 +1,5 @@
 use num_traits::Float;
-use types::{Point, LineString, Polygon, MultiLineString};
+use types::{Point, LineString, Polygon, MultiLineString, MultiPolygon};
 use algorithm::distance::Distance;
 
 // perpendicular distance from a point to a line
@@ -97,9 +97,17 @@ impl<T> Simplify<T> for Polygon<T>
     }
 }
 
+impl<T> Simplify<T> for MultiPolygon<T>
+    where T: Float
+{
+    fn simplify(&self, epsilon: &T) -> MultiPolygon<T> {
+        MultiPolygon(self.0.iter().map(|p| p.simplify(epsilon)).collect())
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use types::{Point, LineString, Polygon, MultiLineString};
+    use types::{Point, LineString, Polygon, MultiLineString, MultiPolygon};
     use super::{point_line_distance, rdp, Simplify};
 
     #[test]
@@ -185,6 +193,30 @@ mod test {
             Point::new(10., 0.),
             Point::new(0., 0.),
               ]), vec![])
+        );
+    }
+
+
+    #[test]
+    fn multipolygon() {
+        let mpoly = MultiPolygon(vec![Polygon::new(LineString(vec![
+            Point::new(0., 0.),
+            Point::new(0., 10.),
+            Point::new(5., 11.),
+            Point::new(10., 10.),
+            Point::new(10., 0.),
+            Point::new(0., 0.),
+        ]), vec![])]);
+
+        let mpoly2 = mpoly.simplify(&2.);
+
+        assert_eq!(mpoly2, MultiPolygon(vec![Polygon::new(LineString(vec![
+            Point::new(0., 0.),
+            Point::new(0., 10.),
+            Point::new(10., 10.),
+            Point::new(10., 0.),
+            Point::new(0., 0.),
+              ]), vec![])])
         );
     }
 }

--- a/src/algorithm/simplify.rs
+++ b/src/algorithm/simplify.rs
@@ -1,5 +1,5 @@
 use num_traits::Float;
-use types::{Point, LineString};
+use types::{Point, LineString, MultiLineString};
 use algorithm::distance::Distance;
 
 // perpendicular distance from a point to a line
@@ -81,10 +81,18 @@ impl<T> Simplify<T> for LineString<T>
     }
 }
 
+impl<T> Simplify<T> for MultiLineString<T>
+    where T: Float
+{
+    fn simplify(&self, epsilon: &T) -> MultiLineString<T> {
+        MultiLineString(self.0.iter().map(|l| l.simplify(epsilon)).collect())
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use types::{Point};
-    use super::{point_line_distance, rdp};
+    use types::{Point, LineString, MultiLineString};
+    use super::{point_line_distance, rdp, Simplify};
 
     #[test]
     fn perpdistance_test() {
@@ -127,5 +135,25 @@ mod test {
         compare.push(Point::new(27.8, 0.1));
         let simplified = rdp(&vec, &1.0);
         assert_eq!(simplified, compare);
+    }
+
+    #[test]
+    fn multilinestring() {
+        let mline = MultiLineString(vec![LineString(vec![
+            Point::new(0.0, 0.0),
+            Point::new(5.0, 4.0),
+            Point::new(11.0, 5.5),
+            Point::new(17.3, 3.2),
+            Point::new(27.8, 0.1),
+        ])]);
+
+        let mline2 = mline.simplify(&1.0);
+
+        assert_eq!(mline2, MultiLineString(vec![LineString(vec![
+            Point::new(0.0, 0.0),
+            Point::new(5.0, 4.0),
+            Point::new(11.0, 5.5),
+            Point::new(27.8, 0.1),
+        ])]));
     }
 }

--- a/src/algorithm/simplifyvw.rs
+++ b/src/algorithm/simplifyvw.rs
@@ -144,8 +144,13 @@ fn area<T>(p1: &Point<T>, p2: &Point<T>, p3: &Point<T>) -> T
     (T::one() + T::one())
 }
 
+/// Simplifies a geometry.
+///
+/// Polygons are simplified by running the algorithm on all their constituent rings.  This may
+/// result in invalid Polygons, and has no guarantee of perserving topology.  Multi* objects are
+/// simplified by simplifyng all their constituent geometries individually.
 pub trait SimplifyVW<T, Epsilon = T> {
-    /// Returns the simplified representation of a LineString, using the [Visvalingam-Whyatt](http://www.tandfonline.com/doi/abs/10.1179/000870493786962263) algorithm
+    /// Returns the simplified representation of a geometry, using the [Visvalingam-Whyatt](http://www.tandfonline.com/doi/abs/10.1179/000870493786962263) algorithm
     ///
     /// See [here](https://bost.ocks.org/mike/simplify/) for a graphical explanation
     ///


### PR DESCRIPTION
If you can simplify a `LineString`, then you can simplify a `MultiLineString`.

I also added implementations for the simplification traits for`Polygon` (and `MultiPolygon`), which just perform the simplification on the constituant linestrings that make up polygon. PostGIS's `ST_Simplfiy` does this AFAIK. The link for VM algorithm shows a polygon (the USA) being simplified, so the concept of "simplifying a polygon" is well understood.