### PR TITLE
Impl Polygon convexity function on the type

### DIFF
--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -45,66 +45,13 @@ where
     direction_sign(u, vi, vj) < T::zero()
 }
 
-// used to check the sign of a vec of floats
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum ListSign {
-    Empty,
-    Positive,
-    Negative,
-    Mixed,
-}
-
-// Wrap-around previous-vertex
-impl<T> Polygon<T>
-where
-    T: Float,
-{
-    fn previous_vertex(&self, current_vertex: &usize) -> usize
-    where
-        T: Float,
-    {
-        (current_vertex + (self.exterior.0.len() - 1) - 1) % (self.exterior.0.len() - 1)
-    }
-}
-
-
 // wrapper for extreme-finding function
 fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes, ()>
 where
     T: Float + Signed,
     F: Fn(&Point<T>, &Polygon<T>) -> Result<usize, ()>,
 {
-    // For each consecutive pair of edges of the polygon (each triplet of points),
-    // compute the z-component of the cross product of the vectors defined by the
-    // edges pointing towards the points in increasing order.
-    // Take the cross product of these vectors
-    // The polygon is convex if the z-components of the cross products are either
-    // all positive or all negative. Otherwise, the polygon is non-convex.
-    // see: http://stackoverflow.com/a/1881201/416626
-    let convex = polygon
-        .exterior
-        .0
-        .iter()
-        .enumerate()
-        .map(|(idx, _)| {
-            let prev_1 = polygon.previous_vertex(&idx);
-            let prev_2 = polygon.previous_vertex(&prev_1);
-            polygon.exterior.0[prev_2].cross_prod(
-                &polygon.exterior.0[prev_1],
-                &polygon.exterior.0[idx]
-            )
-        })
-        // accumulate and check cross-product result signs in a single pass
-        // positive implies ccw convexity, negative implies cw convexity
-        // anything else implies non-convexity
-        .fold(ListSign::Empty, |acc, n| {
-            match (acc, n.is_positive()) {
-                (ListSign::Empty, true) | (ListSign::Positive, true) => ListSign::Positive,
-                (ListSign::Empty, false) | (ListSign::Negative, false) => ListSign::Negative,
-                _ => ListSign::Mixed
-            }
-        });
-    if convex == ListSign::Mixed {
+    if !polygon.convex() {
         return Err(());
     }
     let directions = vec![

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -51,7 +51,7 @@ where
     T: Float + Signed,
     F: Fn(&Point<T>, &Polygon<T>) -> Result<usize, ()>,
 {
-    if !polygon.convex() {
+    if !polygon.is_convex() {
         return Err(());
     }
     let directions = vec![

--- a/src/types.rs
+++ b/src/types.rs
@@ -771,7 +771,7 @@ where
     // The polygon is convex if the z-components of the cross products are either
     // all positive or all negative. Otherwise, the polygon is non-convex.
     // see: http://stackoverflow.com/a/1881201/416626
-    pub fn convex(&self) -> bool {
+    pub fn is_convex(&self) -> bool {
         let convex = self
             .exterior
             .0
@@ -795,11 +795,7 @@ where
                     _ => ListSign::Mixed
                 }
             });
-        if convex == ListSign::Mixed {
-            false
-        } else {
-            true
-        }
+        convex != ListSign::Mixed
     }
 }
 


### PR DESCRIPTION
The convexity function was previously only available within the
Extremes module, but it's generally useful and will be required by
other algorithms. This moves the function and implements it directly
on the type.