### PR TITLE
Allow coordinates to be more types

### DIFF
--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -1,10 +1,8 @@
-use num_traits::Float;
-
-use types::{Bbox, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
+use types::{CoordinateType, Bbox, Point, MultiPoint, Line, LineString, MultiLineString, Polygon, MultiPolygon};
 
 /// Calculation of the bounding box of a geometry.
 
-pub trait BoundingBox<T: Float> {
+pub trait BoundingBox<T: CoordinateType> {
     type Output;
 
     /// Return the Bounding Box of a geometry
@@ -31,7 +29,7 @@ pub trait BoundingBox<T: Float> {
 
 fn get_min_max<T>(p: T, min: T, max: T) -> (T, T)
 where
-    T: Float,
+    T: CoordinateType,
 {
     if p > max {
         (min, p)
@@ -44,8 +42,8 @@ where
 
 fn get_bbox<'a, I, T>(collection: I) -> Option<Bbox<T>>
 where
-    T: 'a + Float,
-    I: 'a + IntoIterator<Item = &'a Point<T>>,
+    T: 'a + CoordinateType,
+    I: 'a + IntoIterator<Item = &'a Point<T>>
 {
     let mut iter = collection.into_iter();
     if let Some(pnt) = iter.next() {
@@ -68,7 +66,7 @@ where
 
 impl<T> BoundingBox<T> for MultiPoint<T>
 where
-    T: Float,
+    T: CoordinateType,
 {
     type Output = Option<Bbox<T>>;
 
@@ -82,7 +80,7 @@ where
 
 impl<T> BoundingBox<T> for Line<T>
 where
-    T: Float,
+    T: CoordinateType,
 {
     type Output = Bbox<T>;
 
@@ -110,7 +108,7 @@ where
 
 impl<T> BoundingBox<T> for LineString<T>
 where
-    T: Float,
+    T: CoordinateType,
 {
     type Output = Option<Bbox<T>>;
 
@@ -124,7 +122,7 @@ where
 
 impl<T> BoundingBox<T> for MultiLineString<T>
 where
-    T: Float,
+    T: CoordinateType,
 {
     type Output = Option<Bbox<T>>;
 
@@ -138,7 +136,7 @@ where
 
 impl<T> BoundingBox<T> for Polygon<T>
 where
-    T: Float,
+    T: CoordinateType,
 {
     type Output = Option<Bbox<T>>;
 
@@ -153,7 +151,7 @@ where
 
 impl<T> BoundingBox<T> for MultiPolygon<T>
 where
-    T: Float,
+    T: CoordinateType,
 {
     type Output = Option<Bbox<T>>;
 

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -1,6 +1,6 @@
 use num_traits::{Float, ToPrimitive};
 
-use types::{Bbox, Line, LineString, MultiPolygon, Point, Polygon, COORD_PRECISION};
+use types::{COORD_PRECISION, CoordinateType, Point, Line, LineString, Polygon, MultiPolygon, Bbox};
 use algorithm::intersects::Intersects;
 use algorithm::distance::Distance;
 
@@ -246,7 +246,7 @@ where
 
 impl<T> Contains<Point<T>> for Bbox<T>
 where
-    T: Float,
+    T: CoordinateType
 {
     fn contains(&self, p: &Point<T>) -> bool {
         p.x() >= self.xmin && p.x() <= self.xmax && p.y() >= self.ymin && p.y() <= self.ymax
@@ -255,7 +255,7 @@ where
 
 impl<T> Contains<Bbox<T>> for Bbox<T>
 where
-    T: Float,
+    T: CoordinateType
 {
     fn contains(&self, bbox: &Bbox<T>) -> bool {
         // All points of LineString must be in the polygon ?
@@ -599,5 +599,16 @@ mod test {
         assert!(linestring0.contains(&line0));
         assert!(linestring1.contains(&line0));
         assert!(!linestring2.contains(&line0));
+    }
+
+    #[test]
+    fn integer_bboxs() {
+        let p: Point<i32> = Point::new(10, 20);
+        let bbox: Bbox<i32> = Bbox{ xmin: 0, ymin:0, xmax: 100, ymax: 100 };
+        assert!(bbox.contains(&p));
+        assert!(!bbox.contains(&Point::new(-10, -10)));
+
+        let smaller_bbox: Bbox<i32> = Bbox{ xmin: 10, ymin: 10, xmax: 20, ymax: 20 };
+        assert!(bbox.contains(&smaller_bbox));
     }
 }

--- a/src/algorithm/map_coords.rs
+++ b/src/algorithm/map_coords.rs
@@ -1,6 +1,4 @@
-use num_traits::Float;
-use types::{Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint, MultiPolygon,
-            Point, Polygon};
+use types::{CoordinateType, Point, Polygon, LineString, Line, MultiPoint, MultiPolygon, MultiLineString, GeometryCollection, Geometry};
 
 /// Map all the coordinates in an object, returning a new one
 pub trait MapCoords<T, NT> {
@@ -30,8 +28,7 @@ pub trait MapCoords<T, NT> {
     /// assert_eq!(p2, Point::new(10.0f64, 20.0f64));
     /// ```
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output
-        where T: Float, NT: Float;
-
+        where T: CoordinateType, NT: CoordinateType;
 
 
 }
@@ -50,10 +47,10 @@ pub trait MapCoordsInplace<T> {
     /// assert_eq!(p, Point::new(1010., 40.));
     /// ```
     fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
-        where T: Float;
+        where T: CoordinateType;
 }
 
-impl<T: Float, NT: Float> MapCoords<T, NT> for Point<T> {
+impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Point<T> {
     type Output = Point<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
@@ -62,7 +59,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Point<T> {
     }
 }
 
-impl<T: Float> MapCoordsInplace<T> for Point<T> {
+impl<T: CoordinateType> MapCoordsInplace<T> for Point<T> {
 
     fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
     {
@@ -72,7 +69,8 @@ impl<T: Float> MapCoordsInplace<T> for Point<T> {
     }
 }
 
-impl<T: Float, NT: Float> MapCoords<T, NT> for Line<T> {
+
+impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Line<T> {
     type Output = Line<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
@@ -80,7 +78,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Line<T> {
     }
 }
 
-impl<T: Float> MapCoordsInplace<T> for Line<T> {
+impl<T: CoordinateType> MapCoordsInplace<T> for Line<T> {
     fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
     {
         self.start.map_coords_inplace(func);
@@ -88,7 +86,8 @@ impl<T: Float> MapCoordsInplace<T> for Line<T> {
     }
 }
 
-impl<T: Float, NT: Float> MapCoords<T, NT> for LineString<T> {
+
+impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for LineString<T> {
     type Output = LineString<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
@@ -96,7 +95,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for LineString<T> {
     }
 }
 
-impl<T: Float> MapCoordsInplace<T> for LineString<T> {
+impl<T: CoordinateType> MapCoordsInplace<T> for LineString<T> {
     fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
     {
         for p in self.0.iter_mut() {
@@ -105,7 +104,8 @@ impl<T: Float> MapCoordsInplace<T> for LineString<T> {
     }
 }
 
-impl<T: Float, NT: Float> MapCoords<T, NT> for Polygon<T> {
+
+impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Polygon<T> {
     type Output = Polygon<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
@@ -116,7 +116,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Polygon<T> {
     }
 }
 
-impl<T: Float> MapCoordsInplace<T> for Polygon<T> {
+impl<T: CoordinateType> MapCoordsInplace<T> for Polygon<T> {
     fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
     {
         self.exterior.map_coords_inplace(func);
@@ -126,7 +126,8 @@ impl<T: Float> MapCoordsInplace<T> for Polygon<T> {
     }
 }
 
-impl<T: Float, NT: Float> MapCoords<T, NT> for MultiPoint<T> {
+
+impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiPoint<T> {
     type Output = MultiPoint<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
@@ -134,7 +135,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for MultiPoint<T> {
     }
 }
 
-impl<T: Float> MapCoordsInplace<T> for MultiPoint<T> {
+impl<T: CoordinateType> MapCoordsInplace<T> for MultiPoint<T> {
     fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
     {
         for p in self.0.iter_mut() {
@@ -143,7 +144,8 @@ impl<T: Float> MapCoordsInplace<T> for MultiPoint<T> {
     }
 }
 
-impl<T: Float, NT: Float> MapCoords<T, NT> for MultiLineString<T> {
+
+impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiLineString<T> {
     type Output = MultiLineString<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
@@ -151,7 +153,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for MultiLineString<T> {
     }
 }
 
-impl<T: Float> MapCoordsInplace<T> for MultiLineString<T> {
+impl<T: CoordinateType> MapCoordsInplace<T> for MultiLineString<T> {
     fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
     {
         for p in self.0.iter_mut() {
@@ -160,7 +162,8 @@ impl<T: Float> MapCoordsInplace<T> for MultiLineString<T> {
     }
 }
 
-impl<T: Float, NT: Float> MapCoords<T, NT> for MultiPolygon<T> {
+
+impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiPolygon<T> {
     type Output = MultiPolygon<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
@@ -168,7 +171,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for MultiPolygon<T> {
     }
 }
 
-impl<T: Float> MapCoordsInplace<T> for MultiPolygon<T> {
+impl<T: CoordinateType> MapCoordsInplace<T> for MultiPolygon<T> {
     fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
     {
         for p in self.0.iter_mut() {
@@ -177,7 +180,8 @@ impl<T: Float> MapCoordsInplace<T> for MultiPolygon<T> {
     }
 }
 
-impl<T: Float, NT: Float> MapCoords<T, NT> for Geometry<T> {
+
+impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Geometry<T> {
     type Output = Geometry<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
@@ -194,7 +198,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for Geometry<T> {
     }
 }
 
-impl<T: Float> MapCoordsInplace<T> for Geometry<T> {
+impl<T: CoordinateType> MapCoordsInplace<T> for Geometry<T> {
     fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
     {
         match *self {
@@ -210,7 +214,8 @@ impl<T: Float> MapCoordsInplace<T> for Geometry<T> {
     }
 }
 
-impl<T: Float, NT: Float> MapCoords<T, NT> for GeometryCollection<T> {
+
+impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for GeometryCollection<T> {
     type Output = GeometryCollection<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
@@ -218,7 +223,7 @@ impl<T: Float, NT: Float> MapCoords<T, NT> for GeometryCollection<T> {
     }
 }
 
-impl<T: Float> MapCoordsInplace<T> for GeometryCollection<T> {
+impl<T: CoordinateType> MapCoordsInplace<T> for GeometryCollection<T> {
     fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
     {
         for p in self.0.iter_mut() {

--- a/src/algorithm/orient.rs
+++ b/src/algorithm/orient.rs
@@ -1,5 +1,4 @@
-use num_traits::Float;
-use types::{MultiPolygon, Polygon};
+use types::{CoordinateType, MultiPolygon, Polygon};
 
 use algorithm::winding_order::{Winding, WindingOrder};
 
@@ -35,7 +34,7 @@ pub trait Orient<T> {
 
 impl<T> Orient<T> for Polygon<T>
 where
-    T: Float,
+    T: CoordinateType,
 {
     fn orient(&self, direction: Direction) -> Polygon<T> {
         orient(self, direction)
@@ -44,7 +43,7 @@ where
 
 impl<T> Orient<T> for MultiPolygon<T>
 where
-    T: Float,
+    T: CoordinateType,
 {
     fn orient(&self, direction: Direction) -> MultiPolygon<T> {
         MultiPolygon(self.0.iter().map(|poly| poly.orient(direction)).collect())
@@ -67,7 +66,7 @@ pub enum Direction {
 // and the interior ring(s) will be oriented clockwise
 fn orient<T>(poly: &Polygon<T>, direction: Direction) -> Polygon<T>
 where
-    T: Float,
+    T: CoordinateType,
 {
     let interiors = poly.interiors.iter().map(|l| l.clone_to_winding_order(
             match direction {

--- a/src/algorithm/translate.rs
+++ b/src/algorithm/translate.rs
@@ -1,4 +1,4 @@
-use num_traits::Float;
+use types::CoordinateType;
 use algorithm::map_coords::{MapCoords, MapCoordsInplace};
 
 pub trait Translate<T> {
@@ -22,14 +22,14 @@ pub trait Translate<T> {
     /// let correct_ls = LineString(correct);
     /// assert_eq!(translated, correct_ls);
     /// ```
-    fn translate(&self, xoff: T, yoff: T) -> Self where T: Float;
+    fn translate(&self, xoff: T, yoff: T) -> Self where T: CoordinateType;
 
     /// Translate a Geometry along its axes, but in place.
-    fn translate_inplace(&mut self, xoff: T, yoff: T) where T: Float;
+    fn translate_inplace(&mut self, xoff: T, yoff: T) where T: CoordinateType;
 }
 
 impl<T, G> Translate<T> for G
-    where T: Float,
+    where T: CoordinateType,
         G: MapCoords<T, T, Output=G>+MapCoordsInplace<T>
 {
     fn translate(&self, xoff: T, yoff: T) -> Self {

--- a/src/algorithm/winding_order.rs
+++ b/src/algorithm/winding_order.rs
@@ -1,7 +1,6 @@
-use num_traits::Float;
-use types::{LineString, Point};
+use types::{CoordinateType, LineString, Point};
 
-pub(crate) fn twice_signed_ring_area<T>(linestring: &LineString<T>) -> T where T: Float {
+pub(crate) fn twice_signed_ring_area<T>(linestring: &LineString<T>) -> T where T: CoordinateType {
     if linestring.0.is_empty() || linestring.0.len() == 1 {
         return T::zero();
     }
@@ -22,7 +21,7 @@ pub enum WindingOrder {
 
 
 /// Calculate, and work with, the winding order
-pub trait Winding<T> where T: Float
+pub trait Winding<T> where T: CoordinateType
 {
     /// Return the winding order of this object
     fn winding_order(&self) -> Option<WindingOrder>;
@@ -74,7 +73,7 @@ pub trait Winding<T> where T: Float
 
 
 impl<T> Winding<T> for LineString<T>
-    where T: Float
+    where T: CoordinateType
 {
 
     /// Returns the winding order of this line

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,8 @@
 pub use Geometry;
 
-use num_traits::Float;
+use types::CoordinateType;
 
-pub trait ToGeo<T: Float> {
+pub trait ToGeo<T: CoordinateType>
+{
     fn to_geo(&self) -> Geometry<T>;
 }


### PR DESCRIPTION
This PR allows the coordinates to be a larger range of types, not just `Float`. Specially it allows for integer coordinates. Some algorithms have been 'expanded' to support this new `CoordinateType`, but most only make sense for `Float`s and have been left. I've only changed what I've used myself, perhaps more algorithms could be expanded. I think this should be a backwards compatible change.

This fixes #137 