### PR TITLE
Clippy pass, rustfmt pass, typo fixes, enum addition

### DIFF
--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -1,9 +1,11 @@
 use num_traits::Float;
-use types::{Line, LineString, Polygon, MultiPolygon, Bbox};
+use types::{Bbox, Line, LineString, MultiPolygon, Polygon};
 
 /// Calculation of the area.
 
-pub trait Area<T> where T: Float
+pub trait Area<T>
+where
+    T: Float,
 {
     /// Area of polygon.
     /// See: https://en.wikipedia.org/wiki/Polygon
@@ -20,7 +22,10 @@ pub trait Area<T> where T: Float
     fn area(&self) -> T;
 }
 
-fn get_linestring_area<T>(linestring: &LineString<T>) -> T where T: Float {
+fn get_linestring_area<T>(linestring: &LineString<T>) -> T
+where
+    T: Float,
+{
     if linestring.0.is_empty() || linestring.0.len() == 1 {
         return T::zero();
     }
@@ -32,7 +37,8 @@ fn get_linestring_area<T>(linestring: &LineString<T>) -> T where T: Float {
 }
 
 impl<T> Area<T> for Line<T>
-    where T: Float
+where
+    T: Float,
 {
     fn area(&self) -> T {
         T::zero()
@@ -40,24 +46,34 @@ impl<T> Area<T> for Line<T>
 }
 
 impl<T> Area<T> for Polygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn area(&self) -> T {
-        self.interiors.iter().fold(get_linestring_area(&self.exterior),
-                                   |total, next| total - get_linestring_area(next))
+        self.interiors
+            .iter()
+            .fold(get_linestring_area(&self.exterior), |total, next| {
+                total - get_linestring_area(next)
+            })
     }
 }
 
 impl<T> Area<T> for MultiPolygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn area(&self) -> T {
-        self.0.iter().fold(T::zero(), |total, next| total + next.area())
+        self.0
+            .iter()
+            .fold(T::zero(), |total, next| {
+                total + next.area()
+            })
     }
 }
 
 impl<T> Area<T> for Bbox<T>
-    where T: Float
+where
+    T: Float,
 {
     fn area(&self) -> T {
         (self.xmax - self.xmin) * (self.ymax - self.ymin)
@@ -66,7 +82,7 @@ impl<T> Area<T> for Bbox<T>
 
 #[cfg(test)]
 mod test {
-    use types::{Coordinate, Point, Line, LineString, Polygon, MultiPolygon, Bbox};
+    use types::{Bbox, Coordinate, Line, LineString, MultiPolygon, Point, Polygon};
     use algorithm::area::Area;
 
     // Area of the polygon
@@ -90,13 +106,24 @@ mod test {
     }
     #[test]
     fn bbox_test() {
-        let bbox = Bbox {xmin: 10., xmax: 20., ymin: 30., ymax: 40.};
+        let bbox = Bbox {
+            xmin: 10.,
+            xmax: 20.,
+            ymin: 30.,
+            ymax: 40.,
+        };
         assert_relative_eq!(bbox.area(), 100.);
     }
     #[test]
     fn area_polygon_inner_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let outer = LineString(vec![p(0., 0.), p(10., 0.), p(10., 10.), p(0., 10.), p(0., 0.)]);
+        let outer = LineString(vec![
+            p(0., 0.),
+            p(10., 0.),
+            p(10., 10.),
+            p(0., 10.),
+            p(0., 0.),
+        ]);
         let inner0 = LineString(vec![p(1., 1.), p(2., 1.), p(2., 2.), p(1., 2.), p(1., 1.)]);
         let inner1 = LineString(vec![p(5., 5.), p(6., 5.), p(6., 6.), p(5., 6.), p(5., 5.)]);
         let poly = Polygon::new(outer, vec![inner0, inner1]);
@@ -105,15 +132,24 @@ mod test {
     #[test]
     fn area_multipolygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let poly0 = Polygon::new(LineString(vec![p(0., 0.), p(10., 0.), p(10., 10.), p(0., 10.),
-                                                 p(0., 0.)]),
-                                 Vec::new());
-        let poly1 = Polygon::new(LineString(vec![p(1., 1.), p(2., 1.), p(2., 2.), p(1., 2.),
-                                                 p(1., 1.)]),
-                                 Vec::new());
-        let poly2 = Polygon::new(LineString(vec![p(5., 5.), p(6., 5.), p(6., 6.), p(5., 6.),
-                                                 p(5., 5.)]),
-                                 Vec::new());
+        let poly0 = Polygon::new(
+            LineString(vec![
+                p(0., 0.),
+                p(10., 0.),
+                p(10., 10.),
+                p(0., 10.),
+                p(0., 0.),
+            ]),
+            Vec::new(),
+        );
+        let poly1 = Polygon::new(
+            LineString(vec![p(1., 1.), p(2., 1.), p(2., 2.), p(1., 2.), p(1., 1.)]),
+            Vec::new(),
+        );
+        let poly2 = Polygon::new(
+            LineString(vec![p(5., 5.), p(6., 5.), p(6., 6.), p(5., 6.), p(5., 5.)]),
+            Vec::new(),
+        );
         let mpoly = MultiPolygon(vec![poly0, poly1, poly2]);
         assert_eq!(mpoly.area(), 102.);
         assert_relative_eq!(mpoly.area(), 102.);

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -80,7 +80,7 @@ impl<T> Centroid<T> for LineString<T>
             return None;
         }
         if self.0.len() == 1 {
-            Some(self.0[0].clone())
+            Some(self.0[0])
         } else {
             let mut sum_x = T::zero();
             let mut sum_y = T::zero();

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -1,6 +1,6 @@
 use num_traits::{Float, FromPrimitive};
 
-use types::{Point, Line, LineString, Polygon, MultiPolygon, Bbox};
+use types::{Bbox, Line, LineString, MultiPolygon, Point, Polygon};
 use algorithm::area::Area;
 use algorithm::length::Length;
 
@@ -27,7 +27,8 @@ pub trait Centroid<T: Float> {
 
 // Calculation of simple (no interior holes) Polygon area
 fn simple_polygon_area<T>(linestring: &LineString<T>) -> T
-    where T: Float
+where
+    T: Float,
 {
     if linestring.0.is_empty() || linestring.0.len() == 1 {
         return T::zero();
@@ -41,7 +42,8 @@ fn simple_polygon_area<T>(linestring: &LineString<T>) -> T
 
 // Calculation of a Polygon centroid without interior rings
 fn simple_polygon_centroid<T>(poly_ext: &LineString<T>) -> Option<Point<T>>
-    where T: Float + FromPrimitive
+where
+    T: Float + FromPrimitive,
 {
     let area = simple_polygon_area(poly_ext);
     let mut sum_x = T::zero();
@@ -56,7 +58,8 @@ fn simple_polygon_centroid<T>(poly_ext: &LineString<T>) -> Option<Point<T>>
 }
 
 impl<T> Centroid<T> for Line<T>
-    where T: Float
+where
+    T: Float,
 {
     type Output = Point<T>;
 
@@ -69,7 +72,8 @@ impl<T> Centroid<T> for Line<T>
 }
 
 impl<T> Centroid<T> for LineString<T>
-    where T: Float
+where
+    T: Float,
 {
     type Output = Option<Point<T>>;
 
@@ -98,7 +102,8 @@ impl<T> Centroid<T> for LineString<T>
 }
 
 impl<T> Centroid<T> for Polygon<T>
-    where T: Float + FromPrimitive
+where
+    T: Float + FromPrimitive,
 {
     type Output = Option<Point<T>>;
 
@@ -124,20 +129,20 @@ impl<T> Centroid<T> for Polygon<T>
             if !self.interiors.is_empty() {
                 let external_area = simple_polygon_area(&self.exterior).abs();
                 // accumulate interior Polygons
-                let (totals_x, totals_y, internal_area) =
-                    self.interiors
-                        .iter()
-                        .map(|ring| {
-                                 let area = simple_polygon_area(ring).abs();
-                                 let centroid = simple_polygon_centroid(ring).unwrap();
-                                 ((centroid.x() * area), (centroid.y() * area), area)
-                             })
-                        .fold((T::zero(), T::zero(), T::zero()),
-                              |accum, val| (accum.0 + val.0, accum.1 + val.1, accum.2 + val.2));
-                return Some(Point::new(((external_centroid.x() * external_area) - totals_x) /
-                                       (external_area - internal_area),
-                                       ((external_centroid.y() * external_area) - totals_y) /
-                                       (external_area - internal_area)));
+                let (totals_x, totals_y, internal_area) = self.interiors
+                    .iter()
+                    .map(|ring| {
+                        let area = simple_polygon_area(ring).abs();
+                        let centroid = simple_polygon_centroid(ring).unwrap();
+                        ((centroid.x() * area), (centroid.y() * area), area)
+                    })
+                    .fold((T::zero(), T::zero(), T::zero()), |accum, val| {
+                        (accum.0 + val.0, accum.1 + val.1, accum.2 + val.2)
+                    });
+                return Some(Point::new(
+                    ((external_centroid.x() * external_area) - totals_x) / (external_area - internal_area),
+                    ((external_centroid.y() * external_area) - totals_y) / (external_area - internal_area),
+                ));
             }
             Some(external_centroid)
         }
@@ -145,7 +150,8 @@ impl<T> Centroid<T> for Polygon<T>
 }
 
 impl<T> Centroid<T> for MultiPolygon<T>
-    where T: Float + FromPrimitive
+where
+    T: Float + FromPrimitive,
 {
     type Output = Option<Point<T>>;
 
@@ -171,7 +177,8 @@ impl<T> Centroid<T> for MultiPolygon<T>
 }
 
 impl<T> Centroid<T> for Bbox<T>
-    where T: Float
+where
+    T: Float,
 {
     type Output = Point<T>;
 
@@ -182,7 +189,8 @@ impl<T> Centroid<T> for Bbox<T>
 }
 
 impl<T> Centroid<T> for Point<T>
-    where T: Float
+where
+    T: Float,
 {
     type Output = Point<T>;
 
@@ -193,7 +201,7 @@ impl<T> Centroid<T> for Point<T>
 
 #[cfg(test)]
 mod test {
-    use types::{COORD_PRECISION, Coordinate, Point, Line, LineString, Polygon, MultiPolygon, Bbox};
+    use types::{Bbox, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, COORD_PRECISION};
     use algorithm::centroid::Centroid;
     use algorithm::distance::Distance;
     // Tests: Centroid of LineString
@@ -217,8 +225,10 @@ mod test {
     fn linestring_test() {
         let p = |x| Point(Coordinate { x: x, y: 1. });
         let linestring = LineString(vec![p(1.), p(7.), p(8.), p(9.), p(10.), p(11.)]);
-        assert_eq!(linestring.centroid(),
-                   Some(Point(Coordinate { x: 6., y: 1. })));
+        assert_eq!(
+            linestring.centroid(),
+            Some(Point(Coordinate { x: 6., y: 1. }))
+        );
     }
     // Tests: Centroid of Polygon
     #[test]
@@ -247,25 +257,31 @@ mod test {
     }
     #[test]
     fn polygon_hole_test() {
-        let ls1 = LineString(vec![Point::new(5.0, 1.0),
-                                  Point::new(4.0, 2.0),
-                                  Point::new(4.0, 3.0),
-                                  Point::new(5.0, 4.0),
-                                  Point::new(6.0, 4.0),
-                                  Point::new(7.0, 3.0),
-                                  Point::new(7.0, 2.0),
-                                  Point::new(6.0, 1.0),
-                                  Point::new(5.0, 1.0)]);
+        let ls1 = LineString(vec![
+            Point::new(5.0, 1.0),
+            Point::new(4.0, 2.0),
+            Point::new(4.0, 3.0),
+            Point::new(5.0, 4.0),
+            Point::new(6.0, 4.0),
+            Point::new(7.0, 3.0),
+            Point::new(7.0, 2.0),
+            Point::new(6.0, 1.0),
+            Point::new(5.0, 1.0),
+        ]);
 
-        let ls2 = LineString(vec![Point::new(5.0, 1.3),
-                                  Point::new(5.5, 2.0),
-                                  Point::new(6.0, 1.3),
-                                  Point::new(5.0, 1.3)]);
+        let ls2 = LineString(vec![
+            Point::new(5.0, 1.3),
+            Point::new(5.5, 2.0),
+            Point::new(6.0, 1.3),
+            Point::new(5.0, 1.3),
+        ]);
 
-        let ls3 = LineString(vec![Point::new(5., 2.3),
-                                  Point::new(5.5, 3.0),
-                                  Point::new(6., 2.3),
-                                  Point::new(5., 2.3)]);
+        let ls3 = LineString(vec![
+            Point::new(5., 2.3),
+            Point::new(5.5, 3.0),
+            Point::new(6., 2.3),
+            Point::new(5., 2.3),
+        ]);
 
         let p1 = Polygon::new(ls1, vec![ls2, ls3]);
         let centroid = p1.centroid().unwrap();
@@ -301,7 +317,13 @@ mod test {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(0., 0.), p(2., 0.), p(2., 2.), p(0., 2.), p(0., 0.)]);
         let poly1 = Polygon::new(linestring, Vec::new());
-        let linestring = LineString(vec![p(0., 0.), p(-2., 0.), p(-2., 2.), p(0., 2.), p(0., 0.)]);
+        let linestring = LineString(vec![
+            p(0., 0.),
+            p(-2., 0.),
+            p(-2., 2.),
+            p(0., 2.),
+            p(0., 0.),
+        ]);
         let poly2 = Polygon::new(linestring, Vec::new());
         assert_eq!(MultiPolygon(vec![poly1, poly2]).centroid(), Some(p(0., 1.)));
     }

--- a/src/algorithm/closest_point.rs
+++ b/src/algorithm/closest_point.rs
@@ -47,7 +47,6 @@ impl<F: Float> ClosestPoint<F> for Point<F> {
     }
 }
 
-
 impl<F: Float> ClosestPoint<F> for Line<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
         let line_length = self.length();
@@ -138,7 +137,6 @@ impl<F: Float> ClosestPoint<F> for MultiLineString<F> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -167,7 +165,6 @@ mod tests {
     closest!(intersects: mid_point, (50.0, 50.0));
     closest!(in_line_far_away, (1000.0, 1000.0) => Closest::SinglePoint(Point::new(100.0, 100.0)));
     closest!(perpendicular_from_50_50, (0.0, 100.0) => Closest::SinglePoint(Point::new(50.0, 50.0)));
-
 
     fn collect_points<F, P, C>(points: &[P]) -> C
     where
@@ -279,7 +276,10 @@ mod tests {
     fn polygon_without_rings_and_point_outside_is_same_as_linestring() {
         let poly = holy_polygon();
         let p = Point::new(1000.0, 12345.6789);
-        assert!(!poly.exterior.contains(&p), "`p` should be outside the polygon!");
+        assert!(
+            !poly.exterior.contains(&p),
+            "`p` should be outside the polygon!"
+        );
 
         let poly_closest = poly.closest_point(&p);
         let exterior_closest = poly.exterior.closest_point(&p);

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -123,7 +123,7 @@ impl<T> Contains<Line<T>> for LineString<T>
                 }
             }
         }
-        return false;
+        false
     }
 }
 
@@ -154,17 +154,13 @@ fn get_position<T>(p: &Point<T>, linestring: &LineString<T>) -> PositionPoint
     let mut xints = T::zero();
     let mut crossings = 0;
     for line in linestring.lines() {
-        if p.y() > line.start.y().min(line.end.y()) {
-            if p.y() <= line.start.y().max(line.end.y()) {
-                if p.x() <= line.start.x().max(line.end.x()) {
-                    if line.start.y() != line.end.y() {
-                        xints = (p.y() - line.start.y()) * (line.end.x() - line.start.x()) /
-                                (line.end.y() - line.start.y()) + line.start.x();
-                    }
-                    if (line.start.x() == line.end.x()) || (p.x() <= xints) {
-                        crossings += 1;
-                    }
-                }
+        if p.y() > line.start.y().min(line.end.y()) && p.y() <= line.start.y().max(line.end.y()) && p.x() <= line.start.x().max(line.end.x()) {
+            if line.start.y() != line.end.y() {
+                xints = (p.y() - line.start.y()) * (line.end.x() - line.start.x()) /
+                (line.end.y() - line.start.y()) + line.start.x();
+            }
+            if (line.start.x() == line.end.x()) || (p.x() <= xints) {
+                crossings += 1;
             }
         }
     }
@@ -180,8 +176,7 @@ impl<T> Contains<Point<T>> for Polygon<T>
 {
     fn contains(&self, p: &Point<T>) -> bool {
         match get_position(p, &self.exterior) {
-            PositionPoint::OnBoundary => false,
-            PositionPoint::Outside => false,
+            PositionPoint::OnBoundary | PositionPoint::Outside => false,
             _ => self.interiors.iter().all(|ls| get_position(p, ls) == PositionPoint::Outside),
         }
     }

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -1,6 +1,6 @@
 use num_traits::{Float, ToPrimitive};
 
-use types::{COORD_PRECISION, Point, Line, LineString, Polygon, MultiPolygon, Bbox};
+use types::{Bbox, Line, LineString, MultiPolygon, Point, Polygon, COORD_PRECISION};
 use algorithm::intersects::Intersects;
 use algorithm::distance::Distance;
 
@@ -33,7 +33,8 @@ pub trait Contains<Rhs = Self> {
 }
 
 impl<T> Contains<Point<T>> for Point<T>
-    where T: Float + ToPrimitive
+where
+    T: Float + ToPrimitive,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         self.distance(p).to_f32().unwrap() < COORD_PRECISION
@@ -41,7 +42,8 @@ impl<T> Contains<Point<T>> for Point<T>
 }
 
 impl<T> Contains<Point<T>> for LineString<T>
-    where T: Float
+where
+    T: Float,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         // LineString without points
@@ -57,12 +59,13 @@ impl<T> Contains<Point<T>> for LineString<T>
             return true;
         }
         for line in self.lines() {
-            if ((line.start.y() == line.end.y()) && (line.start.y() == p.y()) &&
-                (p.x() > line.start.x().min(line.end.x())) &&
-                (p.x() < line.start.x().max(line.end.x()))) ||
-               ((line.start.x() == line.end.x()) && (line.start.x() == p.x()) &&
-                (p.y() > line.start.y().min(line.end.y())) &&
-                (p.y() < line.start.y().max(line.end.y()))) {
+            if ((line.start.y() == line.end.y()) && (line.start.y() == p.y())
+                && (p.x() > line.start.x().min(line.end.x()))
+                && (p.x() < line.start.x().max(line.end.x())))
+                || ((line.start.x() == line.end.x()) && (line.start.x() == p.x())
+                    && (p.y() > line.start.y().min(line.end.y()))
+                    && (p.y() < line.start.y().max(line.end.y())))
+            {
                 return true;
             }
         }
@@ -71,7 +74,8 @@ impl<T> Contains<Point<T>> for LineString<T>
 }
 
 impl<T> Contains<Point<T>> for Line<T>
-    where T: Float
+where
+    T: Float,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         self.intersects(p)
@@ -79,15 +83,17 @@ impl<T> Contains<Point<T>> for Line<T>
 }
 
 impl<T> Contains<Line<T>> for Line<T>
-    where T: Float
+where
+    T: Float,
 {
     fn contains(&self, line: &Line<T>) -> bool {
         self.contains(&line.start) & self.contains(&line.end)
     }
 }
 
-impl<T> Contains<LineString<T>> for Line<T> 
-    where T: Float
+impl<T> Contains<LineString<T>> for Line<T>
+where
+    T: Float,
 {
     fn contains(&self, linestring: &LineString<T>) -> bool {
         linestring.0.iter().all(|pt| self.contains(pt))
@@ -95,7 +101,8 @@ impl<T> Contains<LineString<T>> for Line<T>
 }
 
 impl<T> Contains<Line<T>> for LineString<T>
-    where T: Float
+where
+    T: Float,
 {
     fn contains(&self, line: &Line<T>) -> bool {
         let (p0, p1) = (line.start, line.end);
@@ -118,7 +125,7 @@ impl<T> Contains<Line<T>> for LineString<T>
                     return true;
                 } else if !line.contains(&segment.end) {
                     // If not, and the end of the segment is not on the line, we should stop
-                    // looking 
+                    // looking
                     look_for = None
                 }
             }
@@ -135,7 +142,8 @@ enum PositionPoint {
 }
 
 fn get_position<T>(p: &Point<T>, linestring: &LineString<T>) -> PositionPoint
-    where T: Float
+where
+    T: Float,
 {
     // See: http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
     //      http://geospatialpython.com/search
@@ -154,10 +162,12 @@ fn get_position<T>(p: &Point<T>, linestring: &LineString<T>) -> PositionPoint
     let mut xints = T::zero();
     let mut crossings = 0;
     for line in linestring.lines() {
-        if p.y() > line.start.y().min(line.end.y()) && p.y() <= line.start.y().max(line.end.y()) && p.x() <= line.start.x().max(line.end.x()) {
+        if p.y() > line.start.y().min(line.end.y()) && p.y() <= line.start.y().max(line.end.y())
+            && p.x() <= line.start.x().max(line.end.x())
+        {
             if line.start.y() != line.end.y() {
-                xints = (p.y() - line.start.y()) * (line.end.x() - line.start.x()) /
-                (line.end.y() - line.start.y()) + line.start.x();
+                xints = (p.y() - line.start.y()) * (line.end.x() - line.start.x())
+                    / (line.end.y() - line.start.y()) + line.start.x();
             }
             if (line.start.x() == line.end.x()) || (p.x() <= xints) {
                 crossings += 1;
@@ -172,18 +182,22 @@ fn get_position<T>(p: &Point<T>, linestring: &LineString<T>) -> PositionPoint
 }
 
 impl<T> Contains<Point<T>> for Polygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         match get_position(p, &self.exterior) {
             PositionPoint::OnBoundary | PositionPoint::Outside => false,
-            _ => self.interiors.iter().all(|ls| get_position(p, ls) == PositionPoint::Outside),
+            _ => self.interiors
+                .iter()
+                .all(|ls| get_position(p, ls) == PositionPoint::Outside),
         }
     }
 }
 
 impl<T> Contains<Point<T>> for MultiPolygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         self.0.iter().any(|poly| poly.contains(p))
@@ -191,15 +205,14 @@ impl<T> Contains<Point<T>> for MultiPolygon<T>
 }
 
 impl<T> Contains<Line<T>> for Polygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn contains(&self, line: &Line<T>) -> bool {
         // both endpoints are contained in the polygon and the line
         // does NOT intersect the exterior or any of the interior boundaries
-        self.contains(&line.start) &&
-            self.contains(&line.end) &&
-            !self.exterior.intersects(line) &&
-            !self.interiors.iter().any(|inner| inner.intersects(line))
+        self.contains(&line.start) && self.contains(&line.end) && !self.exterior.intersects(line)
+            && !self.interiors.iter().any(|inner| inner.intersects(line))
     }
 }
 
@@ -214,14 +227,17 @@ where
 }
 
 impl<T> Contains<LineString<T>> for Polygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn contains(&self, linestring: &LineString<T>) -> bool {
         // All LineString points must be inside the Polygon
         if linestring.0.iter().all(|point| self.contains(point)) {
             // The Polygon interior is allowed to intersect with the LineString
             // but the Polygon's rings are not
-            !self.interiors.iter().any(|ring| ring.intersects(linestring))
+            !self.interiors
+                .iter()
+                .any(|ring| ring.intersects(linestring))
         } else {
             false
         }
@@ -229,7 +245,8 @@ impl<T> Contains<LineString<T>> for Polygon<T>
 }
 
 impl<T> Contains<Point<T>> for Bbox<T>
-    where T: Float
+where
+    T: Float,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         p.x() >= self.xmin && p.x() <= self.xmax && p.y() >= self.ymin && p.y() <= self.ymax
@@ -237,7 +254,8 @@ impl<T> Contains<Point<T>> for Bbox<T>
 }
 
 impl<T> Contains<Bbox<T>> for Bbox<T>
-    where T: Float
+where
+    T: Float,
 {
     fn contains(&self, bbox: &Bbox<T>) -> bool {
         // All points of LineString must be in the polygon ?
@@ -245,30 +263,72 @@ impl<T> Contains<Bbox<T>> for Bbox<T>
     }
 }
 
-
 #[cfg(test)]
 mod test {
-    use types::{Coordinate, Point, Line, LineString, Polygon, MultiPolygon, Bbox};
+    use types::{Bbox, Coordinate, Line, LineString, MultiPolygon, Point, Polygon};
     use algorithm::contains::Contains;
     #[test]
     // V doesn't contain rect because two of its edges intersect with V's exterior boundary
     fn polygon_does_not_contain_polygon() {
-        let v = Polygon::new(vec![(150., 350.), (100., 350.), (210., 160.), (290., 350.), (250., 350.), (200., 250.), (150., 350.)].into(), vec![]);
-        let rect = Polygon::new(vec![(250., 310.), (150., 310.), (150., 280.), (250., 280.), (250., 310.)].into(), vec![]);
+        let v = Polygon::new(
+            vec![
+                (150., 350.),
+                (100., 350.),
+                (210., 160.),
+                (290., 350.),
+                (250., 350.),
+                (200., 250.),
+                (150., 350.),
+            ].into(),
+            vec![],
+        );
+        let rect = Polygon::new(
+            vec![
+                (250., 310.),
+                (150., 310.),
+                (150., 280.),
+                (250., 280.),
+                (250., 310.),
+            ].into(),
+            vec![],
+        );
         assert_eq!(!v.contains(&rect), true);
     }
     #[test]
     // V contains rect because all its vertices are contained, and none of its edges intersect with V's boundaries
     fn polygon_contains_polygon() {
-        let v = Polygon::new(vec![(150., 350.), (100., 350.), (210., 160.), (290., 350.), (250., 350.), (200., 250.), (150., 350.)].into(), vec![]);
-        let rect = Polygon::new(vec![(185., 237.), (220., 237.), (220., 220.), (185., 220.), (185., 237.)].into(), vec![]);
+        let v = Polygon::new(
+            vec![
+                (150., 350.),
+                (100., 350.),
+                (210., 160.),
+                (290., 350.),
+                (250., 350.),
+                (200., 250.),
+                (150., 350.),
+            ].into(),
+            vec![],
+        );
+        let rect = Polygon::new(
+            vec![
+                (185., 237.),
+                (220., 237.),
+                (220., 220.),
+                (185., 220.),
+                (185., 237.),
+            ].into(),
+            vec![],
+        );
         assert_eq!(v.contains(&rect), true);
     }
     #[test]
     // LineString is fully contained
     fn linestring_fully_contained_in_polygon() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let poly = Polygon::new(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]), vec![]);
+        let poly = Polygon::new(
+            LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
+            vec![],
+        );
         let ls = LineString(vec![Point::new(3.0, 0.5), Point::new(3.0, 3.5)]);
         assert_eq!(poly.contains(&ls), true);
     }
@@ -339,11 +399,13 @@ mod test {
     fn point_polygon_with_inner_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let linestring = LineString(vec![p(0., 0.), p(2., 0.), p(2., 2.), p(0., 2.), p(0., 0.)]);
-        let inner_linestring = LineString(vec![p(0.5, 0.5),
-                                               p(1.5, 0.5),
-                                               p(1.5, 1.5),
-                                               p(0.0, 1.5),
-                                               p(0.0, 0.0)]);
+        let inner_linestring = LineString(vec![
+            p(0.5, 0.5),
+            p(1.5, 0.5),
+            p(1.5, 1.5),
+            p(0.0, 1.5),
+            p(0.0, 0.0),
+        ]);
         let poly = Polygon::new(linestring, vec![inner_linestring]);
         assert!(poly.contains(&p(0.25, 0.25)));
         assert!(!poly.contains(&p(1., 1.)));
@@ -359,10 +421,14 @@ mod test {
     #[test]
     fn empty_multipolygon_two_polygons_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let poly1 = Polygon::new(LineString(vec![p(0., 0.), p(1., 0.), p(1., 1.), p(0., 1.), p(0., 0.)]),
-                                 Vec::new());
-        let poly2 = Polygon::new(LineString(vec![p(2., 0.), p(3., 0.), p(3., 1.), p(2., 1.), p(2., 0.)]),
-                                 Vec::new());
+        let poly1 = Polygon::new(
+            LineString(vec![p(0., 0.), p(1., 0.), p(1., 1.), p(0., 1.), p(0., 0.)]),
+            Vec::new(),
+        );
+        let poly2 = Polygon::new(
+            LineString(vec![p(2., 0.), p(3., 0.), p(3., 1.), p(2., 1.), p(2., 0.)]),
+            Vec::new(),
+        );
         let multipoly = MultiPolygon(vec![poly1, poly2]);
         assert!(multipoly.contains(&Point::new(0.5, 0.5)));
         assert!(multipoly.contains(&Point::new(2.5, 0.5)));
@@ -371,10 +437,20 @@ mod test {
     #[test]
     fn empty_multipolygon_two_polygons_and_inner_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let poly1 = Polygon::new(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
-                                 vec![LineString(vec![p(1., 1.), p(4., 1.), p(4., 4.), p(1., 1.)])]);
-        let poly2 = Polygon::new(LineString(vec![p(9., 0.), p(14., 0.), p(14., 4.), p(9., 4.), p(9., 0.)]),
-                                 Vec::new());
+        let poly1 = Polygon::new(
+            LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
+            vec![LineString(vec![p(1., 1.), p(4., 1.), p(4., 4.), p(1., 1.)])],
+        );
+        let poly2 = Polygon::new(
+            LineString(vec![
+                p(9., 0.),
+                p(14., 0.),
+                p(14., 4.),
+                p(9., 4.),
+                p(9., 0.),
+            ]),
+            Vec::new(),
+        );
 
         let multipoly = MultiPolygon(vec![poly1, poly2]);
         assert!(multipoly.contains(&Point::new(3., 5.)));
@@ -405,16 +481,30 @@ mod test {
     fn linestring_in_inner_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
 
-        let poly = Polygon::new(LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
-                                vec![LineString(vec![p(1., 1.), p(4., 1.), p(4., 4.), p(1., 4.), p(1., 1.)])]);
+        let poly = Polygon::new(
+            LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]),
+            vec![
+                LineString(vec![p(1., 1.), p(4., 1.), p(4., 4.), p(1., 4.), p(1., 1.)]),
+            ],
+        );
         assert!(!poly.contains(&LineString(vec![p(2., 2.), p(3., 3.)])));
         assert!(!poly.contains(&LineString(vec![p(2., 2.), p(2., 5.)])));
         assert!(!poly.contains(&LineString(vec![p(3., 0.5), p(3., 5.)])));
     }
     #[test]
     fn bbox_in_inner_bbox_test() {
-        let bbox_xl = Bbox { xmin: -100., xmax: 100., ymin: -200., ymax: 200.};
-        let bbox_sm = Bbox { xmin: -10., xmax: 10., ymin: -20., ymax: 20.};
+        let bbox_xl = Bbox {
+            xmin: -100.,
+            xmax: 100.,
+            ymin: -200.,
+            ymax: 200.,
+        };
+        let bbox_sm = Bbox {
+            xmin: -10.,
+            xmax: 10.,
+            ymin: -20.,
+            ymax: 20.,
+        };
         assert_eq!(true, bbox_xl.contains(&bbox_sm));
         assert_eq!(false, bbox_sm.contains(&bbox_xl));
     }
@@ -467,7 +557,13 @@ mod test {
     fn line_in_polygon_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
         let line = Line::new(p(0., 1.), p(3., 4.));
-        let linestring0 = LineString(vec![p(-1., 0.), p(5., 0.), p(5., 5.), p(0., 5.), p(-1., 0.)]);
+        let linestring0 = LineString(vec![
+            p(-1., 0.),
+            p(5., 0.),
+            p(5., 5.),
+            p(0., 5.),
+            p(-1., 0.),
+        ]);
         let poly0 = Polygon::new(linestring0, Vec::new());
         let linestring1 = LineString(vec![p(0., 0.), p(0., 2.), p(2., 2.), p(2., 0.), p(0., 0.)]);
         let poly1 = Polygon::new(linestring1, Vec::new());
@@ -478,16 +574,28 @@ mod test {
     fn line_in_linestring_test() {
         let line0 = Line::new(Point::new(1., 1.), Point::new(2., 2.));
         // line0 is completely contained in the second segment
-        let linestring0 = LineString(vec![Point::new(0., 0.5), Point::new(0.5, 0.5),
-                                          Point::new(3., 3.)]);
+        let linestring0 = LineString(vec![
+            Point::new(0., 0.5),
+            Point::new(0.5, 0.5),
+            Point::new(3., 3.),
+        ]);
         // line0 is contained in the last three segments
-        let linestring1 = LineString(vec![Point::new(0., 0.5), Point::new(0.5, 0.5),
-                                          Point::new(1.2, 1.2), Point::new(1.5, 1.5),
-                                          Point::new(3., 3.)]);
+        let linestring1 = LineString(vec![
+            Point::new(0., 0.5),
+            Point::new(0.5, 0.5),
+            Point::new(1.2, 1.2),
+            Point::new(1.5, 1.5),
+            Point::new(3., 3.),
+        ]);
         // line0 endpoints are contained in the linestring, but the fourth point is off the line
-        let linestring2 = LineString(vec![Point::new(0., 0.5), Point::new(0.5, 0.5),
-                                          Point::new(1.2, 1.2), Point::new(1.5, 0.),
-                                          Point::new(2., 2.), Point::new(3., 3.)]);
+        let linestring2 = LineString(vec![
+            Point::new(0., 0.5),
+            Point::new(0.5, 0.5),
+            Point::new(1.2, 1.2),
+            Point::new(1.5, 0.),
+            Point::new(2., 2.),
+            Point::new(3., 3.),
+        ]);
         assert!(linestring0.contains(&line0));
         assert!(linestring1.contains(&line0));
         assert!(!linestring2.contains(&line0));

--- a/src/algorithm/convexhull.rs
+++ b/src/algorithm/convexhull.rs
@@ -1,5 +1,5 @@
 use num_traits::Float;
-use types::{Point, Polygon, MultiPolygon, LineString, MultiPoint, MultiLineString};
+use types::{LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
 use std::mem;
 
 fn swap_remove_to_first<'a, T>(slice: &mut &'a mut [T], idx: usize) -> &'a mut T {
@@ -49,29 +49,37 @@ fn partition<T, F: FnMut(&T) -> bool>(mut slice: &mut [T], mut pred: F) -> usize
 // If it's negative, it will be on the "right" side of AB
 // (when standing on A and looking towards B). If positive, it will be on the left side
 fn cross_prod<T>(p_a: &Point<T>, p_b: &Point<T>, p_c: &Point<T>) -> T
-    where T: Float
+where
+    T: Float,
 {
     (p_b.x() - p_a.x()) * (p_c.y() - p_a.y()) - (p_b.y() - p_a.y()) * (p_c.x() - p_a.x())
 }
 fn point_location<T>(p_a: &Point<T>, p_b: &Point<T>, p_c: &Point<T>) -> bool
-    where T: Float
+where
+    T: Float,
 {
     cross_prod(p_a, p_b, p_c) > T::zero()
 }
 
 // Fast distance between line segment (p_a, p_b), and point p_c
 fn pseudo_distance<T>(p_a: &Point<T>, p_b: &Point<T>, p_c: &Point<T>) -> T
-    where T: Float
+where
+    T: Float,
 {
     let abx = p_b.x() - p_a.x();
     let aby = p_b.y() - p_a.y();
     let dist = abx * (p_a.y() - p_c.y()) - aby * (p_a.x() - p_c.x());
-    if dist < T::zero() { -dist } else { dist }
+    if dist < T::zero() {
+        -dist
+    } else {
+        dist
+    }
 }
 
 // Adapted from http://www.ahristov.com/tutorial/geometry-games/convex-hull.html
 fn quick_hull<T>(mut points: &mut [Point<T>]) -> Vec<Point<T>>
-    where T: Float
+where
+    T: Float,
 {
     // can't build a hull from fewer than four points
     if points.len() < 4 {
@@ -105,7 +113,8 @@ fn quick_hull<T>(mut points: &mut [Point<T>]) -> Vec<Point<T>>
 
 // recursively calculate the convex hull of a subset of points
 fn hull_set<T>(p_a: &Point<T>, p_b: &Point<T>, mut set: &mut [Point<T>], hull: &mut Vec<Point<T>>)
-    where T: Float
+where
+    T: Float,
 {
     if set.is_empty() {
         return;
@@ -156,11 +165,14 @@ pub trait ConvexHull<T> {
     /// let res = poly.convex_hull();
     /// assert_eq!(res.exterior, correct_hull);
     /// ```
-    fn convex_hull(&self) -> Polygon<T> where T: Float;
+    fn convex_hull(&self) -> Polygon<T>
+    where
+        T: Float;
 }
 
 impl<T> ConvexHull<T> for Polygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
         Polygon::new(LineString(quick_hull(&mut self.exterior.0.clone())), vec![])
@@ -168,10 +180,12 @@ impl<T> ConvexHull<T> for Polygon<T>
 }
 
 impl<T> ConvexHull<T> for MultiPolygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
-        let mut aggregated: Vec<Point<T>> = self.0.iter()
+        let mut aggregated: Vec<Point<T>> = self.0
+            .iter()
             .flat_map(|elem| elem.exterior.0.iter().cloned())
             .collect();
         Polygon::new(LineString(quick_hull(&mut aggregated)), vec![])
@@ -179,7 +193,8 @@ impl<T> ConvexHull<T> for MultiPolygon<T>
 }
 
 impl<T> ConvexHull<T> for LineString<T>
-    where T: Float
+where
+    T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
         Polygon::new(LineString(quick_hull(&mut self.0.clone())), vec![])
@@ -187,10 +202,12 @@ impl<T> ConvexHull<T> for LineString<T>
 }
 
 impl<T> ConvexHull<T> for MultiLineString<T>
-    where T: Float
+where
+    T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
-        let mut aggregated: Vec<Point<T>> = self.0.iter()
+        let mut aggregated: Vec<Point<T>> = self.0
+            .iter()
             .flat_map(|elem| elem.0.iter().cloned())
             .collect();
         Polygon::new(LineString(quick_hull(&mut aggregated)), vec![])
@@ -198,7 +215,8 @@ impl<T> ConvexHull<T> for MultiLineString<T>
 }
 
 impl<T> ConvexHull<T> for MultiPoint<T>
-    where T: Float
+where
+    T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
         Polygon::new(LineString(quick_hull(&mut self.0.clone())), vec![])
@@ -212,45 +230,60 @@ mod test {
 
     #[test]
     fn quick_hull_test1() {
-        let mut v = vec![Point::new(0.0, 0.0),
-                         Point::new(4.0, 0.0),
-                         Point::new(4.0, 1.0),
-                         Point::new(1.0, 1.0),
-                         Point::new(1.0, 4.0),
-                         Point::new(0.0, 4.0),
-                         Point::new(0.0, 0.0)];
-        let correct = vec![Point::new(4.0, 0.0),
-                           Point::new(4.0, 1.0),
-                           Point::new(1.0, 4.0),
-                           Point::new(0.0, 4.0),
-                           Point::new(0.0, 0.0),
-                           Point::new(4.0, 0.0)];
+        let mut v = vec![
+            Point::new(0.0, 0.0),
+            Point::new(4.0, 0.0),
+            Point::new(4.0, 1.0),
+            Point::new(1.0, 1.0),
+            Point::new(1.0, 4.0),
+            Point::new(0.0, 4.0),
+            Point::new(0.0, 0.0),
+        ];
+        let correct = vec![
+            Point::new(4.0, 0.0),
+            Point::new(4.0, 1.0),
+            Point::new(1.0, 4.0),
+            Point::new(0.0, 4.0),
+            Point::new(0.0, 0.0),
+            Point::new(4.0, 0.0),
+        ];
         let res = quick_hull(&mut v);
         assert_eq!(res, correct);
     }
     #[test]
     fn quick_hull_test2() {
-        let mut v = vec![Point::new(0.0, 10.0),
-                         Point::new(1.0, 1.0),
-                         Point::new(10.0, 0.0),
-                         Point::new(1.0, -1.0),
-                         Point::new(0.0, -10.0),
-                         Point::new(-1.0, -1.0),
-                         Point::new(-10.0, 0.0),
-                         Point::new(-1.0, 1.0),
-                         Point::new(0.0, 10.0)];
-        let correct = vec![Point::new(0.0, -10.0),
-                           Point::new(10.0, 0.0),
-                           Point::new(0.0, 10.0),
-                           Point::new(-10.0, 0.0),
-                           Point::new(0.0, -10.0)];
+        let mut v = vec![
+            Point::new(0.0, 10.0),
+            Point::new(1.0, 1.0),
+            Point::new(10.0, 0.0),
+            Point::new(1.0, -1.0),
+            Point::new(0.0, -10.0),
+            Point::new(-1.0, -1.0),
+            Point::new(-10.0, 0.0),
+            Point::new(-1.0, 1.0),
+            Point::new(0.0, 10.0),
+        ];
+        let correct = vec![
+            Point::new(0.0, -10.0),
+            Point::new(10.0, 0.0),
+            Point::new(0.0, 10.0),
+            Point::new(-10.0, 0.0),
+            Point::new(0.0, -10.0),
+        ];
         let res = quick_hull(&mut v);
         assert_eq!(res, correct);
     }
     #[test]
     // test whether output is ccw
     fn quick_hull_test_ccw() {
-        let initial = vec![(1.0, 0.0), (2.0, 1.0), (1.75, 1.1), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
+        let initial = vec![
+            (1.0, 0.0),
+            (2.0, 1.0),
+            (1.75, 1.1),
+            (1.0, 2.0),
+            (0.0, 1.0),
+            (1.0, 0.0),
+        ];
         let mut v: Vec<_> = initial.iter().map(|e| Point::new(e.0, e.1)).collect();
         let correct = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
         let v_correct: Vec<_> = correct.iter().map(|e| Point::new(e.0, e.1)).collect();
@@ -261,9 +294,25 @@ mod test {
     // test that output isn't rotated
     fn quick_hull_test_ccw_maintain() {
         // initial input begins at min y, is oriented ccw
-        let initial = vec![(0., 0.), (2., 0.), (2.5, 1.75), (2.3, 1.7), (1.75, 2.5), (1.3, 2.), (0., 2.), (0., 0.)];
+        let initial = vec![
+            (0., 0.),
+            (2., 0.),
+            (2.5, 1.75),
+            (2.3, 1.7),
+            (1.75, 2.5),
+            (1.3, 2.),
+            (0., 2.),
+            (0., 0.),
+        ];
         let mut v: Vec<_> = initial.iter().map(|e| Point::new(e.0, e.1)).collect();
-        let correct = vec![(2.0, 0.0), (2.5, 1.75), (1.75, 2.5), (0.0, 2.0), (0.0, 0.0), (2.0, 0.0)];
+        let correct = vec![
+            (2.0, 0.0),
+            (2.5, 1.75),
+            (1.75, 2.5),
+            (0.0, 2.0),
+            (0.0, 0.0),
+            (2.0, 0.0),
+        ];
         let v_correct: Vec<_> = correct.iter().map(|e| Point::new(e.0, e.1)).collect();
         let res = quick_hull(&mut v);
         assert_eq!(res, v_correct);
@@ -288,21 +337,25 @@ mod test {
     }
     #[test]
     fn quick_hull_multipoint_test() {
-        let v = vec![Point::new(0.0, 10.0),
-                         Point::new(1.0, 1.0),
-                         Point::new(10.0, 0.0),
-                         Point::new(1.0, -1.0),
-                         Point::new(0.0, -10.0),
-                         Point::new(-1.0, -1.0),
-                         Point::new(-10.0, 0.0),
-                         Point::new(-1.0, 1.0),
-                         Point::new(0.0, 10.0)];
+        let v = vec![
+            Point::new(0.0, 10.0),
+            Point::new(1.0, 1.0),
+            Point::new(10.0, 0.0),
+            Point::new(1.0, -1.0),
+            Point::new(0.0, -10.0),
+            Point::new(-1.0, -1.0),
+            Point::new(-10.0, 0.0),
+            Point::new(-1.0, 1.0),
+            Point::new(0.0, 10.0),
+        ];
         let mp = MultiPoint(v);
-        let correct = vec![Point::new(0.0, -10.0),
-                           Point::new(10.0, 0.0),
-                           Point::new(0.0, 10.0),
-                           Point::new(-10.0, 0.0),
-                           Point::new(0.0, -10.0)];
+        let correct = vec![
+            Point::new(0.0, -10.0),
+            Point::new(10.0, 0.0),
+            Point::new(0.0, 10.0),
+            Point::new(-10.0, 0.0),
+            Point::new(0.0, -10.0),
+        ];
         let res = mp.convex_hull();
         assert_eq!(res.exterior.0, correct);
     }
@@ -317,35 +370,52 @@ mod test {
             Point::new(-1.0, -1.0),
             Point::new(-10.0, 0.0),
             Point::new(-1.0, 1.0),
-            Point::new(0.0, 10.0)];
+            Point::new(0.0, 10.0),
+        ];
         let mp = LineString(v);
         let correct = vec![
             Point::new(0.0, -10.0),
             Point::new(10.0, 0.0),
             Point::new(0.0, 10.0),
             Point::new(-10.0, 0.0),
-            Point::new(0.0, -10.0)];
+            Point::new(0.0, -10.0),
+        ];
         let res = mp.convex_hull();
         assert_eq!(res.exterior.0, correct);
     }
     #[test]
     fn quick_hull_multilinestring_test() {
         let v1 = LineString(vec![Point::new(0.0, 0.0), Point::new(1.0, 10.0)]);
-        let v2 = LineString(vec![Point::new(1.0, 10.0), Point::new(2.0, 0.0), Point::new(3.0, 1.0)]);
+        let v2 = LineString(vec![
+            Point::new(1.0, 10.0),
+            Point::new(2.0, 0.0),
+            Point::new(3.0, 1.0),
+        ]);
         let mls = MultiLineString(vec![v1, v2]);
         let correct = vec![
             Point::new(2.0, 0.0),
             Point::new(3.0, 1.0),
             Point::new(1.0, 10.0),
             Point::new(0.0, 0.0),
-            Point::new(2.0, 0.0)];
+            Point::new(2.0, 0.0),
+        ];
         let res = mls.convex_hull();
         assert_eq!(res.exterior.0, correct);
     }
     #[test]
     fn quick_hull_multipolygon_test() {
-        let ls1 = LineString(vec![Point::new(0.0, 0.0), Point::new(1.0, 10.0), Point::new(2.0, 0.0), Point::new(0.0, 0.0)]);
-        let ls2 = LineString(vec![Point::new(3.0, 0.0), Point::new(4.0, 10.0), Point::new(5.0, 0.0), Point::new(3.0, 0.0)]);
+        let ls1 = LineString(vec![
+            Point::new(0.0, 0.0),
+            Point::new(1.0, 10.0),
+            Point::new(2.0, 0.0),
+            Point::new(0.0, 0.0),
+        ]);
+        let ls2 = LineString(vec![
+            Point::new(3.0, 0.0),
+            Point::new(4.0, 10.0),
+            Point::new(5.0, 0.0),
+            Point::new(3.0, 0.0),
+        ]);
         let p1 = Polygon::new(ls1, vec![]);
         let p2 = Polygon::new(ls2, vec![]);
         let mp = MultiPolygon(vec![p1, p2]);
@@ -354,7 +424,7 @@ mod test {
             Point::new(4.0, 10.0),
             Point::new(1.0, 10.0),
             Point::new(0.0, 0.0),
-            Point::new(5.0, 0.0)
+            Point::new(5.0, 0.0),
         ];
         let res = mp.convex_hull();
         assert_eq!(res.exterior.0, correct);

--- a/src/algorithm/convexhull.rs
+++ b/src/algorithm/convexhull.rs
@@ -126,12 +126,12 @@ fn hull_set<T>(p_a: &Point<T>, p_b: &Point<T>, mut set: &mut [Point<T>], hull: &
     // move Point at furthest_point from set into hull
     let furthest_point = swap_remove_to_first(&mut set, furthest_idx);
     // points over PB
-    let last = partition(set, |p| point_location(&furthest_point, p_b, p));
-    hull_set(&furthest_point, p_b, &mut set[..last], hull);
+    let last = partition(set, |p| point_location(furthest_point, p_b, p));
+    hull_set(furthest_point, p_b, &mut set[..last], hull);
     hull.push(*furthest_point);
     // points over AP
-    let last = partition(set, |p| point_location(p_a, &furthest_point, p));
-    hull_set(p_a, &furthest_point, &mut set[..last], hull);
+    let last = partition(set, |p| point_location(p_a, furthest_point, p));
+    hull_set(p_a, furthest_point, &mut set[..last], hull);
 }
 
 pub trait ConvexHull<T> {

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -1,5 +1,5 @@
 use num_traits::{Float, ToPrimitive};
-use types::{Point, Line, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon};
+use types::{Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
 use algorithm::contains::Contains;
 
 /// Returns the distance between two geometries.
@@ -167,12 +167,11 @@ where
 {
     /// Minimum distance from a Point to a MultiPolygon
     fn distance(&self, mpolygon: &MultiPolygon<T>) -> T {
-        mpolygon.0.iter().map(|p| self.distance(p)).fold(
-            T::max_value(),
-            |accum, val| {
-                accum.min(val)
-            },
-        )
+        mpolygon
+            .0
+            .iter()
+            .map(|p| self.distance(p))
+            .fold(T::max_value(), |accum, val| accum.min(val))
     }
 }
 
@@ -192,12 +191,10 @@ where
 {
     /// Minimum distance from a Point to a MultiLineString
     fn distance(&self, mls: &MultiLineString<T>) -> T {
-        mls.0.iter().map(|ls| self.distance(ls)).fold(
-            T::max_value(),
-            |accum, val| {
-                accum.min(val)
-            },
-        )
+        mls.0
+            .iter()
+            .map(|ls| self.distance(ls))
+            .fold(T::max_value(), |accum, val| accum.min(val))
     }
 }
 
@@ -259,8 +256,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use types::{Point, Line, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon};
-    use algorithm::distance::{Distance, line_segment_distance};
+    use types::{Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
+    use algorithm::distance::{line_segment_distance, Distance};
 
     #[test]
     fn line_segment_distance_test() {

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -111,7 +111,7 @@ fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes,
                           Point::new(-T::one(), T::zero())];
     Ok(directions
            .iter()
-           .map(|p| func(&p, &polygon).unwrap())
+           .map(|p| func(p, polygon).unwrap())
            .collect::<Vec<usize>>()
            .into())
 }
@@ -129,7 +129,7 @@ fn polymax_naive_indices<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<usize, ()
             max = i;
         }
     }
-    return Ok(max);
+    Ok(max)
 }
 
 pub trait ExtremeIndices<T: Float + Signed> {

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -1,7 +1,7 @@
 use num_traits::{Float, Signed};
-use types::{Point, Polygon, MultiPoint, MultiPolygon};
+use types::{MultiPoint, MultiPolygon, Point, Polygon};
 use algorithm::convexhull::ConvexHull;
-use types::{Extremes, ExtremePoint};
+use types::{ExtremePoint, Extremes};
 
 // Useful direction vectors, aligned with x and y axes:
 // 1., 0. = largest x
@@ -14,20 +14,23 @@ use types::{Extremes, ExtremePoint};
 // Not currently used, but maybe useful in the future
 #[allow(dead_code)]
 fn up<T>(u: &Point<T>, v: &Point<T>) -> bool
-    where T: Float
+where
+    T: Float,
 {
     u.dot(v) > T::zero()
 }
 
 fn direction_sign<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> T
-    where T: Float
+where
+    T: Float,
 {
     u.dot(&(*vi - *vj))
 }
 
 // true if Vi is above Vj
 fn above<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> bool
-    where T: Float
+where
+    T: Float,
 {
     direction_sign(u, vi, vj) > T::zero()
 }
@@ -36,7 +39,8 @@ fn above<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> bool
 // Not currently used, but maybe useful in the future
 #[allow(dead_code)]
 fn below<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> bool
-    where T: Float
+where
+    T: Float,
 {
     direction_sign(u, vi, vj) < T::zero()
 }
@@ -52,10 +56,12 @@ enum ListSign {
 
 // Wrap-around previous-vertex
 impl<T> Polygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn previous_vertex(&self, current_vertex: &usize) -> usize
-        where T: Float
+    where
+        T: Float,
     {
         (current_vertex + (self.exterior.0.len() - 1) - 1) % (self.exterior.0.len() - 1)
     }
@@ -63,15 +69,17 @@ impl<T> Polygon<T>
 
 // positive implies a -> b -> c is counter-clockwise, negative implies clockwise
 fn cross_prod<T>(p_a: &Point<T>, p_b: &Point<T>, p_c: &Point<T>) -> T
-    where T: Float
+where
+    T: Float,
 {
     (p_b.x() - p_a.x()) * (p_c.y() - p_a.y()) - (p_b.y() - p_a.y()) * (p_c.x() - p_a.x())
 }
 
 // wrapper for extreme-finding function
 fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes, ()>
-    where T: Float + Signed,
-          F: Fn(&Point<T>, &Polygon<T>) -> Result<usize, ()>
+where
+    T: Float + Signed,
+    F: Fn(&Point<T>, &Polygon<T>) -> Result<usize, ()>,
 {
     // For each consecutive pair of edges of the polygon (each triplet of points),
     // compute the z-component of the cross product of the vectors defined by the
@@ -105,21 +113,24 @@ fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes,
     if convex == ListSign::Mixed {
         return Err(());
     }
-    let directions = vec![Point::new(T::zero(), -T::one()),
-                          Point::new(T::one(), T::zero()),
-                          Point::new(T::zero(), T::one()),
-                          Point::new(-T::one(), T::zero())];
+    let directions = vec![
+        Point::new(T::zero(), -T::one()),
+        Point::new(T::one(), T::zero()),
+        Point::new(T::zero(), T::one()),
+        Point::new(-T::one(), T::zero()),
+    ];
     Ok(directions
-           .iter()
-           .map(|p| func(p, polygon).unwrap())
-           .collect::<Vec<usize>>()
-           .into())
+        .iter()
+        .map(|p| func(p, polygon).unwrap())
+        .collect::<Vec<usize>>()
+        .into())
 }
 
 // find a convex, counter-clockwise oriented polygon's maximum vertex in a specified direction
 // u: a direction vector. We're using a point to represent this, which is a hack but works fine
 fn polymax_naive_indices<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<usize, ()>
-    where T: Float
+where
+    T: Float,
 {
     let vertices = &poly.exterior.0;
     let mut max: usize = 0;
@@ -155,7 +166,8 @@ pub trait ExtremeIndices<T: Float + Signed> {
 }
 
 impl<T> ExtremeIndices<T> for Polygon<T>
-    where T: Float + Signed
+where
+    T: Float + Signed,
 {
     fn extreme_indices(&self) -> Result<Extremes, ()> {
         find_extreme_indices(polymax_naive_indices, self)
@@ -163,7 +175,8 @@ impl<T> ExtremeIndices<T> for Polygon<T>
 }
 
 impl<T> ExtremeIndices<T> for MultiPolygon<T>
-    where T: Float + Signed
+where
+    T: Float + Signed,
 {
     fn extreme_indices(&self) -> Result<Extremes, ()> {
         find_extreme_indices(polymax_naive_indices, &self.convex_hull())
@@ -171,7 +184,8 @@ impl<T> ExtremeIndices<T> for MultiPolygon<T>
 }
 
 impl<T> ExtremeIndices<T> for MultiPoint<T>
-    where T: Float + Signed
+where
+    T: Float + Signed,
 {
     fn extreme_indices(&self) -> Result<Extremes, ()> {
         find_extreme_indices(polymax_naive_indices, &self.convex_hull())
@@ -200,8 +214,9 @@ pub trait ExtremePoints<T: Float> {
 }
 
 impl<T, G> ExtremePoints<T> for G
-    where T: Float + Signed,
-          G: ConvexHull<T> + ExtremeIndices<T>
+where
+    T: Float + Signed,
+    G: ConvexHull<T> + ExtremeIndices<T>,
 {
     // Any Geometry implementing `ConvexHull` and `ExtremeIndices` gets this automatically
     fn extreme_points(&self) -> ExtremePoint<T> {
@@ -220,7 +235,7 @@ impl<T, G> ExtremePoints<T> for G
 #[cfg(test)]
 mod test {
 
-    use types::{Point, LineString};
+    use types::{LineString, Point};
     use super::*;
     #[test]
     fn test_polygon_extreme_x() {
@@ -239,13 +254,15 @@ mod test {
     #[should_panic]
     fn test_extreme_indices_bad_polygon() {
         // non-convex, with a bump on the top-right edge
-        let points_raw = vec![(1.0, 0.0),
-                              (1.3, 1.),
-                              (2.0, 1.0),
-                              (1.75, 1.75),
-                              (1.0, 2.0),
-                              (0.0, 1.0),
-                              (1.0, 0.0)];
+        let points_raw = vec![
+            (1.0, 0.0),
+            (1.3, 1.),
+            (2.0, 1.0),
+            (1.75, 1.75),
+            (1.0, 2.0),
+            (0.0, 1.0),
+            (1.0, 0.0),
+        ];
         let points = points_raw
             .iter()
             .map(|e| Point::new(e.0, e.1))
@@ -263,13 +280,15 @@ mod test {
     #[test]
     fn test_extreme_indices_good_polygon() {
         // non-convex, with a bump on the top-right edge
-        let points_raw = vec![(1.0, 0.0),
-                              (1.3, 1.),
-                              (2.0, 1.0),
-                              (1.75, 1.75),
-                              (1.0, 2.0),
-                              (0.0, 1.0),
-                              (1.0, 0.0)];
+        let points_raw = vec![
+            (1.0, 0.0),
+            (1.3, 1.),
+            (2.0, 1.0),
+            (1.75, 1.75),
+            (1.0, 2.0),
+            (0.0, 1.0),
+            (1.0, 0.0),
+        ];
         let points = points_raw
             .iter()
             .map(|e| Point::new(e.0, e.1))
@@ -287,8 +306,14 @@ mod test {
     #[test]
     fn test_polygon_extreme_wrapper_convex() {
         // convex, with a bump on the top-right edge
-        let points_raw =
-            vec![(1.0, 0.0), (2.0, 1.0), (1.75, 1.75), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
+        let points_raw = vec![
+            (1.0, 0.0),
+            (2.0, 1.0),
+            (1.75, 1.75),
+            (1.0, 2.0),
+            (0.0, 1.0),
+            (1.0, 0.0),
+        ];
         let points = points_raw
             .iter()
             .map(|e| Point::new(e.0, e.1))

--- a/src/algorithm/haversine_destination.rs
+++ b/src/algorithm/haversine_destination.rs
@@ -18,7 +18,8 @@ pub trait HaversineDestination<T: Float> {
 }
 
 impl<T> HaversineDestination<T> for Point<T>
-    where T: Float + FromPrimitive
+where
+    T: Float + FromPrimitive,
 {
     fn haversine_destination(&self, bearing: T, distance: T) -> Point<T> {
         let center_lng = self.x().to_radians();
@@ -28,13 +29,8 @@ impl<T> HaversineDestination<T> for Point<T>
         // WGS84 equatorial radius is 6378137.0
         let rad = distance / T::from(6371000.0).unwrap();
 
-        let lat = {
-                center_lat.sin() * rad.cos() + center_lat.cos() * rad.sin() * bearing_rad.cos()
-            }
-            .asin();
-        let lng = {
-                bearing_rad.sin() * rad.sin() * center_lat.cos()
-            }
+        let lat = { center_lat.sin() * rad.cos() + center_lat.cos() * rad.sin() * bearing_rad.cos() }.asin();
+        let lng = { bearing_rad.sin() * rad.sin() * center_lat.cos() }
             .atan2(rad.cos() - center_lat.sin() * lat.sin()) + center_lng;
 
         Point::new(lng.to_degrees(), lat.to_degrees())
@@ -60,10 +56,7 @@ mod test {
     fn direct_and_indirect_destinations_are_close() {
         let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
         let p_2 = p_1.haversine_destination(45., 10000.);
-        let square_edge = {
-                pow(10000., 2) / 2.
-            }
-            .sqrt();
+        let square_edge = { pow(10000., 2) / 2. }.sqrt();
         let p_3 = p_1.haversine_destination(0., square_edge);
         let p_4 = p_3.haversine_destination(90., square_edge);
         assert_relative_eq!(p_4.x(), p_2.x(), epsilon = 1.0e-6);

--- a/src/algorithm/haversine_distance.rs
+++ b/src/algorithm/haversine_distance.rs
@@ -23,7 +23,8 @@ pub trait HaversineDistance<T, Rhs = Self> {
 }
 
 impl<T> HaversineDistance<T, Point<T>> for Point<T>
-    where T: Float + FromPrimitive
+where
+    T: Float + FromPrimitive,
 {
     fn haversine_distance(&self, rhs: &Point<T>) -> T {
         let two = T::one() + T::one();
@@ -31,8 +32,8 @@ impl<T> HaversineDistance<T, Point<T>> for Point<T>
         let theta2 = rhs.y().to_radians();
         let delta_theta = (rhs.y() - self.y()).to_radians();
         let delta_lambda = (rhs.x() - self.x()).to_radians();
-        let a = (delta_theta / two).sin().powi(2) +
-                theta1.cos() * theta2.cos() * (delta_lambda / two).sin().powi(2);
+        let a = (delta_theta / two).sin().powi(2)
+            + theta1.cos() * theta2.cos() * (delta_lambda / two).sin().powi(2);
         let c = two * a.sqrt().asin();
         // WGS84 equatorial radius is 6378137.0
         T::from(6371000.0).unwrap() * c
@@ -48,18 +49,22 @@ mod test {
     fn distance1_test() {
         let a = Point::<f64>::new(0., 0.);
         let b = Point::<f64>::new(1., 0.);
-        assert_relative_eq!(a.haversine_distance(&b),
-                            111194.92664455874_f64,
-                            epsilon = 1.0e-6);
+        assert_relative_eq!(
+            a.haversine_distance(&b),
+            111194.92664455874_f64,
+            epsilon = 1.0e-6
+        );
     }
 
     #[test]
     fn distance2_test() {
         let a = Point::new(-72.1235, 42.3521);
         let b = Point::new(72.1260, 70.612);
-        assert_relative_eq!(a.haversine_distance(&b),
-                            7130570.458772508_f64,
-                            epsilon = 1.0e-6);
+        assert_relative_eq!(
+            a.haversine_distance(&b),
+            7130570.458772508_f64,
+            epsilon = 1.0e-6
+        );
     }
 
     #[test]
@@ -67,9 +72,11 @@ mod test {
         // this input comes from issue #100
         let a = Point::<f64>::new(-77.036585, 38.897448);
         let b = Point::<f64>::new(-77.009080, 38.889825);
-        assert_relative_eq!(a.haversine_distance(&b),
-                            2526.820014113592_f64,
-                            epsilon = 1.0e-6);
+        assert_relative_eq!(
+            a.haversine_distance(&b),
+            2526.820014113592_f64,
+            epsilon = 1.0e-6
+        );
     }
 
     #[test]
@@ -77,8 +84,6 @@ mod test {
         // this input comes from issue #100
         let a = Point::<f32>::new(-77.036585, 38.897448);
         let b = Point::<f32>::new(-77.009080, 38.889825);
-        assert_relative_eq!(a.haversine_distance(&b),
-                            2526.8318_f32,
-                            epsilon = 1.0e-6);
+        assert_relative_eq!(a.haversine_distance(&b), 2526.8318_f32, epsilon = 1.0e-6);
     }
 }

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -82,8 +82,8 @@ impl<T> Intersects<Line<T>> for Line<T>
         if d == T::zero() {
             // lines are parallel
             // return true iff at least one endpoint intersects the other line
-            self.start.intersects(&line) || self.end.intersects(&line) ||
-            line.start.intersects(&self) || line.end.intersects(&self)
+            self.start.intersects(line) || self.end.intersects(line) ||
+            line.start.intersects(self) || line.end.intersects(self)
         } else {
             let s = (c1*b2 - c2*b1) / d;
             let t = (a1*c2 - a2*c1) / d;
@@ -164,10 +164,10 @@ impl<T> Intersects<LineString<T>> for Polygon<T>
     fn intersects(&self, linestring: &LineString<T>) -> bool {
         // line intersects inner or outer polygon edge
         if self.exterior.intersects(linestring) || self.interiors.iter().any(|inner| inner.intersects(linestring)) {
-            return true;
+            true
         } else {
             // or if it's contained in the polygon
-            return linestring.0.iter().any(|point| self.contains(point))
+            linestring.0.iter().any(|point| self.contains(point))
         }
     }
 }
@@ -178,7 +178,7 @@ impl<T> Intersects<Bbox<T>> for Bbox<T>
     fn intersects(&self, bbox: &Bbox<T>) -> bool {
         // line intersects inner or outer polygon edge
         if bbox.contains(self) {
-            return false
+            false
         } else {
             (self.xmin >= bbox.xmin && self.xmin <= bbox.xmax || self.xmax >= bbox.xmin && self.xmax <= bbox.xmax) &&
             (self.ymin >= bbox.ymin && self.ymin <= bbox.ymax || self.ymax >= bbox.ymin && self.ymax <= bbox.ymax)

--- a/src/algorithm/length.rs
+++ b/src/algorithm/length.rs
@@ -24,7 +24,8 @@ pub trait Length<T, RHS = Self> {
 }
 
 impl<T> Length<T> for Line<T>
-    where T: Float
+where
+    T: Float,
 {
     fn length(&self) -> T {
         self.start.distance(&self.end)
@@ -32,7 +33,8 @@ impl<T> Length<T> for Line<T>
 }
 
 impl<T> Length<T> for LineString<T>
-    where T: Float
+where
+    T: Float,
 {
     fn length(&self) -> T {
         self.lines()
@@ -42,16 +44,21 @@ impl<T> Length<T> for LineString<T>
 }
 
 impl<T> Length<T> for MultiLineString<T>
-    where T: Float
+where
+    T: Float,
 {
     fn length(&self) -> T {
-        self.0.iter().fold(T::zero(), |total, line| total + line.length())
+        self.0
+            .iter()
+            .fold(T::zero(), |total, line| {
+                total + line.length()
+            })
     }
 }
 
 #[cfg(test)]
 mod test {
-    use types::{Coordinate, Point, Line, LineString, MultiLineString};
+    use types::{Coordinate, Line, LineString, MultiLineString, Point};
     use algorithm::length::Length;
 
     #[test]
@@ -73,8 +80,17 @@ mod test {
     #[test]
     fn multilinestring_test() {
         let p = |x, y| Point(Coordinate { x: x, y: y });
-        let mline = MultiLineString(vec![LineString(vec![p(1., 0.), p(7., 0.), p(8., 0.), p(9., 0.), p(10., 0.), p(11., 0.)]),
-                                         LineString(vec![p(0., 0.), p(0., 5.)])]);
+        let mline = MultiLineString(vec![
+            LineString(vec![
+                p(1., 0.),
+                p(7., 0.),
+                p(8., 0.),
+                p(9., 0.),
+                p(10., 0.),
+                p(11., 0.),
+            ]),
+            LineString(vec![p(0., 0.), p(0., 5.)]),
+        ]);
         assert_eq!(15.0_f64, mline.length());
     }
     #[test]

--- a/src/algorithm/map_coords.rs
+++ b/src/algorithm/map_coords.rs
@@ -101,6 +101,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Geometry<T> {
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         match *self {
             Geometry::Point(ref x) => Geometry::Point(x.map_coords(func)),
+            Geometry::Line(ref x) => Geometry::Line(x.map_coords(func)),
             Geometry::LineString(ref x) => Geometry::LineString(x.map_coords(func)),
             Geometry::Polygon(ref x) => Geometry::Polygon(x.map_coords(func)),
             Geometry::MultiPoint(ref x) => Geometry::MultiPoint(x.map_coords(func)),

--- a/src/algorithm/map_coords.rs
+++ b/src/algorithm/map_coords.rs
@@ -1,5 +1,6 @@
 use num_traits::Float;
-use types::{Point, Polygon, LineString, Line, MultiPoint, MultiPolygon, MultiLineString, GeometryCollection, Geometry};
+use types::{Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint, MultiPolygon,
+            Point, Polygon};
 
 /// Map all the coordinates in an object, returning a new one
 pub trait MapCoords<T, NT> {
@@ -29,16 +30,15 @@ pub trait MapCoords<T, NT> {
     /// assert_eq!(p2, Point::new(10.0f64, 20.0f64));
     /// ```
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-        where T: Float, NT: Float;
-
-
+    where
+        T: Float,
+        NT: Float;
 }
 
 impl<T: Float, NT: Float> MapCoords<T, NT> for Point<T> {
     type Output = Point<NT>;
 
-    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-    {
+    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         let new_point = func(&(self.0.x, self.0.y));
         Point::new(new_point.0, new_point.1)
     }
@@ -47,8 +47,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Point<T> {
 impl<T: Float, NT: Float> MapCoords<T, NT> for Line<T> {
     type Output = Line<NT>;
 
-    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-    {
+    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         Line::new(self.start.map_coords(func), self.end.map_coords(func))
     }
 }
@@ -56,8 +55,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Line<T> {
 impl<T: Float, NT: Float> MapCoords<T, NT> for LineString<T> {
     type Output = LineString<NT>;
 
-    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-    {
+    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         LineString(self.0.iter().map(|p| p.map_coords(func)).collect())
     }
 }
@@ -65,17 +63,18 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for LineString<T> {
 impl<T: Float, NT: Float> MapCoords<T, NT> for Polygon<T> {
     type Output = Polygon<NT>;
 
-    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-    {
-        Polygon::new(self.exterior.map_coords(func), self.interiors.iter().map(|l| l.map_coords(func)).collect())
+    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
+        Polygon::new(
+            self.exterior.map_coords(func),
+            self.interiors.iter().map(|l| l.map_coords(func)).collect(),
+        )
     }
 }
 
 impl<T: Float, NT: Float> MapCoords<T, NT> for MultiPoint<T> {
     type Output = MultiPoint<NT>;
 
-    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-    {
+    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         MultiPoint(self.0.iter().map(|p| p.map_coords(func)).collect())
     }
 }
@@ -83,8 +82,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for MultiPoint<T> {
 impl<T: Float, NT: Float> MapCoords<T, NT> for MultiLineString<T> {
     type Output = MultiLineString<NT>;
 
-    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-    {
+    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         MultiLineString(self.0.iter().map(|l| l.map_coords(func)).collect())
     }
 }
@@ -92,8 +90,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for MultiLineString<T> {
 impl<T: Float, NT: Float> MapCoords<T, NT> for MultiPolygon<T> {
     type Output = MultiPolygon<NT>;
 
-    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-    {
+    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         MultiPolygon(self.0.iter().map(|p| p.map_coords(func)).collect())
     }
 }
@@ -101,8 +98,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for MultiPolygon<T> {
 impl<T: Float, NT: Float> MapCoords<T, NT> for Geometry<T> {
     type Output = Geometry<NT>;
 
-    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-    {
+    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         match *self {
             Geometry::Point(ref x) => Geometry::Point(x.map_coords(func)),
             Geometry::LineString(ref x) => Geometry::LineString(x.map_coords(func)),
@@ -118,22 +114,20 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Geometry<T> {
 impl<T: Float, NT: Float> MapCoords<T, NT> for GeometryCollection<T> {
     type Output = GeometryCollection<NT>;
 
-    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-    {
+    fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
         GeometryCollection(self.0.iter().map(|g| g.map_coords(func)).collect())
     }
 }
 
-
 mod test {
     #[allow(unused_imports)]
-    
+
     use super::*;
 
     #[test]
     fn point() {
         let p = Point::new(10., 10.);
-        let new_p = p.map_coords(&|&(x, y)| (x+10., y+100.));
+        let new_p = p.map_coords(&|&(x, y)| (x + 10., y + 100.));
         assert_eq!(new_p.x(), 20.);
         assert_eq!(new_p.y(), 110.);
     }
@@ -141,7 +135,8 @@ mod test {
     #[test]
     fn line() {
         let line = Line::new(Point::new(0., 0.), Point::new(1., 2.));
-        assert_eq!(line.map_coords(&|&(x, y)| (x*2., y)),
+        assert_eq!(
+            line.map_coords(&|&(x, y)| (x * 2., y)),
             Line::new(Point::new(0., 0.), Point::new(2., 2.))
         );
     }
@@ -149,25 +144,45 @@ mod test {
     #[test]
     fn linestring() {
         let line1: LineString<f32> = LineString(vec![Point::new(0., 0.), Point::new(1., 2.)]);
-        let line2 = line1.map_coords(&|&(x, y)| (x+10., y-100.));
+        let line2 = line1.map_coords(&|&(x, y)| (x + 10., y - 100.));
         assert_eq!(line2.0[0], Point::new(10., -100.));
         assert_eq!(line2.0[1], Point::new(11., -98.));
     }
 
     #[test]
     fn polygon() {
-        let exterior = LineString(vec![Point::new(0., 0.), Point::new(1., 1.),
-                                       Point::new(1., 0.), Point::new(0., 0.)]);
-        let interiors = vec![LineString(vec![Point::new(0.1, 0.1), Point::new(0.9, 0.9),
-                                             Point::new(0.9, 0.1), Point::new(0.1, 0.1)])];
+        let exterior = LineString(vec![
+            Point::new(0., 0.),
+            Point::new(1., 1.),
+            Point::new(1., 0.),
+            Point::new(0., 0.),
+        ]);
+        let interiors = vec![
+            LineString(vec![
+                Point::new(0.1, 0.1),
+                Point::new(0.9, 0.9),
+                Point::new(0.9, 0.1),
+                Point::new(0.1, 0.1),
+            ]),
+        ];
         let p = Polygon::new(exterior, interiors);
 
-        let p2 = p.map_coords(&|&(x, y)| (x+10., y-100.));
+        let p2 = p.map_coords(&|&(x, y)| (x + 10., y - 100.));
 
-        let exterior2 = LineString(vec![Point::new(10., -100.), Point::new(11., -99.),
-                                       Point::new(11., -100.), Point::new(10., -100.)]);
-        let interiors2 = vec![LineString(vec![Point::new(10.1, -99.9), Point::new(10.9, -99.1),
-                                             Point::new(10.9, -99.9), Point::new(10.1, -99.9)])];
+        let exterior2 = LineString(vec![
+            Point::new(10., -100.),
+            Point::new(11., -99.),
+            Point::new(11., -100.),
+            Point::new(10., -100.),
+        ]);
+        let interiors2 = vec![
+            LineString(vec![
+                Point::new(10.1, -99.9),
+                Point::new(10.9, -99.1),
+                Point::new(10.9, -99.9),
+                Point::new(10.1, -99.9),
+            ]),
+        ];
         let expected_p2 = Polygon::new(exterior2, interiors2);
 
         assert_eq!(p2, expected_p2);
@@ -180,47 +195,101 @@ mod test {
         let mp = MultiPoint(vec![p1, p2]);
 
         assert_eq!(
-            mp.map_coords(&|&(x, y)| (x+10., y+100.)),
+            mp.map_coords(&|&(x, y)| (x + 10., y + 100.)),
             MultiPoint(vec![Point::new(20., 110.), Point::new(10., 0.)])
-            );
+        );
     }
 
     #[test]
     fn multilinestring() {
         let line1: LineString<f32> = LineString(vec![Point::new(0., 0.), Point::new(1., 2.)]);
-        let line2: LineString<f32> = LineString(vec![Point::new(-1., 0.), Point::new(0., 0.), Point::new(1., 2.)]);
+        let line2: LineString<f32> = LineString(vec![
+            Point::new(-1., 0.),
+            Point::new(0., 0.),
+            Point::new(1., 2.),
+        ]);
         let mline = MultiLineString(vec![line1, line2]);
-        let mline2 = mline.map_coords(&|&(x, y)| (x+10., y-100.));
-        assert_eq!(mline2,
+        let mline2 = mline.map_coords(&|&(x, y)| (x + 10., y - 100.));
+        assert_eq!(
+            mline2,
             MultiLineString(vec![
                 LineString(vec![Point::new(10., -100.), Point::new(11., -98.)]),
-                LineString(vec![Point::new(9., -100.), Point::new(10., -100.), Point::new(11., -98.)]),
-                ])
-            );
-
+                LineString(vec![
+                    Point::new(9., -100.),
+                    Point::new(10., -100.),
+                    Point::new(11., -98.),
+                ]),
+            ])
+        );
     }
 
     #[test]
     fn multipolygon() {
-        let poly1 = Polygon::new(LineString(vec![Point::new(0., 0.), Point::new(10., 0.), Point::new(10., 10.), Point::new(0., 10.), Point::new(0., 0.)]), vec![]);
+        let poly1 = Polygon::new(
+            LineString(vec![
+                Point::new(0., 0.),
+                Point::new(10., 0.),
+                Point::new(10., 10.),
+                Point::new(0., 10.),
+                Point::new(0., 0.),
+            ]),
+            vec![],
+        );
         let poly2 = Polygon::new(
-            LineString(vec![Point::new(11., 11.), Point::new(20., 11.), Point::new(20., 20.), Point::new(11., 20.), Point::new(11., 11.)]),
+            LineString(vec![
+                Point::new(11., 11.),
+                Point::new(20., 11.),
+                Point::new(20., 20.),
+                Point::new(11., 20.),
+                Point::new(11., 11.),
+            ]),
             vec![
-                LineString(vec![Point::new(13., 13.), Point::new(13., 17.), Point::new(17., 17.), Point::new(17., 13.), Point::new(13., 13.)])
-            ]);
+                LineString(vec![
+                    Point::new(13., 13.),
+                    Point::new(13., 17.),
+                    Point::new(17., 17.),
+                    Point::new(17., 13.),
+                    Point::new(13., 13.),
+                ]),
+            ],
+        );
 
         let mp = MultiPolygon(vec![poly1, poly2]);
-        let mp2 = mp.map_coords(&|&(x, y)| (x*2., y+100.));
+        let mp2 = mp.map_coords(&|&(x, y)| (x * 2., y + 100.));
         assert_eq!(mp2.0.len(), 2);
-        assert_eq!(mp2.0[0],
-            Polygon::new(LineString(vec![Point::new(0., 100.), Point::new(20., 100.), Point::new(20., 110.), Point::new(0., 110.), Point::new(0., 100.)]), vec![])
+        assert_eq!(
+            mp2.0[0],
+            Polygon::new(
+                LineString(vec![
+                    Point::new(0., 100.),
+                    Point::new(20., 100.),
+                    Point::new(20., 110.),
+                    Point::new(0., 110.),
+                    Point::new(0., 100.),
+                ]),
+                vec![]
+            )
         );
-        assert_eq!(mp2.0[1],
-           Polygon::new(
-            LineString(vec![Point::new(22., 111.), Point::new(40., 111.), Point::new(40., 120.), Point::new(22., 120.), Point::new(22., 111.)]),
-            vec![
-                LineString(vec![Point::new(26., 113.), Point::new(26., 117.), Point::new(34., 117.), Point::new(34., 113.), Point::new(26., 113.)])
-            ])
+        assert_eq!(
+            mp2.0[1],
+            Polygon::new(
+                LineString(vec![
+                    Point::new(22., 111.),
+                    Point::new(40., 111.),
+                    Point::new(40., 120.),
+                    Point::new(22., 120.),
+                    Point::new(22., 111.),
+                ]),
+                vec![
+                    LineString(vec![
+                        Point::new(26., 113.),
+                        Point::new(26., 117.),
+                        Point::new(34., 117.),
+                        Point::new(34., 113.),
+                        Point::new(26., 113.),
+                    ]),
+                ]
+            )
         );
     }
 
@@ -231,14 +300,18 @@ mod test {
 
         let gc = GeometryCollection(vec![p1, line1]);
 
-        assert_eq!(gc.map_coords(&|&(x, y)| (x+10., y+100.)),
+        assert_eq!(
+            gc.map_coords(&|&(x, y)| (x + 10., y + 100.)),
             GeometryCollection(vec![
                 Geometry::Point(Point::new(20., 110.)),
-                Geometry::LineString(LineString(vec![Point::new(10., 100.), Point::new(11., 102.)])),
-                ])
-            );
+                Geometry::LineString(LineString(vec![
+                    Point::new(10., 100.),
+                    Point::new(11., 102.),
+                ])),
+            ])
+        );
     }
-    
+
     #[test]
     fn convert_type() {
         let p1: Point<f64> = Point::new(1., 2.);
@@ -248,4 +321,3 @@ mod test {
     }
 
 }
-

--- a/src/algorithm/map_coords.rs
+++ b/src/algorithm/map_coords.rs
@@ -18,7 +18,7 @@ pub trait MapCoords<T, NT> {
     /// assert_eq!(p2, Point::new(1010., 40.));
     /// ```
     ///
-    /// You can conver the coordinate type this way as well
+    /// You can also change the coordinate precision in this way:
     ///
     /// ```
     /// # use geo::Point;

--- a/src/algorithm/orient.rs
+++ b/src/algorithm/orient.rs
@@ -1,5 +1,5 @@
 use num_traits::Float;
-use types::{LineString, Polygon, MultiPolygon};
+use types::{LineString, MultiPolygon, Polygon};
 
 pub trait Orient<T> {
     /// Orients a Polygon's exterior and interior rings according to convention
@@ -32,7 +32,8 @@ pub trait Orient<T> {
 }
 
 impl<T> Orient<T> for Polygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn orient(&self, direction: Direction) -> Polygon<T> {
         orient(self, direction)
@@ -40,13 +41,11 @@ impl<T> Orient<T> for Polygon<T>
 }
 
 impl<T> Orient<T> for MultiPolygon<T>
-    where T: Float
+where
+    T: Float,
 {
     fn orient(&self, direction: Direction) -> MultiPolygon<T> {
-        MultiPolygon(self.0
-                         .iter()
-                         .map(|poly| poly.orient(direction))
-                         .collect())
+        MultiPolygon(self.0.iter().map(|poly| poly.orient(direction)).collect())
     }
 }
 
@@ -63,7 +62,8 @@ pub enum Direction {
 
 // the signed area of a linear ring
 fn signed_ring_area<T>(linestring: &LineString<T>) -> T
-    where T: Float
+where
+    T: Float,
 {
     if linestring.0.is_empty() || linestring.0.len() == 1 {
         return T::zero();
@@ -79,7 +79,8 @@ fn signed_ring_area<T>(linestring: &LineString<T>) -> T
 // by default, the exterior ring will be oriented ccw
 // and the interior ring(s) will be oriented clockwise
 fn orient<T>(poly: &Polygon<T>, direction: Direction) -> Polygon<T>
-    where T: Float
+where
+    T: Float,
 {
     let sign = match direction {
         Direction::Default => T::one(),
@@ -104,7 +105,7 @@ fn orient<T>(poly: &Polygon<T>, direction: Direction) -> Polygon<T>
 
 #[cfg(test)]
 mod test {
-    use types::{Polygon, LineString, Point};
+    use types::{LineString, Point, Polygon};
     use super::*;
     #[test]
     fn test_polygon_orientation() {
@@ -123,16 +124,20 @@ mod test {
         let poly1 = Polygon::new(LineString(points_ext), vec![LineString(points_int)]);
         // a diamond shape, oriented counter-clockwise outside,
         let oriented_ext = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
-        let oriented_ext_ls = LineString(oriented_ext
-                                             .iter()
-                                             .map(|e| Point::new(e.0, e.1))
-                                             .collect::<Vec<_>>());
+        let oriented_ext_ls = LineString(
+            oriented_ext
+                .iter()
+                .map(|e| Point::new(e.0, e.1))
+                .collect::<Vec<_>>(),
+        );
         // clockwise interior
         let oriented_int_raw = vec![(1.0, 0.5), (0.5, 1.0), (1.0, 1.5), (1.5, 1.0), (1.0, 0.5)];
-        let oriented_int_ls = LineString(oriented_int_raw
-                                             .iter()
-                                             .map(|e| Point::new(e.0, e.1))
-                                             .collect::<Vec<_>>());
+        let oriented_int_ls = LineString(
+            oriented_int_raw
+                .iter()
+                .map(|e| Point::new(e.0, e.1))
+                .collect::<Vec<_>>(),
+        );
         // build corrected Polygon
         let oriented = orient(&poly1, Direction::Default);
         assert_eq!(oriented.exterior.0, oriented_ext_ls.0);

--- a/src/algorithm/orient.rs
+++ b/src/algorithm/orient.rs
@@ -88,14 +88,14 @@ fn orient<T>(poly: &Polygon<T>, direction: Direction) -> Polygon<T>
     let mut rings = vec![];
     // process interiors first, so push and pop work
     for ring in &poly.interiors {
-        if signed_ring_area(&ring) / sign <= T::zero() {
-            rings.push(LineString(ring.0.iter().cloned().collect()));
+        if signed_ring_area(ring) / sign <= T::zero() {
+            rings.push(LineString(ring.0.to_vec()));
         } else {
             rings.push(LineString(ring.0.iter().rev().cloned().collect()));
         }
     }
     if signed_ring_area(&poly.exterior) / sign >= T::zero() {
-        rings.push(LineString(poly.exterior.0.iter().cloned().collect()));
+        rings.push(LineString(poly.exterior.0.to_vec()));
     } else {
         rings.push(LineString(poly.exterior.0.iter().rev().cloned().collect()));
     }

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -141,9 +141,10 @@ where
     /// Rotate the Polygon about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
         // if a polygon has holes, use the centroid of its outer shell as the rotation origin
-        let centroid = match self.interiors.is_empty() {
-            false => self.exterior.centroid().unwrap(),
-            true => self.centroid().unwrap(),
+        let centroid = if self.interiors.is_empty() {
+            self.centroid().unwrap()
+        } else {
+            self.exterior.centroid().unwrap()
         };
         Polygon::new(
             LineString(rotation_matrix(angle, &centroid, &self.exterior.0)),

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -1,5 +1,5 @@
 use num_traits::{Float, FromPrimitive};
-use types::{Point, Line, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString};
+use types::{Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
 use algorithm::centroid::Centroid;
 use algorithm::map_coords::MapCoords;
 
@@ -150,9 +150,7 @@ where
             LineString(rotation_matrix(angle, &centroid, &self.exterior.0)),
             self.interiors
                 .iter()
-                .map(|ring| {
-                    LineString(rotation_matrix(angle, &centroid, &ring.0))
-                })
+                .map(|ring| LineString(rotation_matrix(angle, &centroid, &ring.0)))
                 .collect(),
         )
     }
@@ -190,7 +188,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use types::{Point, LineString, Polygon};
+    use types::{LineString, Point, Polygon};
     use super::*;
     #[test]
     fn test_rotate_around_point() {

--- a/src/algorithm/simplifyvw.rs
+++ b/src/algorithm/simplifyvw.rs
@@ -395,8 +395,6 @@ where
         let cb = c.to;
         if ca != point_a && ca != point_c && cb != point_a && cb != point_c && cartesian_intersect(&ca, &cb, &point_a, &point_c) {
             true
-        } else if ca != point_a && ca != point_b && cb != point_a && cb != point_b && cartesian_intersect(&ca, &cb, &point_a, &point_b) {
-            true
         } else {
             ca != point_b && ca != point_c && cb != point_b && cb != point_c && cartesian_intersect(&ca, &cb, &point_b, &point_c)
         }
@@ -509,7 +507,7 @@ where
             min_points: 4,
             geomtype: GeomType::Line,
         };
-        let mut simplified = vwp_wrapper(&gt, &self, None, epsilon);
+        let mut simplified = vwp_wrapper(&gt, self, None, epsilon);
         LineString(simplified.pop().unwrap())
     }
 }

--- a/src/algorithm/simplifyvw.rs
+++ b/src/algorithm/simplifyvw.rs
@@ -190,7 +190,12 @@ where
 /// Wrap the actual VW function so the R* Tree can be shared.
 // this ensures that shell and rings have access to all segments, so
 // intersections between outer and inner rings are detected
-fn vwp_wrapper<T>(geomtype: &GeomSettings, exterior: &LineString<T>, interiors: Option<&[LineString<T>]>, epsilon: &T) -> Vec<Vec<Point<T>>>
+fn vwp_wrapper<T>(
+    geomtype: &GeomSettings,
+    exterior: &LineString<T>,
+    interiors: Option<&[LineString<T>]>,
+    epsilon: &T,
+) -> Vec<Vec<Point<T>>>
 where
     T: Float + SpadeFloat,
 {
@@ -227,7 +232,12 @@ where
 
 /// Visvalingam-Whyatt with self-intersection detection to preserve topologies
 // this is a port of the technique at https://www.jasondavies.com/simplify/
-fn visvalingam_preserve<T>(geomtype: &GeomSettings, orig: &[Point<T>], epsilon: &T, tree: &mut RTree<SimpleEdge<Point<T>>>) -> Vec<Point<T>>
+fn visvalingam_preserve<T>(
+    geomtype: &GeomSettings,
+    orig: &[Point<T>],
+    epsilon: &T,
+    tree: &mut RTree<SimpleEdge<Point<T>>>,
+) -> Vec<Point<T>>
 where
     T: Float + SpadeFloat,
 {
@@ -393,10 +403,13 @@ where
         // triangle start point, end point
         let ca = c.from;
         let cb = c.to;
-        if ca != point_a && ca != point_c && cb != point_a && cb != point_c && cartesian_intersect(&ca, &cb, &point_a, &point_c) {
+        if ca != point_a && ca != point_c && cb != point_a && cb != point_c
+            && cartesian_intersect(&ca, &cb, &point_a, &point_c)
+        {
             true
         } else {
-            ca != point_b && ca != point_c && cb != point_b && cb != point_c && cartesian_intersect(&ca, &cb, &point_b, &point_c)
+            ca != point_b && ca != point_c && cb != point_b && cb != point_c
+                && cartesian_intersect(&ca, &cb, &point_b, &point_c)
         }
     })
 }
@@ -406,7 +419,8 @@ fn area<T>(p1: &Point<T>, p2: &Point<T>, p3: &Point<T>) -> T
 where
     T: Float,
 {
-    ((p1.x() - p3.x()) * (p2.y() - p3.y()) - (p2.x() - p3.x()) * (p1.y() - p3.y())).abs() / (T::one() + T::one()).abs()
+    ((p1.x() - p3.x()) * (p2.y() - p3.y()) - (p2.x() - p3.x()) * (p1.y() - p3.y())).abs()
+        / (T::one() + T::one()).abs()
 }
 
 /// Simplifies a geometry.
@@ -602,7 +616,8 @@ where
 #[cfg(test)]
 mod test {
     use types::{LineString, MultiLineString, MultiPolygon, Point, Polygon};
-    use super::{cartesian_intersect, visvalingam, vwp_wrapper, GeomSettings, GeomType, SimplifyVW, SimplifyVWPreserve};
+    use super::{cartesian_intersect, visvalingam, vwp_wrapper, GeomSettings, GeomType, SimplifyVW,
+                SimplifyVWPreserve};
 
     #[test]
     fn visvalingam_test() {

--- a/src/algorithm/translate.rs
+++ b/src/algorithm/translate.rs
@@ -2,126 +2,149 @@ use num_traits::Float;
 use algorithm::map_coords::MapCoords;
 
 pub trait Translate<T> {
-    /// Translate a Geometry along its axes by the given offsets
-    ///
-    ///
-    /// ```
-    /// use geo::{Point, LineString};
-    /// use geo::algorithm::translate::{Translate};
-    ///
-    /// let mut vec = Vec::new();
-    /// vec.push(Point::new(0.0, 0.0));
-    /// vec.push(Point::new(5.0, 5.0));
-    /// vec.push(Point::new(10.0, 10.0));
-    /// let linestring = LineString(vec);
-    /// let translated = linestring.translate(1.5, 3.5);
-    /// let mut correct = Vec::new();
-    /// correct.push(Point::new(1.5, 3.5));
-    /// correct.push(Point::new(6.5, 8.5));
-    /// correct.push(Point::new(11.5, 13.5));
-    /// let correct_ls = LineString(correct);
-    /// assert_eq!(translated, correct_ls);
-    /// ```
-    fn translate(&self, xoff: T, yoff: T) -> Self where T: Float;
+  /// Translate a Geometry along its axes by the given offsets
+  ///
+  ///
+  /// ```
+  /// use geo::{Point, LineString};
+  /// use geo::algorithm::translate::{Translate};
+  ///
+  /// let mut vec = Vec::new();
+  /// vec.push(Point::new(0.0, 0.0));
+  /// vec.push(Point::new(5.0, 5.0));
+  /// vec.push(Point::new(10.0, 10.0));
+  /// let linestring = LineString(vec);
+  /// let translated = linestring.translate(1.5, 3.5);
+  /// let mut correct = Vec::new();
+  /// correct.push(Point::new(1.5, 3.5));
+  /// correct.push(Point::new(6.5, 8.5));
+  /// correct.push(Point::new(11.5, 13.5));
+  /// let correct_ls = LineString(correct);
+  /// assert_eq!(translated, correct_ls);
+  /// ```
+  fn translate(&self, xoff: T, yoff: T) -> Self
+  where
+    T: Float;
 }
 
 impl<T, G> Translate<T> for G
-    where T: Float,
-        G: MapCoords<T, T, Output=G>
+where
+  T: Float,
+  G: MapCoords<T, T, Output = G>,
 {
-    fn translate(&self, xoff: T, yoff: T) -> Self {
-        self.map_coords(&|&(x, y)| (x + xoff, y + yoff))
-    }
+  fn translate(&self, xoff: T, yoff: T) -> Self {
+    self.map_coords(&|&(x, y)| (x + xoff, y + yoff))
+  }
 }
 
 #[cfg(test)]
 mod test {
-    use types::{Point, LineString, Polygon};
-    use super::*;
-    #[test]
-    fn test_translate_point() {
-        let p = Point::new(1.0, 5.0);
-        let translated = p.translate(30.0, 20.0);
-        assert_eq!(translated, Point::new(31.0, 25.0));
-    }
-    #[test]
-    fn test_translate_linestring() {
-        let mut vec = Vec::new();
-        vec.push(Point::new(0.0, 0.0));
-        vec.push(Point::new(5.0, 1.0));
-        vec.push(Point::new(10.0, 0.0));
-        let linestring = LineString(vec);
-        let translated = linestring.translate(17.0, 18.0);
-        let mut correct = Vec::new();
-        correct.push(Point::new(17.0, 18.0));
-        correct.push(Point::new(22.0, 19.0));
-        correct.push(Point::new(27., 18.));
-        let correct_ls = LineString(correct);
-        assert_eq!(translated, correct_ls);
-    }
-    #[test]
-    fn test_translate_polygon() {
-        let points_raw = vec![(5., 1.), (4., 2.), (4., 3.), (5., 4.), (6., 4.), (7., 3.),
-                              (7., 2.), (6., 1.), (5., 1.)];
-        let points = points_raw
-            .iter()
-            .map(|e| Point::new(e.0, e.1))
-            .collect::<Vec<_>>();
-        let poly1 = Polygon::new(LineString(points), vec![]);
-        let translated = poly1.translate(17.0, 18.0);
-        let correct_outside = vec![(22.0, 19.0),
-                                 (21.0, 20.0),
-                                 (21.0, 21.0),
-                                 (22.0, 22.0),
-                                 (23.0, 22.0),
-                                 (24.0, 21.0),
-                                 (24.0, 20.0),
-                                 (23.0, 19.0),
-                                 (22.0, 19.0)];
-        let correct = Polygon::new(LineString(correct_outside
-                                                  .iter()
-                                                  .map(|e| Point::new(e.0, e.1))
-                                                  .collect::<Vec<_>>()),
-                                   vec![]);
-        // results agree with Shapely / GEOS
-        assert_eq!(translated, correct);
-    }
-    #[test]
-    fn test_rotate_polygon_holes() {
-        let ls1 = LineString(vec![Point::new(5.0, 1.0),
-                                  Point::new(4.0, 2.0),
-                                  Point::new(4.0, 3.0),
-                                  Point::new(5.0, 4.0),
-                                  Point::new(6.0, 4.0),
-                                  Point::new(7.0, 3.0),
-                                  Point::new(7.0, 2.0),
-                                  Point::new(6.0, 1.0),
-                                  Point::new(5.0, 1.0)]);
+  use types::{LineString, Point, Polygon};
+  use super::*;
+  #[test]
+  fn test_translate_point() {
+    let p = Point::new(1.0, 5.0);
+    let translated = p.translate(30.0, 20.0);
+    assert_eq!(translated, Point::new(31.0, 25.0));
+  }
+  #[test]
+  fn test_translate_linestring() {
+    let mut vec = Vec::new();
+    vec.push(Point::new(0.0, 0.0));
+    vec.push(Point::new(5.0, 1.0));
+    vec.push(Point::new(10.0, 0.0));
+    let linestring = LineString(vec);
+    let translated = linestring.translate(17.0, 18.0);
+    let mut correct = Vec::new();
+    correct.push(Point::new(17.0, 18.0));
+    correct.push(Point::new(22.0, 19.0));
+    correct.push(Point::new(27., 18.));
+    let correct_ls = LineString(correct);
+    assert_eq!(translated, correct_ls);
+  }
+  #[test]
+  fn test_translate_polygon() {
+    let points_raw = vec![
+      (5., 1.),
+      (4., 2.),
+      (4., 3.),
+      (5., 4.),
+      (6., 4.),
+      (7., 3.),
+      (7., 2.),
+      (6., 1.),
+      (5., 1.),
+    ];
+    let points = points_raw
+      .iter()
+      .map(|e| Point::new(e.0, e.1))
+      .collect::<Vec<_>>();
+    let poly1 = Polygon::new(LineString(points), vec![]);
+    let translated = poly1.translate(17.0, 18.0);
+    let correct_outside = vec![
+      (22.0, 19.0),
+      (21.0, 20.0),
+      (21.0, 21.0),
+      (22.0, 22.0),
+      (23.0, 22.0),
+      (24.0, 21.0),
+      (24.0, 20.0),
+      (23.0, 19.0),
+      (22.0, 19.0),
+    ];
+    let correct = Polygon::new(
+      LineString(
+        correct_outside
+          .iter()
+          .map(|e| Point::new(e.0, e.1))
+          .collect::<Vec<_>>(),
+      ),
+      vec![],
+    );
+    // results agree with Shapely / GEOS
+    assert_eq!(translated, correct);
+  }
+  #[test]
+  fn test_rotate_polygon_holes() {
+    let ls1 = LineString(vec![
+      Point::new(5.0, 1.0),
+      Point::new(4.0, 2.0),
+      Point::new(4.0, 3.0),
+      Point::new(5.0, 4.0),
+      Point::new(6.0, 4.0),
+      Point::new(7.0, 3.0),
+      Point::new(7.0, 2.0),
+      Point::new(6.0, 1.0),
+      Point::new(5.0, 1.0),
+    ]);
 
-        let ls2 = LineString(vec![Point::new(5.0, 1.3),
-                                  Point::new(5.5, 2.0),
-                                  Point::new(6.0, 1.3),
-                                  Point::new(5.0, 1.3)]);
+    let ls2 = LineString(vec![
+      Point::new(5.0, 1.3),
+      Point::new(5.5, 2.0),
+      Point::new(6.0, 1.3),
+      Point::new(5.0, 1.3),
+    ]);
 
-        let poly1 = Polygon::new(ls1, vec![ls2]);
-        let rotated = poly1.translate(17.0, 18.0);
-        let correct_outside = vec![(22.0, 19.0),
-                                    (21.0, 20.0),
-                                    (21.0, 21.0),
-                                    (22.0, 22.0),
-                                    (23.0, 22.0),
-                                    (24.0, 21.0),
-                                    (24.0, 20.0),
-                                    (23.0, 19.0),
-                                    (22.0, 19.0)]
-                .iter()
-                .map(|e| Point::new(e.0, e.1))
-                .collect::<Vec<_>>();
-        let correct_inside = vec![(22.0, 19.3), (22.5, 20.0), (23.0, 19.3), (22.0, 19.3)]
-                .iter()
-                .map(|e| Point::new(e.0, e.1))
-                .collect::<Vec<_>>();
-        assert_eq!(rotated.exterior.0, correct_outside);
-        assert_eq!(rotated.interiors[0].0, correct_inside);
-    }
+    let poly1 = Polygon::new(ls1, vec![ls2]);
+    let rotated = poly1.translate(17.0, 18.0);
+    let correct_outside = vec![
+      (22.0, 19.0),
+      (21.0, 20.0),
+      (21.0, 21.0),
+      (22.0, 22.0),
+      (23.0, 22.0),
+      (24.0, 21.0),
+      (24.0, 20.0),
+      (23.0, 19.0),
+      (22.0, 19.0),
+    ].iter()
+      .map(|e| Point::new(e.0, e.1))
+      .collect::<Vec<_>>();
+    let correct_inside = vec![(22.0, 19.3), (22.5, 20.0), (23.0, 19.3), (22.0, 19.3)]
+      .iter()
+      .map(|e| Point::new(e.0, e.1))
+      .collect::<Vec<_>>();
+    assert_eq!(rotated.exterior.0, correct_outside);
+    assert_eq!(rotated.interiors[0].0, correct_inside);
+  }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,7 @@
-pub use ::Geometry;
+pub use Geometry;
 
 use num_traits::Float;
 
-pub trait ToGeo<T: Float>
-{
+pub trait ToGeo<T: Float> {
     fn to_geo(&self) -> Geometry<T>;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -689,7 +689,7 @@ where
 ///
 /// Can be created from a `Vec` of `Polygon`s, or `collect`ed from an Iterator which yields `Polygon`s.
 ///
-/// Iterating over this objects, yields the component Polygons.
+/// Iterating over this object yields the component Polygons.
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct MultiPolygon<T>(pub Vec<Polygon<T>>)
 where

--- a/src/types.rs
+++ b/src/types.rs
@@ -749,7 +749,7 @@ impl<T: Float> IntoIterator for GeometryCollection<T> {
 
 /// An enum representing any possible geometry type.
 ///
-/// All types can be converted to a `Geometry` using the `.into()` (as part of the
+/// All `Geo` types can be converted to a `Geometry` member using `.into()` (as part of the
 /// `std::convert::Into` pattern).
 #[derive(PartialEq, Clone, Debug)]
 pub enum Geometry<T>
@@ -757,6 +757,7 @@ where
     T: Float,
 {
     Point(Point<T>),
+    Line(Line<T>),
     LineString(LineString<T>),
     Polygon(Polygon<T>),
     MultiPoint(MultiPoint<T>),

--- a/src/types.rs
+++ b/src/types.rs
@@ -466,7 +466,7 @@ impl<T> Line<T>
 
 /// An ordered collection of two or more [`Point`s](struct.Point.html), representing a path between locations
 ///
-/// Create a LineString by calling it directly:
+/// Create a `LineString` by calling it directly:
 ///
 /// ```
 /// use geo::{LineString, Point};
@@ -562,9 +562,9 @@ impl<T: Float> IntoIterator for LineString<T> {
 
 /// A collection of [`LineString`s](struct.LineString.html)
 ///
-/// Can be created from a `Vec` of `LineString`s, or from an Iterator which yields LineStrings.
+/// Can be created from a `Vec` of `LineString`s, or from an Iterator which yields `LineString`s.
 ///
-/// Iterating over this objects, yields the component LineStrings.
+/// Iterating over this objects, yields the component `LineString`s.
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct MultiLineString<T>(pub Vec<LineString<T>>) where T: Float;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,19 +5,19 @@ use std::ops::Sub;
 
 use std::fmt::Debug;
 
-use std::iter::{self, Iterator, FromIterator};
+use std::iter::{self, FromIterator, Iterator};
 
 use num_traits::{Float, ToPrimitive};
 use spade::SpadeNum;
 use spade::{PointN, TwoDimensional};
-
 
 pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
 
 /// A primitive type which holds `x` and `y` position information
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Coordinate<T>
-    where T: Float
+where
+    T: Float,
 {
     pub x: T,
     pub y: T,
@@ -25,14 +25,18 @@ pub struct Coordinate<T>
 
 impl<T: Float> From<(T, T)> for Coordinate<T> {
     fn from(coords: (T, T)) -> Self {
-        Coordinate{ x: coords.0, y: coords.1 }
+        Coordinate {
+            x: coords.0,
+            y: coords.1,
+        }
     }
 }
 
 /// A container for the bounding box of a [`Geometry`](enum.Geometry.html)
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Bbox<T>
-    where T: Float
+where
+    T: Float,
 {
     pub xmin: T,
     pub xmax: T,
@@ -63,8 +67,9 @@ impl From<Vec<usize>> for Extremes {
 /// A container for the coordinates of the minimum and maximum points of a [`Geometry`](enum.Geometry.html)
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct ExtremePoint<T>
-    where T: Float
- {
+where
+    T: Float,
+{
     pub ymin: Point<T>,
     pub xmax: Point<T>,
     pub ymax: Point<T>,
@@ -82,7 +87,9 @@ pub struct ExtremePoint<T>
 /// let p2: Point<f64> = c.into();
 /// ```
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
-pub struct Point<T> (pub Coordinate<T>) where T: Float;
+pub struct Point<T>(pub Coordinate<T>)
+where
+    T: Float;
 
 impl<T: Float> From<Coordinate<T>> for Point<T> {
     fn from(x: Coordinate<T>) -> Point<T> {
@@ -97,7 +104,8 @@ impl<T: Float> From<(T, T)> for Point<T> {
 }
 
 impl<T> Point<T>
-    where T: Float + ToPrimitive
+where
+    T: Float + ToPrimitive,
 {
     /// Creates a new point.
     ///
@@ -245,7 +253,8 @@ impl<T> Point<T>
 }
 
 impl<T> Neg for Point<T>
-    where T: Float + Neg<Output = T> + ToPrimitive
+where
+    T: Float + Neg<Output = T> + ToPrimitive,
 {
     type Output = Point<T>;
 
@@ -265,7 +274,8 @@ impl<T> Neg for Point<T>
 }
 
 impl<T> Add for Point<T>
-    where T: Float + ToPrimitive
+where
+    T: Float + ToPrimitive,
 {
     type Output = Point<T>;
 
@@ -285,7 +295,8 @@ impl<T> Add for Point<T>
 }
 
 impl<T> Sub for Point<T>
-    where T: Float + ToPrimitive
+where
+    T: Float + ToPrimitive,
 {
     type Output = Point<T>;
 
@@ -306,7 +317,8 @@ impl<T> Sub for Point<T>
 
 // These are required for Spade RTree
 impl<T> PointN for Point<T>
-    where T: Float + SpadeNum + Debug
+where
+    T: Float + SpadeNum + Debug,
 {
     type Scalar = T;
 
@@ -320,23 +332,27 @@ impl<T> PointN for Point<T>
         match index {
             0 => &self.0.x,
             1 => &self.0.y,
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
     fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
         match index {
             0 => &mut self.0.x,
             1 => &mut self.0.y,
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 }
 
 impl<T> TwoDimensional for Point<T>
-where T: Float + SpadeNum + Debug {}
+where
+    T: Float + SpadeNum + Debug,
+{
+}
 
 impl<T> Add for Bbox<T>
-    where T: Float + ToPrimitive
+where
+    T: Float + ToPrimitive,
 {
     type Output = Bbox<T>;
 
@@ -355,17 +371,34 @@ impl<T> Add for Bbox<T>
     /// assert_eq!(1000., bbox.ymax);
     /// ```
     fn add(self, rhs: Bbox<T>) -> Bbox<T> {
-        Bbox{
-            xmin: if self.xmin <= rhs.xmin {self.xmin} else {rhs.xmin},
-            xmax: if self.xmax >= rhs.xmax {self.xmax} else {rhs.xmax},
-            ymin: if self.ymin <= rhs.ymin {self.ymin} else {rhs.ymin},
-            ymax: if self.ymax >= rhs.ymax {self.ymax} else {rhs.ymax},
+        Bbox {
+            xmin: if self.xmin <= rhs.xmin {
+                self.xmin
+            } else {
+                rhs.xmin
+            },
+            xmax: if self.xmax >= rhs.xmax {
+                self.xmax
+            } else {
+                rhs.xmax
+            },
+            ymin: if self.ymin <= rhs.ymin {
+                self.ymin
+            } else {
+                rhs.ymin
+            },
+            ymax: if self.ymax >= rhs.ymax {
+                self.ymax
+            } else {
+                rhs.ymax
+            },
         }
     }
 }
 
 impl<T> AddAssign for Bbox<T>
-    where T: Float + ToPrimitive
+where
+    T: Float + ToPrimitive,
 {
     /// Add a BoundingBox to the given BoundingBox.
     ///
@@ -381,14 +414,29 @@ impl<T> AddAssign for Bbox<T>
     /// assert_eq!(10., bbox0.ymin);
     /// assert_eq!(1000., bbox0.ymax);
     /// ```
-    fn add_assign(&mut self, rhs: Bbox<T>){
-        self.xmin = if self.xmin <= rhs.xmin {self.xmin} else {rhs.xmin};
-        self.xmax = if self.xmax >= rhs.xmax {self.xmax} else {rhs.xmax};
-        self.ymin = if self.ymin <= rhs.ymin {self.ymin} else {rhs.ymin};
-        self.ymax = if self.ymax >= rhs.ymax {self.ymax} else {rhs.ymax};
+    fn add_assign(&mut self, rhs: Bbox<T>) {
+        self.xmin = if self.xmin <= rhs.xmin {
+            self.xmin
+        } else {
+            rhs.xmin
+        };
+        self.xmax = if self.xmax >= rhs.xmax {
+            self.xmax
+        } else {
+            rhs.xmax
+        };
+        self.ymin = if self.ymin <= rhs.ymin {
+            self.ymin
+        } else {
+            rhs.ymin
+        };
+        self.ymax = if self.ymax >= rhs.ymax {
+            self.ymax
+        } else {
+            rhs.ymax
+        };
     }
 }
-
 
 /// A collection of [`Point`s](struct.Point.html)
 ///
@@ -402,7 +450,9 @@ impl<T> AddAssign for Bbox<T>
 /// }
 /// ```
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub struct MultiPoint<T>(pub Vec<Point<T>>) where T: Float;
+pub struct MultiPoint<T>(pub Vec<Point<T>>)
+where
+    T: Float;
 
 impl<T: Float, IP: Into<Point<T>>> From<IP> for MultiPoint<T> {
     /// Convert a single `Point` (or something which can be converted to a `Point`) into a
@@ -422,7 +472,7 @@ impl<T: Float, IP: Into<Point<T>>> From<Vec<IP>> for MultiPoint<T> {
 
 impl<T: Float, IP: Into<Point<T>>> FromIterator<IP> for MultiPoint<T> {
     /// Collect the results of a `Point` iterator into a `MultiPoint`
-    fn from_iter<I: IntoIterator<Item=IP>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = IP>>(iter: I) -> Self {
         MultiPoint(iter.into_iter().map(|p| p.into()).collect())
     }
 }
@@ -440,14 +490,16 @@ impl<T: Float> IntoIterator for MultiPoint<T> {
 /// A line segment made up of exactly two [`Point`s](struct.Point.html)
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Line<T>
-    where T: Float
+where
+    T: Float,
 {
     pub start: Point<T>,
-    pub end: Point<T>
+    pub end: Point<T>,
 }
 
 impl<T> Line<T>
-    where T: Float
+where
+    T: Float,
 {
     /// Creates a new line segment.
     ///
@@ -460,7 +512,10 @@ impl<T> Line<T>
     /// assert_eq!(line.end, Point::new(1., 2.));
     /// ```
     pub fn new(start: Point<T>, end: Point<T>) -> Line<T> {
-        Line {start: start, end: end}
+        Line {
+            start: start,
+            end: end,
+        }
     }
 }
 
@@ -499,7 +554,9 @@ impl<T> Line<T>
 /// ```
 ///
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub struct LineString<T>(pub Vec<Point<T>>) where T: Float;
+pub struct LineString<T>(pub Vec<Point<T>>)
+where
+    T: Float;
 
 impl<T: Float> LineString<T> {
     /// Return an `Line` iterator that yields one `Line` for each line segment
@@ -545,7 +602,7 @@ impl<T: Float, IP: Into<Point<T>>> From<Vec<IP>> for LineString<T> {
 
 /// Turn a `Point`-ish iterator into a `LineString`.
 impl<T: Float, IP: Into<Point<T>>> FromIterator<IP> for LineString<T> {
-    fn from_iter<I: IntoIterator<Item=IP>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = IP>>(iter: I) -> Self {
         LineString(iter.into_iter().map(|p| p.into()).collect())
     }
 }
@@ -566,7 +623,9 @@ impl<T: Float> IntoIterator for LineString<T> {
 ///
 /// Iterating over this objects, yields the component `LineString`s.
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub struct MultiLineString<T>(pub Vec<LineString<T>>) where T: Float;
+pub struct MultiLineString<T>(pub Vec<LineString<T>>)
+where
+    T: Float;
 
 impl<T: Float, ILS: Into<LineString<T>>> From<ILS> for MultiLineString<T> {
     fn from(ls: ILS) -> Self {
@@ -575,7 +634,7 @@ impl<T: Float, ILS: Into<LineString<T>>> From<ILS> for MultiLineString<T> {
 }
 
 impl<T: Float, ILS: Into<LineString<T>>> FromIterator<ILS> for MultiLineString<T> {
-    fn from_iter<I: IntoIterator<Item=ILS>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = ILS>>(iter: I) -> Self {
         MultiLineString(iter.into_iter().map(|ls| ls.into()).collect())
     }
 }
@@ -594,14 +653,16 @@ impl<T: Float> IntoIterator for MultiLineString<T> {
 /// It has one exterior *ring* or *shell*, and zero or more interior rings, representing holes.
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct Polygon<T>
-    where T: Float
+where
+    T: Float,
 {
     pub exterior: LineString<T>,
-    pub interiors: Vec<LineString<T>>
+    pub interiors: Vec<LineString<T>>,
 }
 
 impl<T> Polygon<T>
-    where T: Float
+where
+    T: Float,
 {
     /// Creates a new polygon.
     ///
@@ -617,7 +678,10 @@ impl<T> Polygon<T>
     /// assert_eq!(p.interiors, interiors);
     /// ```
     pub fn new(exterior: LineString<T>, interiors: Vec<LineString<T>>) -> Polygon<T> {
-        Polygon { exterior: exterior, interiors: interiors }
+        Polygon {
+            exterior: exterior,
+            interiors: interiors,
+        }
     }
 }
 
@@ -627,7 +691,9 @@ impl<T> Polygon<T>
 ///
 /// Iterating over this objects, yields the component Polygons.
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub struct MultiPolygon<T>(pub Vec<Polygon<T>>) where T: Float;
+pub struct MultiPolygon<T>(pub Vec<Polygon<T>>)
+where
+    T: Float;
 
 impl<T: Float, IP: Into<Polygon<T>>> From<IP> for MultiPolygon<T> {
     fn from(x: IP) -> Self {
@@ -636,7 +702,7 @@ impl<T: Float, IP: Into<Polygon<T>>> From<IP> for MultiPolygon<T> {
 }
 
 impl<T: Float, IP: Into<Polygon<T>>> FromIterator<IP> for MultiPolygon<T> {
-    fn from_iter<I: IntoIterator<Item=IP>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = IP>>(iter: I) -> Self {
         MultiPolygon(iter.into_iter().map(|p| p.into()).collect())
     }
 }
@@ -656,7 +722,9 @@ impl<T: Float> IntoIterator for MultiPolygon<T> {
 ///
 /// Iterating over this objects, yields the component Geometries.
 #[derive(PartialEq, Clone, Debug)]
-pub struct GeometryCollection<T>(pub Vec<Geometry<T>>) where T: Float;
+pub struct GeometryCollection<T>(pub Vec<Geometry<T>>)
+where
+    T: Float;
 
 impl<T: Float, IG: Into<Geometry<T>>> From<IG> for GeometryCollection<T> {
     fn from(x: IG) -> Self {
@@ -665,7 +733,7 @@ impl<T: Float, IG: Into<Geometry<T>>> From<IG> for GeometryCollection<T> {
 }
 
 impl<T: Float, IG: Into<Geometry<T>>> FromIterator<IG> for GeometryCollection<T> {
-    fn from_iter<I: IntoIterator<Item=IG>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = IG>>(iter: I) -> Self {
         GeometryCollection(iter.into_iter().map(|g| g.into()).collect())
     }
 }
@@ -685,7 +753,8 @@ impl<T: Float> IntoIterator for GeometryCollection<T> {
 /// `std::convert::Into` pattern).
 #[derive(PartialEq, Clone, Debug)]
 pub enum Geometry<T>
-    where T: Float
+where
+    T: Float,
 {
     Point(Point<T>),
     LineString(LineString<T>),
@@ -693,7 +762,7 @@ pub enum Geometry<T>
     MultiPoint(MultiPoint<T>),
     MultiLineString(MultiLineString<T>),
     MultiPolygon(MultiPolygon<T>),
-    GeometryCollection(GeometryCollection<T>)
+    GeometryCollection(GeometryCollection<T>),
 }
 
 /// The result of trying to find the closest spot on an object to a point.
@@ -732,16 +801,40 @@ impl<F: Float> Closest<F> {
     }
 }
 
-impl<T: Float> From<Point<T>> for Geometry<T> { fn from(x: Point<T>) -> Geometry<T> { Geometry::Point(x) } }
-impl<T: Float> From<LineString<T>> for Geometry<T> { fn from(x: LineString<T>) -> Geometry<T> { Geometry::LineString(x) } }
-impl<T: Float> From<Polygon<T>> for Geometry<T> { fn from(x: Polygon<T>) -> Geometry<T> { Geometry::Polygon(x) } }
-impl<T: Float> From<MultiPoint<T>> for Geometry<T> { fn from(x: MultiPoint<T>) -> Geometry<T> { Geometry::MultiPoint(x) } }
-impl<T: Float> From<MultiLineString<T>> for Geometry<T> { fn from(x: MultiLineString<T>) -> Geometry<T> { Geometry::MultiLineString(x) } }
-impl<T: Float> From<MultiPolygon<T>> for Geometry<T> { fn from(x: MultiPolygon<T>) -> Geometry<T> { Geometry::MultiPolygon(x) } }
+impl<T: Float> From<Point<T>> for Geometry<T> {
+    fn from(x: Point<T>) -> Geometry<T> {
+        Geometry::Point(x)
+    }
+}
+impl<T: Float> From<LineString<T>> for Geometry<T> {
+    fn from(x: LineString<T>) -> Geometry<T> {
+        Geometry::LineString(x)
+    }
+}
+impl<T: Float> From<Polygon<T>> for Geometry<T> {
+    fn from(x: Polygon<T>) -> Geometry<T> {
+        Geometry::Polygon(x)
+    }
+}
+impl<T: Float> From<MultiPoint<T>> for Geometry<T> {
+    fn from(x: MultiPoint<T>) -> Geometry<T> {
+        Geometry::MultiPoint(x)
+    }
+}
+impl<T: Float> From<MultiLineString<T>> for Geometry<T> {
+    fn from(x: MultiLineString<T>) -> Geometry<T> {
+        Geometry::MultiLineString(x)
+    }
+}
+impl<T: Float> From<MultiPolygon<T>> for Geometry<T> {
+    fn from(x: MultiPolygon<T>) -> Geometry<T> {
+        Geometry::MultiPolygon(x)
+    }
+}
 
 #[cfg(test)]
 mod test {
-    use ::types::*;
+    use types::*;
 
     #[test]
     fn type_test() {
@@ -760,15 +853,24 @@ mod test {
         let p: Point<f32> = (0f32, 1f32).into();
         assert_eq!(p.x(), 0.);
         assert_eq!(p.y(), 1.);
-
     }
 
     #[test]
     fn polygon_new_test() {
-        let exterior = LineString(vec![Point::new(0., 0.), Point::new(1., 1.),
-                                       Point::new(1., 0.), Point::new(0., 0.)]);
-        let interiors = vec![LineString(vec![Point::new(0.1, 0.1), Point::new(0.9, 0.9),
-                                             Point::new(0.9, 0.1), Point::new(0.1, 0.1)])];
+        let exterior = LineString(vec![
+            Point::new(0., 0.),
+            Point::new(1., 1.),
+            Point::new(1., 0.),
+            Point::new(0., 0.),
+        ]);
+        let interiors = vec![
+            LineString(vec![
+                Point::new(0.1, 0.1),
+                Point::new(0.9, 0.9),
+                Point::new(0.9, 0.1),
+                Point::new(0.1, 0.1),
+            ]),
+        ];
         let p = Polygon::new(exterior.clone(), interiors.clone());
 
         assert_eq!(p.exterior, exterior);


### PR DESCRIPTION
99% of these changes are from `rustfmt` – the rest are changes suggested by Clippy, which now only finds a single issue.
I've also tidied up some doc typos, and added `Line` to the `Geometry` enum. 