### PR TITLE
Map coords inplace

### DIFF
--- a/src/algorithm/map_coords.rs
+++ b/src/algorithm/map_coords.rs
@@ -64,7 +64,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Point<T> {
 
 impl<T: Float> MapCoordsInplace<T> for Point<T> {
 
-    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T)) 
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
     {
         let new_point = func(&(self.0.x, self.0.y));
         self.0.x = new_point.0;
@@ -229,9 +229,8 @@ impl<T: Float> MapCoordsInplace<T> for GeometryCollection<T> {
 
 
 
+#[cfg(test)]
 mod test {
-    #[allow(unused_imports)]
-
     use super::*;
 
     #[test]

--- a/src/algorithm/map_coords.rs
+++ b/src/algorithm/map_coords.rs
@@ -18,7 +18,7 @@ pub trait MapCoords<T, NT> {
     /// assert_eq!(p2, Point::new(1010., 40.));
     /// ```
     ///
-    /// You can also change the coordinate precision in this way:
+    /// You can convert the coordinate type this way as well
     ///
     /// ```
     /// # use geo::Point;
@@ -30,9 +30,27 @@ pub trait MapCoords<T, NT> {
     /// assert_eq!(p2, Point::new(10.0f64, 20.0f64));
     /// ```
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-    where
-        T: Float,
-        NT: Float;
+        where T: Float, NT: Float;
+
+
+
+}
+
+/// Map all the coordinates in an object in place
+pub trait MapCoordsInplace<T> {
+    /// Apply a function to all the coordinates in a geometric object, in place
+    ///
+    /// ```
+    /// use geo::Point;
+    /// use geo::algorithm::map_coords::MapCoordsInplace;
+    ///
+    /// let mut p = Point::new(10., 20.);
+    /// p.map_coords_inplace(&|&(x, y)| (x+1000., y*2.));
+    ///
+    /// assert_eq!(p, Point::new(1010., 40.));
+    /// ```
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+        where T: Float;
 }
 
 impl<T: Float, NT: Float> MapCoords<T, NT> for Point<T> {
@@ -44,6 +62,16 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Point<T> {
     }
 }
 
+impl<T: Float> MapCoordsInplace<T> for Point<T> {
+
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T)) 
+    {
+        let new_point = func(&(self.0.x, self.0.y));
+        self.0.x = new_point.0;
+        self.0.y = new_point.1;
+    }
+}
+
 impl<T: Float, NT: Float> MapCoords<T, NT> for Line<T> {
     type Output = Line<NT>;
 
@@ -52,11 +80,28 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Line<T> {
     }
 }
 
+impl<T: Float> MapCoordsInplace<T> for Line<T> {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        self.start.map_coords_inplace(func);
+        self.end.map_coords_inplace(func);
+    }
+}
+
 impl<T: Float, NT: Float> MapCoords<T, NT> for LineString<T> {
     type Output = LineString<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         LineString(self.0.iter().map(|p| p.map_coords(func)).collect())
+    }
+}
+
+impl<T: Float> MapCoordsInplace<T> for LineString<T> {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        for p in self.0.iter_mut() {
+            p.map_coords_inplace(func);
+        }
     }
 }
 
@@ -71,11 +116,30 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Polygon<T> {
     }
 }
 
+impl<T: Float> MapCoordsInplace<T> for Polygon<T> {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        self.exterior.map_coords_inplace(func);
+        for p in self.interiors.iter_mut() {
+            p.map_coords_inplace(func);
+        }
+    }
+}
+
 impl<T: Float, NT: Float> MapCoords<T, NT> for MultiPoint<T> {
     type Output = MultiPoint<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         MultiPoint(self.0.iter().map(|p| p.map_coords(func)).collect())
+    }
+}
+
+impl<T: Float> MapCoordsInplace<T> for MultiPoint<T> {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        for p in self.0.iter_mut() {
+            p.map_coords_inplace(func);
+        }
     }
 }
 
@@ -87,11 +151,29 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for MultiLineString<T> {
     }
 }
 
+impl<T: Float> MapCoordsInplace<T> for MultiLineString<T> {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        for p in self.0.iter_mut() {
+            p.map_coords_inplace(func);
+        }
+    }
+}
+
 impl<T: Float, NT: Float> MapCoords<T, NT> for MultiPolygon<T> {
     type Output = MultiPolygon<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         MultiPolygon(self.0.iter().map(|p| p.map_coords(func)).collect())
+    }
+}
+
+impl<T: Float> MapCoordsInplace<T> for MultiPolygon<T> {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        for p in self.0.iter_mut() {
+            p.map_coords_inplace(func);
+        }
     }
 }
 
@@ -112,6 +194,22 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Geometry<T> {
     }
 }
 
