### PR TITLE
Easy methods to convert a Geometry to the underlying type

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -833,6 +833,79 @@ impl<T: Float> From<MultiPolygon<T>> for Geometry<T> {
     }
 }
 
+impl<T: Float> Geometry<T> {
+
+    /// If this Geometry is a Point, then return that, else None.
+    ///
+    /// ```
+    /// use geo::*;
+    /// let g = Geometry::Point(Point::new(0., 0.));
+    /// let p2: Point<f32> = g.as_point().unwrap();
+    /// assert_eq!(p2, Point::new(0., 0.,));
+    /// ```
+    pub fn as_point(self) -> Option<Point<T>> {
+        if let Geometry::Point(x) = self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    /// If this Geometry is a LineString, then return that LineString, else None.
+    pub fn as_linestring(self) -> Option<LineString<T>> {
+        if let Geometry::LineString(x) = self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    /// If this Geometry is a Line, then return that Line, else None.
+    pub fn as_line(self) -> Option<Line<T>> {
+        if let Geometry::Line(x) = self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    /// If this Geometry is a Polygon, then return that, else None.
+    pub fn as_polygon(self) -> Option<Polygon<T>> {
+        if let Geometry::Polygon(x) = self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    /// If this Geometry is a MultiPoint, then return that, else None.
+    pub fn as_multipoint(self) -> Option<MultiPoint<T>> {
+        if let Geometry::MultiPoint(x) = self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    /// If this Geometry is a MultiLineString, then return that, else None.
+    pub fn as_multilinestring(self) -> Option<MultiLineString<T>> {
+        if let Geometry::MultiLineString(x) = self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    /// If this Geometry is a MultiPolygon, then return that, else None.
+    pub fn as_multipolygon(self) -> Option<MultiPolygon<T>> {
+        if let Geometry::MultiPolygon(x) = self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use types::*;
@@ -854,6 +927,15 @@ mod test {
         let p: Point<f32> = (0f32, 1f32).into();
         assert_eq!(p.x(), 0.);
         assert_eq!(p.y(), 1.);
+    }
+
+    #[test]
+    fn convert_types() {
+        let p: Point<f32> = Point::new(0., 0.);
+        let p1 = p.clone();
+        let g: Geometry<f32> = p.into();
+        let p2 = g.as_point().unwrap();
+        assert_eq!(p1, p2);
     }
 
     #[test]


### PR DESCRIPTION
Added a few `.as_point()` etc. methods to "unwrap" `Geometry`s. It helps with ergonomics