### PR TITLE
Don't enable 'proj' feature when building docs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ proj = ["proj-sys", "libc"]
 approx = "0.1.1"
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["postgis"]


### PR DESCRIPTION
The build is currently failing because the docs.rs machines don't have proj installed: https://docs.rs/crate/geo/0.8.0