### PR TITLE
Avoid Box in methods returning iterators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   * <https://github.com/georust/rust-geo/pull/209>
 * Use the `proj` crate, rename feature to `use-proj`
   * <https://github.com/georust/rust-geo/pull/214>
+* Return unboxed iterators from `LineString::lines`, `Winding::points_cw`, and `Winding::points_ccw`
+  * <https://github.com/georust/rust-geo/pull/218>
 * Fix compilation errors when using the `proj` feature
   * <https://github.com/georust/rust-geo/commit/0924f3179c95bfffb847562ee91675d7aa8454f5>
 

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -17,7 +17,7 @@ use std::ops::Neg;
 use std::ops::Sub;
 
 use num_traits::{Float, Num, NumCast, Signed, ToPrimitive};
-use std::iter::{self, FromIterator, Iterator};
+use std::iter::{FromIterator, Iterator};
 
 #[cfg(feature = "spade")]
 use spade::{BoundingRect, PointN, SpatialObject, TwoDimensional, SpadeNum};
@@ -518,15 +518,12 @@ impl<T: CoordinateType> LineString<T> {
     /// );
     /// assert!(lines.next().is_none());
     /// ```
-    pub fn lines<'a>(&'a self) -> Box<Iterator<Item = Line<T>> + 'a> {
-        if self.0.len() < 2 {
-            return Box::new(iter::empty());
-        }
-        Box::new(self.0.windows(2).map(|w| unsafe {
+    pub fn lines<'a>(&'a self) -> impl Iterator<Item = Line<T>> + 'a {
+        self.0.windows(2).map(|w| unsafe {
             // As long as the LineString has at least two points, we shouldn't
             // need to do bounds checking here.
             Line::new(*w.get_unchecked(0), *w.get_unchecked(1))
-        }))
+        })
     }
 
     pub fn points(&self) -> ::std::slice::Iter<Point<T>> {


### PR DESCRIPTION
Part of #198.

This only uses `impl Iterator` for `lines`. The other methods can't use it because they're part of a trait.

The code is a little ugly, and replacing `Points` with `impl Trait` in the future will be a breaking change. Feel free to close if you think it's not worth it.

For what it's worth, if we do switch to `impl Iterator` in the future, writing down the ugly `EitherIter<&'a Point<T>, Iter<'a, Point<T>>, Rev<Iter<'a, Point<T>>>>` type will no longer be needed.