### PR TITLE
Closest point

### DIFF
--- a/src/algorithm/closest_point.rs
+++ b/src/algorithm/closest_point.rs
@@ -1,0 +1,12 @@
+use num_traits::Float;
+use Point;
+
+pub enum Closest<F: Float> {
+    SinglePoint,
+    Intersect(Point<F>),
+    Indeterminate,
+}
+
+pub trait ClosestPoint<F: Float, Other = Point<F>> {
+    fn closest_point(&self, other: &Other) -> Closest<F>;
+}

--- a/src/algorithm/closest_point.rs
+++ b/src/algorithm/closest_point.rs
@@ -1,12 +1,29 @@
 use num_traits::Float;
 use prelude::*;
-use {Line, LineString, Point};
+use {Line, LineString, Point, Polygon};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum Closest<F: Float> {
     Intersection(Point<F>),
     SinglePoint(Point<F>),
     Indeterminate,
+}
+
+impl<F: Float> Closest<F> {
+    fn best_of_two(&self, other: &Self, p: &Point<F>) -> Self {
+        let left = match *self {
+            Closest::Indeterminate => return *other,
+            Closest::Intersection(_) => return *self,
+            Closest::SinglePoint(l) => l,
+        };
+        let right = match *other {
+            Closest::Indeterminate => return *self,
+            Closest::Intersection(_) => return *other,
+            Closest::SinglePoint(r) => r,
+        };
+
+        unimplemented!()
+    }
 }
 
 /// Find the closest point between two objects, where the other object is
@@ -31,6 +48,16 @@ pub enum Closest<F: Float> {
 pub trait ClosestPoint<F: Float, Rhs = Point<F>> {
     /// Find the closest point between `self` and `p`.
     fn closest_point(&self, p: &Rhs) -> Closest<F>;
+}
+
+impl<'a, F, C> ClosestPoint<F> for &'a C
+where
+    C: ClosestPoint<F>,
+    F: Float,
+{
+    fn closest_point(&self, p: &Point<F>) -> Closest<F> {
+        (*self).closest_point(p)
+    }
 }
 
 impl<F: Float> ClosestPoint<F> for Point<F> {
@@ -82,28 +109,71 @@ impl<F: Float> ClosestPoint<F> for Line<F> {
     }
 }
 
+/// A generic function which takes some iterator of points and gives you the
+/// "best" `Closest` it can find. Where "best" is the first intersection or
+/// the `Closest::SinglePoint` which is closest to `p`.
+///
+/// If the iterator is empty, we get `Closest::Indeterminate`.
+fn closest_of<C, F, I>(iter: I, p: &Point<F>) -> Closest<F>
+where
+    F: Float,
+    I: IntoIterator<Item = C>,
+    C: ClosestPoint<F>,
+{
+    let mut single_points = Vec::new();
+
+    for line_segment in iter {
+        let closest = line_segment.closest_point(p);
+        match closest {
+            Closest::Intersection(_) => return closest,
+            Closest::SinglePoint(close) => single_points.push(close),
+            _ => {},
+        }
+    }
+
+    single_points
+        .into_iter()
+        .min_by(|l, r| {
+            l.distance(p)
+                .partial_cmp(&r.distance(p))
+                .expect("Should never get NaN")
+        })
+        .map(|closest_point| Closest::SinglePoint(closest_point))
+        .unwrap_or(Closest::Indeterminate)
+}
+
 impl<F: Float> ClosestPoint<F> for LineString<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        let mut single_points = Vec::new();
+        closest_of(self.lines(), p)
+    }
+}
 
