### PR TITLE
cross_prod method added to Point

### DIFF
--- a/src/algorithm/convexhull.rs
+++ b/src/algorithm/convexhull.rs
@@ -48,17 +48,11 @@ fn partition<T, F: FnMut(&T) -> bool>(mut slice: &mut [T], mut pred: F) -> usize
 // we can compute the cross product AB x AC and check its sign:
 // If it's negative, it will be on the "right" side of AB
 // (when standing on A and looking towards B). If positive, it will be on the left side
-fn cross_prod<T>(p_a: &Point<T>, p_b: &Point<T>, p_c: &Point<T>) -> T
-where
-    T: Float,
-{
-    (p_b.x() - p_a.x()) * (p_c.y() - p_a.y()) - (p_b.y() - p_a.y()) * (p_c.x() - p_a.x())
-}
 fn point_location<T>(p_a: &Point<T>, p_b: &Point<T>, p_c: &Point<T>) -> bool
 where
     T: Float,
 {
-    cross_prod(p_a, p_b, p_c) > T::zero()
+    p_a.cross_prod(p_b, p_c) > T::zero()
 }
 
 // Fast distance between line segment (p_a, p_b), and point p_c

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -67,13 +67,6 @@ where
     }
 }
 
-// positive implies a -> b -> c is counter-clockwise, negative implies clockwise
-fn cross_prod<T>(p_a: &Point<T>, p_b: &Point<T>, p_c: &Point<T>) -> T
-where
-    T: Float,
-{
-    (p_b.x() - p_a.x()) * (p_c.y() - p_a.y()) - (p_b.y() - p_a.y()) * (p_c.x() - p_a.x())
-}
 
 // wrapper for extreme-finding function
 fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes, ()>
@@ -96,9 +89,10 @@ where
         .map(|(idx, _)| {
             let prev_1 = polygon.previous_vertex(&idx);
             let prev_2 = polygon.previous_vertex(&prev_1);
-            cross_prod(&polygon.exterior.0[prev_2],
-                       &polygon.exterior.0[prev_1],
-                       &polygon.exterior.0[idx])
+            polygon.exterior.0[prev_2].cross_prod(
+                &polygon.exterior.0[prev_1],
+                &polygon.exterior.0[idx]
+            )
         })
         // accumulate and check cross-product result signs in a single pass
         // positive implies ccw convexity, negative implies cw convexity

--- a/src/types.rs
+++ b/src/types.rs
@@ -254,7 +254,12 @@ where
         self.x() * point.x() + self.y() * point.y()
     }
 
-    /// Returns the cross product of 3 points
+    /// Returns the cross product of 3 points. A positive value implies
+    /// `self` → `point_b` → `point_c` is counter-clockwise, negative implies
+    /// clockwise.
+    /// 
+    /// # Examples
+    ///
     /// ```
     /// use geo::Point;
     /// 
@@ -266,12 +271,12 @@ where
     /// 
     /// assert_eq!(cross, 2.0)
     /// ```
-    /// A positive value implies self → point_b → point_c is counter-clockwise, negative implies clockwise.
     pub fn cross_prod(&self, point_b: &Point<T>, point_c: &Point<T>) -> T
     where
         T: Float,
     {
-        (point_b.x() - self.x()) * (point_c.y() - self.y()) - (point_b.y() - self.y()) * (point_c.x() - self.x())
+        (point_b.x() - self.x()) * (point_c.y() - self.y()) -
+            (point_b.y() - self.y()) * (point_c.x() - self.x())
     }
     
     /// Convert this `Point` into a tuple of its `x` and `y` coordinates.

--- a/src/types.rs
+++ b/src/types.rs
@@ -266,6 +266,7 @@ where
     /// 
     /// assert_eq!(cross, 2.0)
     /// ```
+    /// A positive value implies self → point_b → point_c is counter-clockwise, negative implies clockwise.
     pub fn cross_prod(&self, point_b: &Point<T>, point_c: &Point<T>) -> T
     where
         T: Float,

--- a/src/types.rs
+++ b/src/types.rs
@@ -254,6 +254,25 @@ where
         self.x() * point.x() + self.y() * point.y()
     }
 
+    /// Returns the cross product of 3 points
+    /// ```
+    /// use geo::Point;
+    /// 
+    /// let p_a = Point::new(1.0, 2.0);
+    /// let p_b = Point::new(3.0,5.0);
+    /// let p_c = Point::new(7.0,12.0);
+    /// 
+    /// let cross = p_a.cross_prod(&p_b, &p_c);
+    /// 
+    /// assert_eq!(cross, 2.0)
+    /// ```
+    pub fn cross_prod(&self, point_b: &Point<T>, point_c: &Point<T>) -> T
+    where
+        T: Float,
+    {
+        (point_b.x() - self.x()) * (point_c.y() - self.y()) - (point_b.y() - self.y()) * (point_c.x() - self.x())
+    }
+    
     /// Convert this `Point` into a tuple of its `x` and `y` coordinates.
     pub(crate) fn coords(&self) -> (T, T) {
         (self.x(), self.y())


### PR DESCRIPTION
Solves #133 

`Point` struct  now implements a cross product fuction `cross_prod` that use previously used inline in 2 different parts of the codebase.
- algorithm/extremes.rs
- algorithm/convexhull.rs

It uses the same implementation the other inline function were using.