### PR TITLE
HaversineIntermediate trait to find intermediate points along a great circle route

### DIFF
--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -324,6 +324,30 @@ where
     }
 }
 
+/// Line to MultiPolygon distance
+impl<T> EuclideanDistance<T, MultiPolygon<T>> for Line<T>
+where
+    T: Float + FloatConst + Signed + SpadeFloat,
+{
+    fn euclidean_distance(&self, mpolygon: &MultiPolygon<T>) -> T {
+        mpolygon
+            .0
+            .iter()
+            .map(|p| self.euclidean_distance(p))
+            .fold(T::max_value(), |accum, val| accum.min(val))
+    }
+}
+
+/// MultiPolygon to Line distance
+impl<T> EuclideanDistance<T, Line<T>> for MultiPolygon<T>
+where
+    T: Float + FloatConst + Signed + SpadeFloat,
+{
+    fn euclidean_distance(&self, other: &Line<T>) -> T {
+        other.euclidean_distance(self)
+    }
+}
+
 // Line to Polygon distance
 impl<T> EuclideanDistance<T, Polygon<T>> for Line<T>
 where
@@ -552,6 +576,50 @@ mod test {
         // 0.41036467732879783 <-- Shapely
         assert_relative_eq!(dist, 0.41036467732879767);
     }