+impl<T: Float> MapCoordsInplace<T> for Geometry<T> {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        match *self {
+            Geometry::Point(ref mut x) => x.map_coords_inplace(func),
+            Geometry::Line(ref mut x) => x.map_coords_inplace(func),
+            Geometry::LineString(ref mut x) => x.map_coords_inplace(func),
+            Geometry::Polygon(ref mut x) => x.map_coords_inplace(func),
+            Geometry::MultiPoint(ref mut x) => x.map_coords_inplace(func),
+            Geometry::MultiLineString(ref mut x) => x.map_coords_inplace(func),
+            Geometry::MultiPolygon(ref mut x) => x.map_coords_inplace(func),
+            Geometry::GeometryCollection(ref mut x) => x.map_coords_inplace(func),
+        }
+    }
+}
+
 impl<T: Float, NT: Float> MapCoords<T, NT> for GeometryCollection<T> {
     type Output = GeometryCollection<NT>;
 
@@ -119,6 +217,17 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for GeometryCollection<T> {
         GeometryCollection(self.0.iter().map(|g| g.map_coords(func)).collect())
     }
 }
+
+impl<T: Float> MapCoordsInplace<T> for GeometryCollection<T> {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        for p in self.0.iter_mut() {
+            p.map_coords_inplace(func);
+        }
+    }
+}
+
+
 
 mod test {
     #[allow(unused_imports)]
@@ -131,6 +240,14 @@ mod test {
         let new_p = p.map_coords(&|&(x, y)| (x + 10., y + 100.));
         assert_eq!(new_p.x(), 20.);
         assert_eq!(new_p.y(), 110.);
+    }
+
+    #[test]
+    fn point_inplace() {
+        let mut p2 = Point::new(10f32, 10f32);
+        p2.map_coords_inplace(&|&(x, y)| (x+10., y+100.));
+        assert_eq!(p2.x(), 20.);
+        assert_eq!(p2.y(), 110.);
     }
 
     #[test]

--- a/src/algorithm/translate.rs
+++ b/src/algorithm/translate.rs
@@ -1,40 +1,44 @@
 use num_traits::Float;
-use algorithm::map_coords::MapCoords;
+use algorithm::map_coords::{MapCoords, MapCoordsInplace};
 
 pub trait Translate<T> {
-  /// Translate a Geometry along its axes by the given offsets
-  ///
-  ///
-  /// ```
-  /// use geo::{Point, LineString};
-  /// use geo::algorithm::translate::{Translate};
-  ///
-  /// let mut vec = Vec::new();
-  /// vec.push(Point::new(0.0, 0.0));
-  /// vec.push(Point::new(5.0, 5.0));
-  /// vec.push(Point::new(10.0, 10.0));
-  /// let linestring = LineString(vec);
-  /// let translated = linestring.translate(1.5, 3.5);
-  /// let mut correct = Vec::new();
-  /// correct.push(Point::new(1.5, 3.5));
-  /// correct.push(Point::new(6.5, 8.5));
-  /// correct.push(Point::new(11.5, 13.5));
-  /// let correct_ls = LineString(correct);
-  /// assert_eq!(translated, correct_ls);
-  /// ```
-  fn translate(&self, xoff: T, yoff: T) -> Self
-  where
-    T: Float;
+    /// Translate a Geometry along its axes by the given offsets
+    ///
+    ///
+    /// ```
+    /// use geo::{Point, LineString};
+    /// use geo::algorithm::translate::{Translate};
+    ///
+    /// let mut vec = Vec::new();
+    /// vec.push(Point::new(0.0, 0.0));
+    /// vec.push(Point::new(5.0, 5.0));
+    /// vec.push(Point::new(10.0, 10.0));
+    /// let linestring = LineString(vec);
+    /// let translated = linestring.translate(1.5, 3.5);
+    /// let mut correct = Vec::new();
+    /// correct.push(Point::new(1.5, 3.5));
+    /// correct.push(Point::new(6.5, 8.5));
+    /// correct.push(Point::new(11.5, 13.5));
+    /// let correct_ls = LineString(correct);
+    /// assert_eq!(translated, correct_ls);
+    /// ```
+    fn translate(&self, xoff: T, yoff: T) -> Self where T: Float;
+
+    /// Translate a Geometry along its axes, but in place.
+    fn translate_inplace(&mut self, xoff: T, yoff: T) where T: Float;
 }
 
 impl<T, G> Translate<T> for G
-where
-  T: Float,
-  G: MapCoords<T, T, Output = G>,
+    where T: Float,
+        G: MapCoords<T, T, Output=G>+MapCoordsInplace<T>
 {
-  fn translate(&self, xoff: T, yoff: T) -> Self {
-    self.map_coords(&|&(x, y)| (x + xoff, y + yoff))
-  }
+    fn translate(&self, xoff: T, yoff: T) -> Self {
+        self.map_coords(&|&(x, y)| (x + xoff, y + yoff))
+    }
+
+    fn translate_inplace(&mut self, xoff: T, yoff: T) {
+        self.map_coords_inplace(&|&(x, y)| (x + xoff, y + yoff))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
To compliment the `.map_coords()` feature, I've added a `.map_coords_inplace` which will apply a provided function to all coordinatines in place, i.e. not doing any allocations.

Some of this has a lot of overlap with #164.

I've used that to add a `.translate_inplace()` feature.