### PR TITLE
[WIP] implement coordinate reprojection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = "1.0"
 serde_derive = "1.0"
 spade = "1.3.0"
 postgis = { version = "0.5", optional = true }
+proj = { version = "0.3", optional = true }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ proj = { version = "0.3", optional = true }
 [features]
 default = []
 postgis-integration = ["postgis"]
+reprojection = ["proj"]
 
 [dev-dependencies]
 approx = "0.1.1"

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -46,6 +46,6 @@ pub mod to_postgis;
 pub mod haversine_length;
 /// Calculate, and work with, the winding order of Linestrings
 pub mod winding_order;
-/// Apply a projection transformation to a Geometry
+/// Apply a coordinate projection transformation to a Geometry using `rust-proj`
 #[cfg(feature = "reprojection")]
 pub mod reproject;

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -46,3 +46,6 @@ pub mod to_postgis;
 pub mod haversine_length;
 /// Calculate, and work with, the winding order of Linestrings
 pub mod winding_order;
+/// Apply a projection transformation to a Geometry
+#[cfg(feature = "reprojection")]
+pub mod reproject;

--- a/src/algorithm/reproject.rs
+++ b/src/algorithm/reproject.rs
@@ -6,7 +6,8 @@ use proj::Proj;
 
 /// Reproject the coordinates of a `Geometry` using `rust-proj`
 pub trait Reproject<T> {
-    /// Projects (or inverse-projects) the coordinates using 
+    /// Projects (or inverse-projects) the coordinates using the specified
+    /// source and destination projections
     fn reproject(&self, source_proj: &Proj, dest_proj: &Proj) -> Self
     where
         T: Float;

--- a/src/algorithm/reproject.rs
+++ b/src/algorithm/reproject.rs
@@ -1,16 +1,16 @@
 use num_traits::Float;
-use types::Point;
+use types::{CoordinateType, Point};
 use algorithm::map_coords::MapCoords;
 
 use proj::Proj;
 
-/// Reproject the coordinates of a `Geometry` using `rust-proj`
+/// Project or transform the coordinates of a `Geometry` using `rust-proj`
 pub trait Reproject<T> {
     /// Projects (or inverse-projects) the coordinates using the specified
     /// source and destination projections
     fn reproject(&self, source_proj: &Proj, dest_proj: &Proj) -> Self
     where
-        T: Float;
+        T: CoordinateType;
 }
 
 impl<T, G> Reproject<T> for G

--- a/src/algorithm/reproject.rs
+++ b/src/algorithm/reproject.rs
@@ -1,0 +1,25 @@
+use num_traits::Float;
+use types::Point;
+use algorithm::map_coords::MapCoords;
+
+use proj::Proj; 
+
+pub trait Reproject<T> {
+    /// Reproject the coordinates of a `Geometry` using `rust-proj`
+    fn reproject(&self, sproj: &Proj, dproj: &Proj) -> Self
+    where
+        T: Float;
+}
+
+impl<T, G> Reproject<T> for G
+where
+    T: Float,
+    G: MapCoords<T, T, Output = G>,
+{
+    fn reproject(&self, sproj: &Proj, dproj: &Proj) -> Self {
+        self.map_coords(&|&(x, y)| {
+            let reprojected = sproj.project(dproj, Point::new(x, y));
+            (reprojected.x(), reprojected.y())
+        })
+    }
+}

--- a/src/algorithm/reproject.rs
+++ b/src/algorithm/reproject.rs
@@ -2,11 +2,12 @@ use num_traits::Float;
 use types::Point;
 use algorithm::map_coords::MapCoords;
 
-use proj::Proj; 
+use proj::Proj;
 
+/// Reproject the coordinates of a `Geometry` using `rust-proj`
 pub trait Reproject<T> {
-    /// Reproject the coordinates of a `Geometry` using `rust-proj`
-    fn reproject(&self, sproj: &Proj, dproj: &Proj) -> Self
+    /// Projects (or inverse-projects) the coordinates using 
+    fn reproject(&self, source_proj: &Proj, dest_proj: &Proj) -> Self
     where
         T: Float;
 }
@@ -16,10 +17,27 @@ where
     T: Float,
     G: MapCoords<T, T, Output = G>,
 {
-    fn reproject(&self, sproj: &Proj, dproj: &Proj) -> Self {
+    fn reproject(&self, source_proj: &Proj, dest_proj: &Proj) -> Self {
         self.map_coords(&|&(x, y)| {
-            let reprojected = sproj.project(dproj, Point::new(x, y));
+            let reprojected = source_proj.project(dest_proj, Point::new(x, y));
             (reprojected.x(), reprojected.y())
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use types::Point;
+    use super::*;
+    #[test]
+    fn test_reproject() {
+        let wgs84_name = "+proj=longlat +datum=WGS84 +no_defs";
+        let wgs84 = Proj::new(wgs84_name).unwrap();
+        let stereo70 = Proj::new(
+            "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +units=m +no_defs"
+        ).unwrap();
+        let p = Point::new(500000., 500000.);
+        let rp = p.reproject(&stereo70, &wgs84);
+        assert_eq!(rp, Point::new(0.436332, 0.802851));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate num_traits;
 #[macro_use]
 extern crate serde_derive;
 extern crate spade;
+extern crate proj;
 #[cfg(feature = "postgis-integration")]
 extern crate postgis;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate num_traits;
 #[macro_use]
 extern crate serde_derive;
 extern crate spade;
+#[cfg(feature = "reprojection")]
 extern crate proj;
 #[cfg(feature = "postgis-integration")]
 extern crate postgis;
@@ -46,4 +47,6 @@ pub mod prelude {
     pub use algorithm::from_postgis::FromPostgis;
     #[cfg(feature = "postgis-integration")]
     pub use algorithm::to_postgis::ToPostgis;
+    #[cfg(feature = "reprojection")]
+    pub use algorithm::reproject::Reproject;
 }


### PR DESCRIPTION
This should implement coordinate reprojection on all Geometries which implement MapCoords. <s>However, I'm not at all sure I've got the type bounds correct (It _looks_ like `Reproject` shouldn't need any, but I think I need it for the impl on MapCoords).</s> The actual problem is that I'm getting a type mismatch error in the `project` function:

      --> src/algorithm/reproject.rs:22:62
       |
    22 |             let reprojected = source_proj.project(dest_proj, Point::new(x, y));
       |                                                              ^^^^^^^^^^^^^^^^ expected struct `geo::types::Point`, found struct `types::Point`
       |
       = note: expected type `geo::types::Point<_>`
                  found type `types::Point<T>`

And I have no idea why it's occurring, so if anyone has any ideas…