### PR TITLE
Translation bounds

### DIFF
--- a/src/algorithm/translate.rs
+++ b/src/algorithm/translate.rs
@@ -1,4 +1,4 @@
-use num_traits::{Float, FromPrimitive};
+use num_traits::Float;
 use algorithm::map_coords::MapCoords;
 
 pub trait Translate<T> {
@@ -26,7 +26,7 @@ pub trait Translate<T> {
 }
 
 impl<T, G> Translate<T> for G
-    where T: Float + FromPrimitive,
+    where T: Float,
         G: MapCoords<T, T, Output=G>
 {
     fn translate(&self, xoff: T, yoff: T) -> Self {


### PR DESCRIPTION
As we discussed in #147 I've removed the unnecessary `FromPrimitive` bound on the `Translate` trait. 

I also made `MapCoords::map_coords()` generic over any `Fn(&(T, T)) -> (NT, NT)` so it uses static dispatch instead of dynamic dispatch and you don't need to write funky `&|&(x, y)| { ... }` borrowed closures any more. 

(fixes #147)