### PR TITLE
Add generic trait impl for RotatePoint.

### DIFF
--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -7,7 +7,8 @@ use algorithm::map_coords::MapCoords;
 // origin can be an arbitrary point, pass &Point::new(0., 0.)
 // for the actual origin
 fn rotation_matrix<T>(angle: T, origin: &Point<T>, points: &[Point<T>]) -> Vec<Point<T>>
-    where T: Float
+where
+    T: Float,
 {
     let cos_theta = angle.to_radians().cos();
     let sin_theta = angle.to_radians().sin();
@@ -16,11 +17,13 @@ fn rotation_matrix<T>(angle: T, origin: &Point<T>, points: &[Point<T>]) -> Vec<P
     points
         .iter()
         .map(|point| {
-                 let x = point.x() - x0;
-                 let y = point.y() - y0;
-                 Point::new(x * cos_theta - y * sin_theta + x0,
-                            x * sin_theta + y * cos_theta + y0)
-             })
+            let x = point.x() - x0;
+            let y = point.y() - y0;
+            Point::new(
+                x * cos_theta - y * sin_theta + x0,
+                x * sin_theta + y * cos_theta + y0,
+            )
+        })
         .collect::<Vec<_>>()
 }
 
@@ -46,7 +49,9 @@ pub trait Rotate<T> {
     /// let correct_ls = LineString(correct);
     /// assert_eq!(rotated, correct_ls);
     /// ```
-    fn rotate(&self, angle: T) -> Self where T: Float;
+    fn rotate(&self, angle: T) -> Self
+    where
+        T: Float;
 }
 
 pub trait RotatePoint<T> {
@@ -71,12 +76,15 @@ pub trait RotatePoint<T> {
     /// let correct_ls = LineString(correct);
     /// assert_eq!(rotated, correct_ls);
     /// ```
-    fn rotate_around_point(&self, angle: T, point: &Point<T>) -> Self where T: Float;
+    fn rotate_around_point(&self, angle: T, point: &Point<T>) -> Self
+    where
+        T: Float;
 }
 
 impl<T, G> RotatePoint<T> for G
-    where T: Float,
-        G: MapCoords<T, T, Output=G>,
+where
+    T: Float,
+    G: MapCoords<T, T, Output = G>,
 {
     fn rotate_around_point(&self, angle: T, point: &Point<T>) -> Self {
         let cos_theta = angle.to_radians().cos();
@@ -86,14 +94,17 @@ impl<T, G> RotatePoint<T> for G
         self.map_coords(&|&(x, y)| {
             let x = x - x0;
             let y = y - y0;
-            (x * cos_theta - y * sin_theta + x0,
-            x * sin_theta + y * cos_theta + y0)
+            (
+                x * cos_theta - y * sin_theta + x0,
+                x * sin_theta + y * cos_theta + y0,
+            )
         })
     }
 }
 
 impl<T> Rotate<T> for Point<T>
-    where T: Float
+where
+    T: Float,
 {
     /// Rotate the Point about itself by the given number of degrees
     /// This operation leaves the point coordinates unchanged
@@ -103,7 +114,8 @@ impl<T> Rotate<T> for Point<T>
 }
 
 impl<T> Rotate<T> for Line<T>
-    where T: Float
+where
+    T: Float,
 {
     fn rotate(&self, angle: T) -> Self {
         let pts = vec![self.start, self.end];
@@ -113,7 +125,8 @@ impl<T> Rotate<T> for Line<T>
 }
 
 impl<T> Rotate<T> for LineString<T>
-    where T: Float
+where
+    T: Float,
 {
     /// Rotate the LineString about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -122,7 +135,8 @@ impl<T> Rotate<T> for LineString<T>
 }
 
 impl<T> Rotate<T> for Polygon<T>
-    where T: Float + FromPrimitive
+where
+    T: Float + FromPrimitive,
 {
     /// Rotate the Polygon about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -131,16 +145,21 @@ impl<T> Rotate<T> for Polygon<T>
             false => self.exterior.centroid().unwrap(),
             true => self.centroid().unwrap(),
         };
-        Polygon::new(LineString(rotation_matrix(angle, &centroid, &self.exterior.0)),
-                     self.interiors
-                         .iter()
-                         .map(|ring| LineString(rotation_matrix(angle, &centroid, &ring.0)))
-                         .collect())
+        Polygon::new(
+            LineString(rotation_matrix(angle, &centroid, &self.exterior.0)),
+            self.interiors
+                .iter()
+                .map(|ring| {
+                    LineString(rotation_matrix(angle, &centroid, &ring.0))
+                })
+                .collect(),
+        )
     }
 }
 
 impl<T> Rotate<T> for MultiPolygon<T>
