### PR TITLE
Fix Github language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rs linguist-language=Rust


### PR DESCRIPTION
Github is currently mis-classifying Rust-Geo as a RenderScript project because it can't recognise some of the test fixtures in use as Rust files. This override fixes that, so that we can be found / seen by users again.