+
+    #[test]
+    fn line_distance_multipolygon_do_not_touch_test() {
+        // checks that the distance from the multipolygon
+        // is equal to the distance from the closest polygon
+        // taken in isolation, whatever that distance is
+        let ls1 = LineString(vec![
+            Point::new(0.0,  0.0),
+            Point::new(10.0, 0.0),
+            Point::new(10.0, 10.0),
+            Point::new(5.0,  15.0),
+            Point::new(0.0,  10.0),
+            Point::new(0.0,  0.0),
+        ]);
+        let ls2 = LineString(vec![
+            Point::new(0.0,  30.0),
+            Point::new(0.0,  25.0),
+            Point::new(10.0, 25.0),
+            Point::new(10.0, 30.0),
+            Point::new(0.0,  30.0),
+        ]);
+        let ls3 = LineString(vec![
+            Point::new(15.0, 30.0),
+            Point::new(15.0, 25.0),
+            Point::new(20.0, 25.0),
+            Point::new(20.0, 30.0),
+            Point::new(15.0, 30.0),
+        ]);
+        let pol1 = Polygon::new(ls1, vec![]);
+        let pol2 = Polygon::new(ls2, vec![]);
+        let pol3 = Polygon::new(ls3, vec![]);
+        let mp   = MultiPolygon(vec![
+            pol1.clone(),
+            pol2.clone(),
+            pol3.clone(),
+        ]);
+        let pnt1 = Point::new(0.0,  15.0);
+        let pnt2 = Point::new(10.0, 20.0);
+        let ln   = Line::new(pnt1, pnt2);
+        let dist_mp_ln   = ln.euclidean_distance(&mp);
+        let dist_pol1_ln = ln.euclidean_distance(&pol1);
+        assert_relative_eq!(dist_mp_ln, dist_pol1_ln);
+    }
+
     #[test]
     fn point_distance_multipolygon_test() {
         let ls1 = LineString(vec![

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -578,7 +578,7 @@ mod test {
     }
 
     #[test]
-    fn line_distance_multipolygon_do_not_touch_test() {
+    fn line_distance_multipolygon_do_not_intersect_test() {
         // checks that the distance from the multipolygon
         // is equal to the distance from the closest polygon
         // taken in isolation, whatever that distance is

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -1,0 +1,66 @@
+use num_traits::{Float, FromPrimitive};
+use ::Point;
+
+/// Returns a new Point along a great circle route between two existing points
+
+pub trait HaversineIntermediate<T: Float> {
+    /// Returns a new Point along a great circle route between two existing points.
+    ///
+    /// ```
+    /// use geo::Point;
+    /// use geo::algorithm::haversine_intermediate::HaversineIntermediate;
+    ///
+    /// let p1 = Point::<f64>::new(10.0, 20.0);
+    /// let p2 = Point::<f64>::new(15.0, 25.0);
+    /// let pi = p1.haversine_intermediate(&p2, 0.5);
+    /// assert_eq!(pi, Point::<f64>::new(0.0, 0.0))
+    /// ```
+    fn haversine_intermediate(&self, other: &Point<T>, f: T) -> Point<T>;
+}
+
+impl<T> HaversineIntermediate<T> for Point<T>
+where
+    T: Float + FromPrimitive,
+{
+    fn haversine_intermediate(&self, other: &Point<T>, f: T) -> Point<T> {
+        Point::new(T::zero(), T::zero())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use algorithm::haversine_intermediate::HaversineIntermediate;
+    use num_traits::pow;
+
+    #[test]
+    fn f_is_zero_or_one_test() {
+        let p1 = Point::<f64>::new(10.0, 20.0);
+        let p2 = Point::<f64>::new(15.0, 25.0);
+        let i0   = p1.haversine_intermediate(&p2, 0.0);
+        let i100 = p1.haversine_intermediate(&p2, 1.0);
+        assert_eq!(i0,   p1);
+        assert_eq!(i100, p2);
+    }
+
+    #[test]
+    fn various_f_values_test() {
+        let p1 = Point::<f64>::new(10.0,  20.0);
+        let p2 = Point::<f64>::new(125.0, 25.0);
+        let i20  = p1.haversine_intermediate(&p2, 0.2);
+        let i50  = p1.haversine_intermediate(&p2, 0.5);
+        let i80  = p1.haversine_intermediate(&p2, 0.8);
+        assert_eq!(i20, Point::new(29.83519,  29.94841));
+        assert_eq!(i50, Point::new(65.87471,  37.72201));
+        assert_eq!(i80, Point::new(103.56036, 33.50518));
+    }
+
+    #[test]
+    fn should_be_north_pole_test() {
+        let p1 = Point::<f64>::new(0.0, 0.0);
+        let p2 = Point::<f64>::new(0.0, 180.0);
+        let i50  = p1.haversine_intermediate(&p2, 0.5);
+        assert_eq!(i50, Point::new(90.0, 0.0));
+    }
+}
+

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -32,12 +32,12 @@ where
         let lon2 = other.x().to_radians();
 
         let k = (((lat1 - lat2).sin() / two).powi(2) +
-                lat1.cos() + lat2.cos() *
+                lat1.cos() * lat2.cos() *
                 ((lon1 - lon2).sin() / two).powi(2)).sqrt();
 
-        let d = two * k.sin();
+        let d = two * k.asin();
 
-        let a = (one - f).sin() * d / d.sin();
+        let a = ((one - f) * d).sin() / d.sin();
         let b = (f * d).sin() / d.sin();
 
         let x = a * lat1.cos() * lon1.cos() +
@@ -95,10 +95,10 @@ mod test {
 
     #[test]
     fn should_be_north_pole_test() {
-        let p1 = Point::<f64>::new(0.0, 0.0);
-        let p2 = Point::<f64>::new(0.0, 180.0);
+        let p1 = Point::<f64>::new(0.0,   10.0);
+        let p2 = Point::<f64>::new(180.0, 10.0);
         let i50  = p1.haversine_intermediate(&p2, 0.5);
-        let i50_should = Point::new(90.0, 0.0);
+        let i50_should = Point::new(90.0, 90.0);
         assert_relative_eq!(i50.x(), i50_should.x(), epsilon=1.0e-6);
         assert_relative_eq!(i50.y(), i50_should.y(), epsilon=1.0e-6);
     }

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -113,14 +113,10 @@ fn get_params<T: Float + FromPrimitive>(p1: &Point<T>, p2: &Point<T>) -> Haversi
     let lat2 = p2.y().to_radians();
     let lon2 = p2.x().to_radians();
 
-    let lat1_cos = lat1.cos();
-    let lon1_cos = lon1.cos();
-    let lat2_cos = lat2.cos();
-    let lon2_cos = lon2.cos();
-    let lat1_sin = lat1.sin();
-    let lon1_sin = lon1.sin();
-    let lat2_sin = lat2.sin();
-    let lon2_sin = lon2.sin();
+    let (lat1_sin, lat1_cos) = lat1.sin_cos();
+    let (lat2_sin, lat2_cos) = lat2.sin_cos();
+    let (lon1_sin, lon1_cos) = lon1.sin_cos();
+    let (lon2_sin, lon2_cos) = lon2.sin_cos();
 
     let m = lat1_cos * lat2_cos;
 
@@ -219,4 +215,3 @@ mod test {
         assert_eq!(route, vec![p1, i25, i50, i75, p2]);
     }
 }
-

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -60,9 +60,7 @@ where
         let y = a * lat1.cos() * lon1.sin() + b * lat2.cos() * lon2.sin();
         let z = a * lat1.sin() + b * lat2.sin();
 
-        let dxy = (x.powi(2) + y.powi(2)).sqrt();
-
-        let lat = z.atan2(dxy);
+        let lat = z.atan2(x.hypot(y));
         let lon = y.atan2(x);
 
         Point::new(lon.to_degrees(), lat.to_degrees())

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -59,7 +59,7 @@ where
             }
         }
 
-        let number_of_points = (total_distance / max_dist).ceil();
+        let number_of_points = (total_distance / max_dist).floor();
         let step             = T::one() / number_of_points;
 
         let mut current_step = T::zero();

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -59,16 +59,16 @@ where
             }
         }
 
-        let number_of_points = (total_distance / max_dist).floor();
-        let step             = T::one() / number_of_points;
+        let number_of_points = (total_distance / max_dist).ceil();
+        let interval         = T::one() / number_of_points;
 
-        let mut current_step = T::zero();
+        let mut current_step = interval;
         let mut points = if include_ends { vec![self.clone()] } else { vec![] };
 
         while current_step < T::one() {
             let point  = get_point(&params, current_step);
             points.push(point);
-            current_step = current_step + step;
+            current_step = current_step + interval;
         }
 
         if include_ends {
@@ -183,6 +183,40 @@ mod test {
         let i50_should = Point::new(90.0, 90.0);
         assert_relative_eq!(i50.x(), i50_should.x(), epsilon=1.0e-6);
         assert_relative_eq!(i50.y(), i50_should.y(), epsilon=1.0e-6);
+    }
+
+    #[test]
+    fn should_be_start_end_test() {
+        let p1 = Point::<f64>::new(30.0, 40.0);
+        let p2 = Point::<f64>::new(40.0, 50.0);
+        let max_dist = 1500000.0; // meters
+        let include_ends = true;
+        let route = p1.haversine_intermediate_fill(&p2, max_dist, include_ends);
+        assert_eq!(route, vec![p1, p2]);
+    }
+
+    #[test]
+    fn should_add_i50_test() {
+        let p1 = Point::<f64>::new(30.0, 40.0);
+        let p2 = Point::<f64>::new(40.0, 50.0);
+        let max_dist = 1000000.0; // meters
+        let include_ends = true;
+        let i50 = p1.clone().haversine_intermediate(&p2, 0.5);
+        let route = p1.haversine_intermediate_fill(&p2, max_dist, include_ends);
+        assert_eq!(route, vec![p1, i50, p2]);
+    }
+
+    #[test]
+    fn should_add_i25_i50_i75_test() {
+        let p1 = Point::<f64>::new(30.0, 40.0);
+        let p2 = Point::<f64>::new(40.0, 50.0);
+        let max_dist = 400000.0; // meters
+        let include_ends = true;
+        let i25 = p1.clone().haversine_intermediate(&p2, 0.25);
+        let i50 = p1.clone().haversine_intermediate(&p2, 0.5);
+        let i75 = p1.clone().haversine_intermediate(&p2, 0.75);
+        let route = p1.haversine_intermediate_fill(&p2, max_dist, include_ends);
+        assert_eq!(route, vec![p1, i25, i50, i75, p2]);
     }
 }
 

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -7,13 +7,28 @@ pub trait HaversineIntermediate<T: Float> {
     /// Returns a new Point along a great circle route between two existing points.
     ///
     /// ```
+    /// # extern crate geo;
+    /// # #[macro_use] extern crate approx;
+    /// #
     /// use geo::Point;
     /// use geo::algorithm::haversine_intermediate::HaversineIntermediate;
     ///
-    /// let p1 = Point::<f64>::new(10.0, 20.0);
-    /// let p2 = Point::<f64>::new(15.0, 25.0);
-    /// let pi = p1.haversine_intermediate(&p2, 0.5);
-    /// assert_eq!(pi, Point::<f64>::new(0.0, 0.0))
+    /// # fn main() {
+    /// let p1 = Point::<f64>::new(10.0,  20.0);
+    /// let p2 = Point::<f64>::new(125.0, 25.0);
+    /// let i20        = p1.haversine_intermediate(&p2, 0.2);
+    /// let i50        = p1.haversine_intermediate(&p2, 0.5);
+    /// let i80        = p1.haversine_intermediate(&p2, 0.8);
+    /// let i20_should = Point::new(29.8,  29.9);
+    /// let i50_should = Point::new(65.8,  37.7);
+    /// let i80_should = Point::new(103.5, 33.5);
+    /// assert_relative_eq!(i20.x(), i20_should.x(), epsilon=0.2);
+    /// assert_relative_eq!(i20.y(), i20_should.y(), epsilon=0.2);
+    /// assert_relative_eq!(i50.x(), i50_should.x(), epsilon=0.2);
+    /// assert_relative_eq!(i50.y(), i50_should.y(), epsilon=0.2);
+    /// assert_relative_eq!(i80.x(), i80_should.x(), epsilon=0.2);
+    /// assert_relative_eq!(i80.y(), i80_should.y(), epsilon=0.2);
+    /// # }
     /// ```
     fn haversine_intermediate(&self, other: &Point<T>, f: T) -> Point<T>;
 }
@@ -31,21 +46,18 @@ where
         let lat2 = other.y().to_radians();
         let lon2 = other.x().to_radians();
 
-        let k = (((lat1 - lat2).sin() / two).powi(2) +
-                lat1.cos() * lat2.cos() *
-                ((lon1 - lon2).sin() / two).powi(2)).sqrt();
+        let k = (
+            ((lat1 - lat2) / two).sin().powi(2) +
+            lat1.cos() * lat2.cos() * ((lon1 - lon2) / two).sin().powi(2)
+        ).sqrt();
 
         let d = two * k.asin();
 
         let a = ((one - f) * d).sin() / d.sin();
         let b = (f * d).sin() / d.sin();
 
-        let x = a * lat1.cos() * lon1.cos() +
-                b * lat2.cos() * lon2.cos();
-
-        let y = a * lat1.cos() * lon1.sin() +
-                b * lat2.cos() * lon2.sin();
-
+        let x = a * lat1.cos() * lon1.cos() + b * lat2.cos() * lon2.cos();
+        let y = a * lat1.cos() * lon1.sin() + b * lat2.cos() * lon2.sin();
         let z = a * lat1.sin() + b * lat2.sin();
 
         let dxy = (x.powi(2) + y.powi(2)).sqrt();
@@ -85,12 +97,12 @@ mod test {
         let i20_should = Point::new(29.83519,  29.94841);
         let i50_should = Point::new(65.87471,  37.72201);
         let i80_should = Point::new(103.56036, 33.50518);
-        assert_relative_eq!(i20.x(), i20_should.x(), epsilon=1.0e-6);
-        assert_relative_eq!(i20.y(), i20_should.y(), epsilon=1.0e-6);
-        assert_relative_eq!(i50.x(), i50_should.x(), epsilon=1.0e-6);
-        assert_relative_eq!(i50.y(), i50_should.y(), epsilon=1.0e-6);
-        assert_relative_eq!(i80.x(), i80_should.x(), epsilon=1.0e-6);
-        assert_relative_eq!(i80.y(), i80_should.y(), epsilon=1.0e-6);
+        assert_relative_eq!(i20.x(), i20_should.x(), epsilon=0.2);
+        assert_relative_eq!(i20.y(), i20_should.y(), epsilon=0.2);
+        assert_relative_eq!(i50.x(), i50_should.x(), epsilon=0.2);
+        assert_relative_eq!(i50.y(), i50_should.y(), epsilon=0.2);
+        assert_relative_eq!(i80.x(), i80_should.x(), epsilon=0.2);
+        assert_relative_eq!(i80.y(), i80_should.y(), epsilon=0.2);
     }
 
     #[test]

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -82,9 +82,15 @@ mod test {
         let i20  = p1.haversine_intermediate(&p2, 0.2);
         let i50  = p1.haversine_intermediate(&p2, 0.5);
         let i80  = p1.haversine_intermediate(&p2, 0.8);
-        assert_eq!(i20, Point::new(29.83519,  29.94841));
-        assert_eq!(i50, Point::new(65.87471,  37.72201));
-        assert_eq!(i80, Point::new(103.56036, 33.50518));
+        let i20_should = Point::new(29.83519,  29.94841);
+        let i50_should = Point::new(65.87471,  37.72201);
+        let i80_should = Point::new(103.56036, 33.50518);
+        assert_relative_eq!(i20.x(), i20_should.x(), epsilon=1.0e-6);
+        assert_relative_eq!(i20.y(), i20_should.y(), epsilon=1.0e-6);
+        assert_relative_eq!(i50.x(), i50_should.x(), epsilon=1.0e-6);
+        assert_relative_eq!(i50.y(), i50_should.y(), epsilon=1.0e-6);
+        assert_relative_eq!(i80.x(), i80_should.x(), epsilon=1.0e-6);
+        assert_relative_eq!(i80.y(), i80_should.y(), epsilon=1.0e-6);
     }
 
     #[test]
@@ -92,7 +98,9 @@ mod test {
         let p1 = Point::<f64>::new(0.0, 0.0);
         let p2 = Point::<f64>::new(0.0, 180.0);
         let i50  = p1.haversine_intermediate(&p2, 0.5);
-        assert_eq!(i50, Point::new(90.0, 0.0));
+        let i50_should = Point::new(90.0, 0.0);
+        assert_relative_eq!(i50.x(), i50_should.x(), epsilon=1.0e-6);
+        assert_relative_eq!(i50.y(), i50_should.y(), epsilon=1.0e-6);
     }
 }
 

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -12,6 +12,8 @@ pub mod bearing;
 pub mod euclidean_length;
 /// Returns the Euclidean distance between two geometries.
 pub mod euclidean_distance;
+/// Returns a new Point along a great circle between two points.
+pub mod haversine_intermediate;
 /// Returns a new Point using distance and bearing.
 pub mod haversine_destination;
 /// Returns the Haversine distance between two geometries.

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -40,6 +40,7 @@ pub mod prelude {
     pub use algorithm::euclidean_distance::EuclideanDistance;
     pub use algorithm::euclidean_length::EuclideanLength;
     pub use algorithm::extremes::ExtremePoints;
+    pub use algorithm::haversine_intermediate::HaversineIntermediate;
     pub use algorithm::haversine_destination::HaversineDestination;
     pub use algorithm::haversine_distance::HaversineDistance;
     pub use algorithm::intersects::Intersects;


### PR DESCRIPTION
Given two existing points, implements the ability to find intermediate points along the great circle route joining the initial points.

The `haversine_intermediate` method takes three parameters:

- `&self`
- `other: &Point<T>` which represents the other side of the great circle route
- `f: T` which represents the fraction of the route at which to put the intermediate point

`f` must be included between `T::zero()` and `T::one()`.

Return value is `Point<T>`.