-    where T: Float + FromPrimitive
+where
+    T: Float + FromPrimitive,
 {
     /// Rotate the contained Polygons about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -149,7 +168,8 @@ impl<T> Rotate<T> for MultiPolygon<T>
 }
 
 impl<T> Rotate<T> for MultiLineString<T>
-    where T: Float + FromPrimitive
+where
+    T: Float + FromPrimitive,
 {
     /// Rotate the contained LineStrings about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -158,7 +178,8 @@ impl<T> Rotate<T> for MultiLineString<T>
 }
 
 impl<T> Rotate<T> for MultiPoint<T>
-    where T: Float + FromPrimitive
+where
+    T: Float + FromPrimitive,
 {
     /// Rotate the contained Points about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -195,74 +216,97 @@ mod test {
     }
     #[test]
     fn test_rotate_polygon() {
-        let points_raw = vec![(5., 1.), (4., 2.), (4., 3.), (5., 4.), (6., 4.), (7., 3.),
-                              (7., 2.), (6., 1.), (5., 1.)];
+        let points_raw = vec![
+            (5., 1.),
+            (4., 2.),
+            (4., 3.),
+            (5., 4.),
+            (6., 4.),
+            (7., 3.),
+            (7., 2.),
+            (6., 1.),
+            (5., 1.),
+        ];
         let points = points_raw
             .iter()
             .map(|e| Point::new(e.0, e.1))
             .collect::<Vec<_>>();
         let poly1 = Polygon::new(LineString(points), vec![]);
         let rotated = poly1.rotate(-15.0);
-        let correct_outside = vec![(4.628808519201685, 1.1805207831176578),
-                                   (3.921701738015137, 2.405265654509247),
-                                   (4.180520783117657, 3.3711914807983154),
-                                   (5.405265654509247, 4.0782982619848624),
-                                   (6.371191480798315, 3.819479216882342),
-                                   (7.0782982619848624, 2.594734345490753),
-                                   (6.819479216882343, 1.6288085192016848),
-                                   (5.594734345490753, 0.9217017380151371),
-                                   (4.628808519201685, 1.1805207831176578)];
-        let correct = Polygon::new(LineString(correct_outside
-                                                  .iter()
-                                                  .map(|e| Point::new(e.0, e.1))
-                                                  .collect::<Vec<_>>()),
-                                   vec![]);
+        let correct_outside = vec![
+            (4.628808519201685, 1.1805207831176578),
+            (3.921701738015137, 2.405265654509247),
+            (4.180520783117657, 3.3711914807983154),
+            (5.405265654509247, 4.0782982619848624),
+            (6.371191480798315, 3.819479216882342),
+            (7.0782982619848624, 2.594734345490753),
+            (6.819479216882343, 1.6288085192016848),
+            (5.594734345490753, 0.9217017380151371),
+            (4.628808519201685, 1.1805207831176578),
+        ];
+        let correct = Polygon::new(
+            LineString(
+                correct_outside
+                    .iter()
+                    .map(|e| Point::new(e.0, e.1))
+                    .collect::<Vec<_>>(),
+            ),
+            vec![],
+        );
         // results agree with Shapely / GEOS
         assert_eq!(rotated, correct);
     }
     #[test]
     fn test_rotate_polygon_holes() {
-        let ls1 = LineString(vec![Point::new(5.0, 1.0),
-                                  Point::new(4.0, 2.0),
-                                  Point::new(4.0, 3.0),
-                                  Point::new(5.0, 4.0),
-                                  Point::new(6.0, 4.0),
-                                  Point::new(7.0, 3.0),
-                                  Point::new(7.0, 2.0),
-                                  Point::new(6.0, 1.0),
-                                  Point::new(5.0, 1.0)]);
+        let ls1 = LineString(vec![
+            Point::new(5.0, 1.0),
+            Point::new(4.0, 2.0),
+            Point::new(4.0, 3.0),
+            Point::new(5.0, 4.0),
+            Point::new(6.0, 4.0),
+            Point::new(7.0, 3.0),
+            Point::new(7.0, 2.0),
+            Point::new(6.0, 1.0),
+            Point::new(5.0, 1.0),
+        ]);
 
-        let ls2 = LineString(vec![Point::new(5.0, 1.3),
-                                  Point::new(5.5, 2.0),
-                                  Point::new(6.0, 1.3),
-                                  Point::new(5.0, 1.3)]);
+        let ls2 = LineString(vec![
+            Point::new(5.0, 1.3),
+            Point::new(5.5, 2.0),
+            Point::new(6.0, 1.3),
+            Point::new(5.0, 1.3),
+        ]);
 
-        let ls3 = LineString(vec![Point::new(5., 2.3),
-                                  Point::new(5.5, 3.0),
-                                  Point::new(6., 2.3),
-                                  Point::new(5., 2.3)]);
+        let ls3 = LineString(vec![
+            Point::new(5., 2.3),
+            Point::new(5.5, 3.0),
+            Point::new(6., 2.3),
+            Point::new(5., 2.3),
+        ]);
 
         let poly1 = Polygon::new(ls1, vec![ls2, ls3]);
         let rotated = poly1.rotate(-15.0);
-        let correct_outside = vec![(4.628808519201685, 1.180520783117658),
-                                   (3.921701738015137, 2.4052656545092472),
-                                   (4.180520783117657, 3.3711914807983154),
-                                   (5.405265654509247, 4.078298261984863),
-                                   (6.371191480798315, 3.8194792168823426),
-                                   (7.0782982619848624, 2.594734345490753),
-                                   (6.819479216882343, 1.628808519201685),
-                                   (5.594734345490753, 0.9217017380151373),
-                                   (4.628808519201685, 1.180520783117658)]
-                .iter()
-                .map(|e| Point::new(e.0, e.1))
-                .collect::<Vec<_>>();
-        let correct_inside = vec![(4.706454232732441, 1.4702985310043786),
-                                  (5.37059047744874, 2.017037086855466),
-                                  (5.672380059021509, 1.2114794859018578),
-                                  (4.706454232732441, 1.4702985310043786)]
-                .iter()
-                .map(|e| Point::new(e.0, e.1))
-                .collect::<Vec<_>>();
+        let correct_outside = vec![
+            (4.628808519201685, 1.180520783117658),
+            (3.921701738015137, 2.4052656545092472),
+            (4.180520783117657, 3.3711914807983154),
+            (5.405265654509247, 4.078298261984863),
+            (6.371191480798315, 3.8194792168823426),
+            (7.0782982619848624, 2.594734345490753),
+            (6.819479216882343, 1.628808519201685),
+            (5.594734345490753, 0.9217017380151373),
+            (4.628808519201685, 1.180520783117658),
+        ].iter()
+            .map(|e| Point::new(e.0, e.1))
+            .collect::<Vec<_>>();
+        let correct_inside = vec![
+            (4.706454232732441, 1.4702985310043786),
+            (5.37059047744874, 2.017037086855466),
+            (5.672380059021509, 1.2114794859018578),
+            (4.706454232732441, 1.4702985310043786),
+        ].iter()
+            .map(|e| Point::new(e.0, e.1))
+            .collect::<Vec<_>>();
         // println!("INSIDE {:?}", rotated.interiors[0].0);
         assert_eq!(rotated.exterior.0, correct_outside);
         assert_eq!(rotated.interiors[0].0, correct_inside);
@@ -282,7 +326,10 @@ mod test {
     #[test]
     fn test_rotate_line_around_point() {
         let line0 = Line::new(Point::new(0., 0.), Point::new(0., 2.));
-        let line1 = Line::new(Point::new(0., 0.), Point::new(-2., 0.00000000000000012246467991473532));
+        let line1 = Line::new(
+            Point::new(0., 0.),
+            Point::new(-2., 0.00000000000000012246467991473532),
+        );
         assert_eq!(line0.rotate_around_point(90., &Point::new(0., 0.)), line1);
     }
 }


### PR DESCRIPTION
Originally added in https://github.com/georust/rust-geo/pull/151, but
extracted out due to indecision about how to move forward with Rotate.