-        for line_segment in self.lines() {
-            let closest = line_segment.closest_point(p);
-            match closest {
-                Closest::Intersection(_) => return closest,
-                Closest::SinglePoint(close) => single_points.push(close),
-                _ => {},
-            }
+impl<F: Float> ClosestPoint<F> for Polygon<F> {
+    fn closest_point(&self, p: &Point<F>) -> Closest<F> {
+        let closest_of_interior = closest_of(self.interiors.iter(), p);
+        if let Closest::Intersection(_) = closest_of_interior {
+            return closest_of_interior;
         }
 
-        single_points
-            .into_iter()
-            .min_by(|l, r| {
-                l.distance(p)
-                    .partial_cmp(&r.distance(p))
-                    .expect("Should never get NaN")
-            })
-            .map(|closest_point| Closest::SinglePoint(closest_point))
-            .unwrap_or(Closest::Indeterminate)
+        let initial_guess = self.exterior.closest_point(p);
+
+        let interior = match closest_of_interior {
+            Closest::Indeterminate => return initial_guess,
+            Closest::SinglePoint(interior) => interior,
+            Closest::Intersection(_) => unreachable!(),
+        };
+
+        let exterior = match initial_guess {
+            Closest::Intersection(_) => return initial_guess,
+            Closest::SinglePoint(exterior) => exterior,
+            Closest::Indeterminate => unreachable!(),
+        };
+
+        if exterior.distance(p) <= interior.distance(p) {
+            initial_guess
+        } else {
+            closest_of_interior
+        }
     }
 }
 
@@ -111,6 +181,7 @@ impl<F: Float> ClosestPoint<F> for LineString<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use algorithm::orient::Direction;
 
     /// Create a test which checks that we get `$should_be` when trying to find
     /// the closest distance between `$p` and the line `(0, 0) -> (100, 100)`.
@@ -137,6 +208,66 @@ mod tests {
     closest!(in_line_far_away, (1000.0, 1000.0) => Closest::SinglePoint(Point::new(100.0, 100.0)));
     closest!(perpendicular_from_50_50, (0.0, 100.0) => Closest::SinglePoint(Point::new(50.0, 50.0)));
 
+
+    fn collect_points<F, P, C>(points: &[P]) -> C
+    where
+        F: Float,
+        P: Into<Point<F>> + Clone,
+        C: ::std::iter::FromIterator<Point<F>>,
+    {
+        points.iter().map(|p| p.clone().into()).collect()
+    }
+
+    fn a_square(width: f32) -> LineString<f32> {
+        let points = vec![
+            (0.0, 0.0),
+            (width, 0.0),
+            (width, width),
+            (0.0, width),
+            (0.0, 0.0),
+        ];
+
+        collect_points(&points)
+    }
+
+    fn random_looking_points() -> Vec<Point<f32>> {
+        let mut points = vec![
+            (0.0, 0.0),
+            (100.0, 100.0),
+            (1000.0, 1000.0),
+            (100.0, 0.0),
+            (50.0, 50.0),
+            (1234.567, -987.6543),
+        ];
+
+        collect_points(&points)
+    }
+
+    fn fuzz_two_impls<A, B>(left: A, right: B)
+    where
+        A: ClosestPoint<f32>,
+        B: ClosestPoint<f32>,
+    {
+        let some_random_points = random_looking_points();
+
+        for (i, random_point) in some_random_points.into_iter().enumerate() {
+            let p: Point<_> = random_point.into();
+
+            let got_from_left = left.closest_point(&p);
+            let got_from_right = right.closest_point(&p);
+
+            assert_eq!(
+                got_from_left,
+                got_from_right,
+                "{}: {:?} got {:?} and {:?}",
+                i,
+                p,
+                got_from_left,
+                got_from_right
+            );
+        }
+    }
+
     #[test]
     fn zero_length_line_is_indeterminate() {
         let line: Line<f32> = Line::new(Point::new(0.0, 0.0), Point::new(0.0, 0.0));
@@ -147,36 +278,13 @@ mod tests {
         assert_eq!(got, should_be);
     }
 
-    fn points_to_line<F, P>(points: &[P]) -> LineString<F>
-    where
-        F: Float,
-        P: Into<Point<F>> + Clone,
-    {
-        points.iter().map(|p| p.clone().into()).collect()
-    }
-
     #[test]
     fn line_string_with_single_element_behaves_like_line() {
         let points = vec![(0.0, 0.0), (100.0, 100.0)];
-        let line_string = points_to_line(&points);
+        let line_string: LineString<f32> = collect_points(&points);
         let line = Line::new(points[0].into(), points[1].into());
 
-        let some_random_points = vec![
-            (0.0, 0.0),
-            (100.0, 100.0),
-            (50.0, 50.0),
-            (1000.0, 1000.0),
-            (100.0, 0.0),
-        ];
-
-        for (i, random_point) in some_random_points.into_iter().enumerate() {
-            let p: Point<f32> = random_point.into();
-
-            let got_from_line = line.closest_point(&p);
-            let got_from_line_string = line_string.closest_point(&p);
-
-            assert_eq!(got_from_line, got_from_line_string, "{}: {:?}", i, p);
-        }
+        fuzz_two_impls(line, line_string);
     }
 
     #[test]
@@ -186,5 +294,58 @@ mod tests {
 
         let got = ls.closest_point(&p);
         assert_eq!(got, Closest::Indeterminate);
+    }
+
+    #[test]
+    fn simple_polygon_is_same_as_linestring() {
+        let square: LineString<f32> = a_square(100.0);
+        let poly = Polygon::new(square.clone(), Vec::new());
+
+        fuzz_two_impls(square, poly);
+    }
+
+    /// A polygon with 2 holes in it.
+    fn holy_polygon() -> Polygon<f32> {
+        let square: LineString<f32> = a_square(100.0);
+        let ring_1 = a_square(20.0).translate(20.0, 10.0);
+        let ring_2 = a_square(10.0).translate(70.0, 60.0);
+        Polygon::new(square.clone(), vec![ring_1, ring_2])
+    }
+
+    #[test]
+    fn polygon_without_rings_and_point_outside_is_same_as_linestring() {
+        let poly = holy_polygon();
+        let p = Point::new(1000.0, 12345.6789);
+        assert!(!poly.exterior.contains(&p), "`p` should be outside the polygon!");
+
+        let poly_closest = poly.closest_point(&p);
+        let exterior_closest = poly.exterior.closest_point(&p);
+
+        assert_eq!(poly_closest, exterior_closest);
+    }
+
+    #[test]
+    fn polygon_with_point_on_interior_ring() {
+        let poly = holy_polygon();
+        let p = poly.interiors[0].0[3];
+        let should_be = Closest::Intersection(p);
+
+        let got = poly.closest_point(&p);
+
+        assert_eq!(got, should_be);
+    }
+
+    #[test]
+    fn polygon_with_point_near_interior_ring() {
+        let poly = holy_polygon();
+        let random_ring_corner = poly.interiors[0].0[3];
+        let p = random_ring_corner.translate(-3.0, 3.0);
+
+        let should_be = Closest::SinglePoint(random_ring_corner);
+        println!("{:?} {:?}", p, random_ring_corner);
+
+        let got = poly.closest_point(&p);
+
+        assert_eq!(got, should_be);
     }
 }

--- a/src/algorithm/closest_point.rs
+++ b/src/algorithm/closest_point.rs
@@ -1,6 +1,6 @@
 use num_traits::Float;
 use prelude::*;
-use {Line, Point};
+use {Line, LineString, Point};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum Closest<F: Float> {
@@ -29,12 +29,13 @@ pub enum Closest<F: Float> {
 /// assert_eq!(closest, Closest::SinglePoint(Point::new(0.0, 0.0)));
 /// ```
 pub trait ClosestPoint<F: Float, Rhs = Point<F>> {
-    fn closest_point(&self, other: &Rhs) -> Closest<F>;
+    /// Find the closest point between `self` and `p`.
+    fn closest_point(&self, p: &Rhs) -> Closest<F>;
 }
 
 impl<F: Float> ClosestPoint<F> for Point<F> {
-    fn closest_point(&self, other: &Self) -> Closest<F> {
-        if self == other {
+    fn closest_point(&self, p: &Self) -> Closest<F> {
+        if self == p {
             Closest::Intersection(*self)
         } else {
             Closest::SinglePoint(*self)
@@ -44,7 +45,7 @@ impl<F: Float> ClosestPoint<F> for Point<F> {
 
 
 impl<F: Float> ClosestPoint<F> for Line<F> {
-    fn closest_point(&self, other: &Point<F>) -> Closest<F> {
+    fn closest_point(&self, p: &Point<F>) -> Closest<F> {
         let line_length = self.length();
         if line_length == F::zero() {
             // if we've got a zero length line, technically the entire line
@@ -53,12 +54,14 @@ impl<F: Float> ClosestPoint<F> for Line<F> {
         }
 
         // For some line AB, there is some point, C, which will be closest to
-        // P (`other`). The line AB will be perpendicular to CP.
+        // P. The line AB will be perpendicular to CP.
+        //
+        // Line equation: P = start + t * (end - start)
 
         let direction_vector = self.end - self.start;
-        let to_other = *other - self.start;
+        let to_p = *p - self.start;
 
-        let t = to_other.dot(&direction_vector) / direction_vector.dot(&direction_vector);
+        let t = to_p.dot(&direction_vector) / direction_vector.dot(&direction_vector);
 
         // check the cases where the closest point is "outside" the line
         if t < F::zero() {
@@ -71,11 +74,36 @@ impl<F: Float> ClosestPoint<F> for Line<F> {
         let displacement = Point::new(t * x, t * y);
         let c = self.start + displacement;
 
-        if self.contains(other) {
+        if self.contains(p) {
             Closest::Intersection(c)
         } else {
             Closest::SinglePoint(c)
         }
+    }
+}
+
+impl<F: Float> ClosestPoint<F> for LineString<F> {
+    fn closest_point(&self, p: &Point<F>) -> Closest<F> {
+        let mut single_points = Vec::new();
+
+        for line_segment in self.lines() {
+            let closest = line_segment.closest_point(p);
+            match closest {
+                Closest::Intersection(_) => return closest,
+                Closest::SinglePoint(close) => single_points.push(close),
+                _ => {},
+            }
+        }
+
+        single_points
+            .into_iter()
+            .min_by(|l, r| {
+                l.distance(p)
+                    .partial_cmp(&r.distance(p))
+                    .expect("Should never get NaN")
+            })
+            .map(|closest_point| Closest::SinglePoint(closest_point))
+            .unwrap_or(Closest::Indeterminate)
     }
 }
 
@@ -117,5 +145,46 @@ mod tests {
 
         let got = line.closest_point(&p);
         assert_eq!(got, should_be);
+    }
+
+    fn points_to_line<F, P>(points: &[P]) -> LineString<F>
+    where
+        F: Float,
+        P: Into<Point<F>> + Clone,
+    {
+        points.iter().map(|p| p.clone().into()).collect()
+    }
+
+    #[test]
+    fn line_string_with_single_element_behaves_like_line() {
+        let points = vec![(0.0, 0.0), (100.0, 100.0)];
+        let line_string = points_to_line(&points);
+        let line = Line::new(points[0].into(), points[1].into());
+
+        let some_random_points = vec![
+            (0.0, 0.0),
+            (100.0, 100.0),
+            (50.0, 50.0),
+            (1000.0, 1000.0),
+            (100.0, 0.0),
+        ];
+
+        for (i, random_point) in some_random_points.into_iter().enumerate() {
+            let p: Point<f32> = random_point.into();
+
+            let got_from_line = line.closest_point(&p);
+            let got_from_line_string = line_string.closest_point(&p);
+
+            assert_eq!(got_from_line, got_from_line_string, "{}: {:?}", i, p);
+        }
+    }
+
+    #[test]
+    fn empty_line_string_is_indeterminate() {
+        let ls: LineString<f32> = LineString(Vec::new());
+        let p = Point::new(0.0, 0.0);
+
+        let got = ls.closest_point(&p);
+        assert_eq!(got, Closest::Indeterminate);
     }
 }

--- a/src/algorithm/closest_point.rs
+++ b/src/algorithm/closest_point.rs
@@ -1,12 +1,121 @@
 use num_traits::Float;
-use Point;
+use prelude::*;
+use {Line, Point};
 
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum Closest<F: Float> {
-    SinglePoint,
-    Intersect(Point<F>),
+    Intersection(Point<F>),
+    SinglePoint(Point<F>),
     Indeterminate,
 }
 
-pub trait ClosestPoint<F: Float, Other = Point<F>> {
-    fn closest_point(&self, other: &Other) -> Closest<F>;
+/// Find the closest point between two objects, where the other object is
+/// assumed to be a `Point` by default.
+///
+/// # Examples
+///
+/// Here's a simple example where we've got a horizontal line which goes
+/// through `(-50, 0) -> (50, 0)` and want to find the closest point to
+/// `(0, 100)`. If you draw it out on paper the point on the line which is
+/// closest to `(0, 100)` will be the origin.
+///
+/// ```rust
+/// # use geo::algorithm::closest_point::{Closest, ClosestPoint};
+/// # use geo::{Point, Line};
+/// let p: Point<f32> = Point::new(0.0, 100.0);
+/// let horizontal_line: Line<f32> = Line::new(Point::new(-50.0, 0.0), Point::new(50.0, 0.0));
+///
+/// let closest = horizontal_line.closest_point(&p);
+/// assert_eq!(closest, Closest::SinglePoint(Point::new(0.0, 0.0)));
+/// ```
+pub trait ClosestPoint<F: Float, Rhs = Point<F>> {
+    fn closest_point(&self, other: &Rhs) -> Closest<F>;
+}
+
+impl<F: Float> ClosestPoint<F> for Point<F> {
+    fn closest_point(&self, other: &Self) -> Closest<F> {
+        if self == other {
+            Closest::Intersection(*self)
+        } else {
+            Closest::SinglePoint(*self)
+        }
+    }
+}
+
+
+impl<F: Float> ClosestPoint<F> for Line<F> {
+    fn closest_point(&self, other: &Point<F>) -> Closest<F> {
+        let line_length = self.length();
+        if line_length == F::zero() {
+            // if we've got a zero length line, technically the entire line
+            // is the closest point...
+            return Closest::Indeterminate;
+        }
+
+        // For some line AB, there is some point, C, which will be closest to
+        // P (`other`). The line AB will be perpendicular to CP.
+
+        let direction_vector = self.end - self.start;
+        let to_other = *other - self.start;
+
+        let t = to_other.dot(&direction_vector) / direction_vector.dot(&direction_vector);
+
+        // check the cases where the closest point is "outside" the line
+        if t < F::zero() {
+            return Closest::SinglePoint(self.start);
+        } else if t > F::one() {
+            return Closest::SinglePoint(self.end);
+        }
+
+        let (x, y) = direction_vector.coords();
+        let displacement = Point::new(t * x, t * y);
+        let c = self.start + displacement;
+
+        if self.contains(other) {
+            Closest::Intersection(c)
+        } else {
+            Closest::SinglePoint(c)
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a test which checks that we get `$should_be` when trying to find
+    /// the closest distance between `$p` and the line `(0, 0) -> (100, 100)`.
+    macro_rules! closest {
+        (intersects: $name:ident, $p:expr) => {
+            closest!($name, $p => Closest::Intersection($p.into()));
+        };
+        ($name:ident, $p:expr => $should_be:expr) => {
+            #[test]
+            fn $name() {
+                let line: Line<f32> = Line::new(Point::new(0.0, 0.0), Point::new(100.0, 100.0));
+                let p: Point<f32> = $p.into();
+                let should_be: Closest<f32> = $should_be;
+
+                let got = line.closest_point(&p);
+                assert_eq!(got, should_be);
+            }
+        };
+    }
+
+    closest!(intersects: start_point, (0.0, 0.0));
+    closest!(intersects: end_point, (100.0, 100.0));
+    closest!(intersects: mid_point, (50.0, 50.0));
+    closest!(in_line_far_away, (1000.0, 1000.0) => Closest::SinglePoint(Point::new(100.0, 100.0)));
+    closest!(perpendicular_from_50_50, (0.0, 100.0) => Closest::SinglePoint(Point::new(50.0, 50.0)));
+
+    #[test]
+    fn zero_length_line_is_indeterminate() {
+        let line: Line<f32> = Line::new(Point::new(0.0, 0.0), Point::new(0.0, 0.0));
+        let p: Point<f32> = Point::new(100.0, 100.0);
+        let should_be: Closest<f32> = Closest::Indeterminate;
+
+        let got = line.closest_point(&p);
+        assert_eq!(got, should_be);
+    }
 }

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -32,3 +32,5 @@ pub mod rotate;
 pub mod translate;
 /// Apply a function to all coordinates
 pub mod map_coords;
+/// Determine the closest point between two objects.
+pub mod closest_point;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
+extern crate num_traits;
 #[macro_use]
 extern crate serde_derive;
-extern crate num_traits;
 extern crate spade;
 
 pub use traits::ToGeo;
@@ -36,6 +36,5 @@ pub mod prelude {
     pub use algorithm::simplify::Simplify;
     pub use algorithm::simplifyvw::SimplifyVW;
     pub use algorithm::translate::Translate;
-
-
+    pub use algorithm::closest_point::ClosestPoint;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -235,6 +235,11 @@ impl<T> Point<T>
     pub fn dot(&self, point: &Point<T>) -> T {
         self.x() * point.x() + self.y() * point.y()
     }
+
+    /// Convert this `Point` into a tuple of its `x` and `y` coordinates.
+    pub(crate) fn coords(&self) -> (T, T) {
+        (self.x(), self.y())
+    }
 }
 
 impl<T> Neg for Point<T>

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,6 +11,9 @@ use num_traits::{Float, ToPrimitive};
 use spade::SpadeNum;
 use spade::PointN;
 
+// re-export `Closest` for convenience.
+pub use algorithm::closest_point::Closest;
+
 pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
 
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
The initial implementation of a `ClosestPoint` algorithm. The trait itself looks something like this:

```rust
pub trait ClosestPoint<F: Float, Rhs = Point<F>> {
    fn closest_point(&self, other: &Rhs) -> Closest<F>;
}

pub enum Closest<F: Float> {
    Intersection(Point<F>),
    SinglePoint(Point<F>),
    Indeterminate,
}
```

If you can think of a better name for `Closest` please let me know (names are hard!).

(fixes #161)