### PR TITLE
Use new bulk-load method for initial R* Tree population

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "georust/rust-geo" }
 num-traits = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
-spade = "1.2.0"
+spade = "1.3.0"
 
 [dev-dependencies]
 approx = "0.1.1"

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,7 @@ use std::iter::{self, Iterator, FromIterator};
 
 use num_traits::{Float, ToPrimitive};
 use spade::SpadeNum;
-use spade::PointN;
+use spade::{PointN, TwoDimensional};
 
 
 pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
@@ -331,6 +331,9 @@ impl<T> PointN for Point<T>
         }
     }
 }
+
+impl<T> TwoDimensional for Point<T>
+where T: Float + SpadeNum + Debug {}
 
 impl<T> Add for Bbox<T>
     where T: Float + ToPrimitive


### PR DESCRIPTION
This gets us a big speedup, and a higher-quality tree for nearest-neighbour searches.