### PR TITLE
Add Haversine length algorithm

### DIFF
--- a/src/algorithm/haversine_length.rs
+++ b/src/algorithm/haversine_length.rs
@@ -1,0 +1,50 @@
+
+use num_traits::{Float, FromPrimitive};
+
+use types::{Line, LineString, MultiLineString};
+use algorithm::haversine_distance::HaversineDistance;
+
+/// Calculation of the length
+
+pub trait HaversineLength<T, RHS = Self> {
+    /// Calculation of the length of a Line
+    ///
+    /// ```
+    /// use geo::{Point, LineString, Coordinate};
+    /// use geo::algorithm::haversine_length::HaversineLength;
+    ///
+    /// let mut vec = Vec::new();
+    /// vec.push(Point::new(40.02f64, 116.34));
+    /// vec.push(Point::new(42.02f64, 116.34));
+    /// let linestring = LineString(vec);
+    ///
+    /// println!("HaversineLength {}", linestring.haversine_length());
+    /// ```
+    ///
+    fn haversine_length(&self) -> T;
+}
+
+impl<T> HaversineLength<T> for Line<T>
+    where T: Float + FromPrimitive
+{
+    fn haversine_length(&self) -> T {
+        self.start.haversine_distance(&self.end)
+    }
+}
+
+impl<T> HaversineLength<T> for LineString<T>
+    where T: Float + FromPrimitive
+{
+    fn haversine_length(&self) -> T {
+        self.0.windows(2)
+              .fold(T::zero(), |total_length, p| total_length + p[0].haversine_distance(&p[1]))
+    }
+}
+
+impl<T> HaversineLength<T> for MultiLineString<T>
+    where T: Float + FromPrimitive
+{
+    fn haversine_length(&self) -> T {
+        self.0.iter().fold(T::zero(), |total, line| total + line.haversine_length())
+    }
+}

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -40,3 +40,5 @@ pub mod from_postgis;
 /// Converts geometry into PostGIS types.
 #[cfg(feature = "postgis-integration")]
 pub mod to_postgis;
+/// Returns the Haversine length of a line.
+pub mod haversine_length;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,4 +39,9 @@ pub mod prelude {
     pub use algorithm::simplifyvw::SimplifyVW;
     pub use algorithm::translate::Translate;
     pub use algorithm::closest_point::ClosestPoint;
+    pub use algorithm::haversine_length::HaversineLength;
+    #[cfg(feature = "postgis-integration")]
+    pub use algorithm::from_postgis::FromPostgis;
+    #[cfg(feature = "postgis-integration")]
+    pub use algorithm::to_postgis::ToPostgis;
 }


### PR DESCRIPTION
This PR adds a new algorithm, `haversine_length`, that computes the "Haversine length" of a line or linestring - i.e. the sum of the Haversine distances between every two points in the line.

It also reexports this algorithm, and the PostGIS algorithms introduced in #180, in the prelude (because I realised I forgot to reexport them in #180...)
