### PR TITLE
Add “Examples” section headings in doc comments.

### DIFF
--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -56,6 +56,8 @@ impl<T: CoordinateType> From<MultiPolygon<T>> for Geometry<T> {
 impl<T: CoordinateType> Geometry<T> {
     /// If this Geometry is a Point, then return that, else None.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo_types::*;
     /// let g = Geometry::Point(Point::new(0., 0.));

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -20,6 +20,8 @@ where
 {
     /// Creates a new line segment.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo_types::{Point, Line};
     ///

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -3,6 +3,8 @@ use {CoordinateType, Line, Point};
 
 /// An ordered collection of two or more [`Point`s](struct.Point.html), representing a path between locations
 ///
+/// # Examples
+///
 /// Create a `LineString` by calling it directly:
 ///
 /// ```

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -3,6 +3,8 @@ use {CoordinateType, Point};
 
 /// A collection of [`Point`s](struct.Point.html)
 ///
+/// # Examples
+///
 /// Iterating over a `MultiPoint` yields the `Point`s inside.
 ///
 /// ```

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -8,6 +8,8 @@ use {Coordinate, CoordinateType};
 ///
 /// Points can be created using the `new(x, y)` constructor, or from a `Coordinate` or pair of points.
 ///
+/// # Examples
+///
 /// ```
 /// use geo_types::{Point, Coordinate};
 /// let p1: Point<f64> = (0., 1.).into();
@@ -38,6 +40,8 @@ where
 {
     /// Creates a new point.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo_types::Point;
     ///
@@ -52,6 +56,8 @@ where
 
     /// Returns the x/horizontal component of the point.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo_types::Point;
     ///
@@ -64,6 +70,8 @@ where
     }
 
     /// Sets the x/horizontal component of the point.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo_types::Point;
@@ -80,6 +88,8 @@ where
 
     /// Returns the y/vertical component of the point.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo_types::Point;
     ///
@@ -92,6 +102,8 @@ where
     }
 
     /// Sets the y/vertical component of the point.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo_types::Point;
@@ -108,6 +120,8 @@ where
 
     /// Returns the longitude/horizontal component of the point.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo_types::Point;
     ///
@@ -120,6 +134,8 @@ where
     }
 
     /// Sets the longitude/horizontal component of the point.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo_types::Point;
@@ -135,6 +151,8 @@ where
 
     /// Returns the latitude/vertical component of the point.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo_types::Point;
     ///
@@ -147,6 +165,8 @@ where
     }
 
     /// Sets the latitude/vertical component of the point.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo_types::Point;
@@ -162,6 +182,8 @@ where
 
     /// Returns the dot product of the two points:
     /// `dot = x1 * x2 + y1 * y2`
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo_types::Point;
@@ -209,6 +231,8 @@ where
 
     /// Returns a point with the x and y components negated.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo_types::Point;
     ///
@@ -230,6 +254,8 @@ where
 
     /// Add a point to the given point.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo_types::Point;
     ///
@@ -250,6 +276,8 @@ where
     type Output = Point<T>;
 
     /// Subtract a point from the given point.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo_types::Point;

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -5,6 +5,8 @@ use {CoordinateType, LineString};
 ///
 /// It has one exterior *ring* or *shell*, and zero or more interior rings, representing holes.
 ///
+/// # Examples
+///
 /// Polygons can be created from collections of `Point`-like objects, such as arrays or tuples:
 ///
 /// ```
@@ -27,6 +29,8 @@ where
     T: CoordinateType,
 {
     /// Creates a new polygon.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo_types::{Point, LineString, Polygon};

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -12,6 +12,8 @@ where
     /// Area of polygon.
     /// See: https://en.wikipedia.org/wiki/Polygon
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Coordinate, Point, LineString, Polygon};
     /// use geo::algorithm::area::Area;

--- a/geo/src/algorithm/bearing.rs
+++ b/geo/src/algorithm/bearing.rs
@@ -9,6 +9,8 @@ use ::Point;
 pub trait Bearing<T: Float> {
     /// Returns the bearing to another Point in degrees, where North is 0° and East is 45°.
     ///
+    /// # Examples
+    ///
     /// ```
     /// # extern crate geo;
     /// # #[macro_use] extern crate approx;

--- a/geo/src/algorithm/boundingbox.rs
+++ b/geo/src/algorithm/boundingbox.rs
@@ -7,6 +7,8 @@ pub trait BoundingBox<T: CoordinateType> {
 
     /// Return the Bounding Box of a geometry
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Point, LineString};
     /// use geo::algorithm::boundingbox::BoundingBox;

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -10,6 +10,8 @@ pub trait Centroid<T: Float> {
 
     /// See: https://en.wikipedia.org/wiki/Centroid
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Point, LineString};
     /// use geo::algorithm::centroid::Centroid;

--- a/geo/src/algorithm/contains.rs
+++ b/geo/src/algorithm/contains.rs
@@ -8,6 +8,8 @@ use {Bbox, CoordinateType, Line, LineString, MultiPolygon, Point, Polygon, COORD
 pub trait Contains<Rhs = Self> {
     /// Checks if `rhs` is completely contained within `self`.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Coordinate, Point, LineString, Polygon};
     /// use geo::algorithm::contains::Contains;

--- a/geo/src/algorithm/convexhull.rs
+++ b/geo/src/algorithm/convexhull.rs
@@ -144,6 +144,8 @@ pub trait ConvexHull<T> {
     /// based on [Barber, C. Bradford; Dobkin, David P.; Huhdanpaa, Hannu (1 December 1996)](https://dx.doi.org/10.1145%2F235815.235821)
     /// Original paper here: http://www.cs.princeton.edu/~dpd/Papers/BarberDobkinHuhdanpaa.pdf
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Point, LineString, Polygon};
     /// use geo::convexhull::ConvexHull;

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -21,6 +21,8 @@ pub trait EuclideanDistance<T, Rhs = Self> {
     ///
     /// The distance between a `Point` and an empty `LineString` is `0.0`
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{COORD_PRECISION, Point, LineString, Polygon};
     /// use geo::algorithm::euclidean_distance::EuclideanDistance;

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -8,6 +8,8 @@ use algorithm::euclidean_distance::EuclideanDistance;
 pub trait EuclideanLength<T, RHS = Self> {
     /// Calculation of the length of a Line
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Point, LineString, Coordinate};
     /// use geo::algorithm::euclidean_length::EuclideanLength;

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -89,6 +89,8 @@ pub trait ExtremeIndices<T: Float + Signed> {
     ///
     /// The polygon **must be convex and properly (ccw) oriented**.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Point, LineString, Polygon};
     /// use geo::extremes::ExtremeIndices;
@@ -137,6 +139,8 @@ pub trait ExtremePoints<T: Float> {
     /// Find the extreme `x` and `y` points of a Geometry
     ///
     /// This trait is available to any struct implementing both `ConvexHull` amd `ExtremeIndices`
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo::{Point, LineString, Polygon};

--- a/geo/src/algorithm/haversine_destination.rs
+++ b/geo/src/algorithm/haversine_destination.rs
@@ -6,6 +6,8 @@ use ::Point;
 pub trait HaversineDestination<T: Float> {
     /// Returns a new Point using distance to the existing Point and a bearing for the direction
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::Point;
     /// use geo::algorithm::haversine_destination::HaversineDestination;

--- a/geo/src/algorithm/haversine_distance.rs
+++ b/geo/src/algorithm/haversine_distance.rs
@@ -6,6 +6,8 @@ use ::Point;
 pub trait HaversineDistance<T, Rhs = Self> {
     /// Returns the Haversine distance between two points:
     ///
+    /// # Examples
+    ///
     /// ```
     /// # extern crate geo;
     /// # #[macro_use] extern crate approx;

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -6,6 +6,8 @@ use ::Point;
 pub trait HaversineIntermediate<T: Float> {
     /// Returns a new Point along a great circle route between two existing points.
     ///
+    /// # Examples
+    ///
     /// ```
     /// # extern crate geo;
     /// # #[macro_use] extern crate approx;

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -9,6 +9,8 @@ use algorithm::haversine_distance::HaversineDistance;
 pub trait HaversineLength<T, RHS = Self> {
     /// Calculation of the length of a Line
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Point, LineString, Coordinate};
     /// use geo::algorithm::haversine_length::HaversineLength;

--- a/geo/src/algorithm/intersects.rs
+++ b/geo/src/algorithm/intersects.rs
@@ -7,6 +7,8 @@ use {Bbox, Line, LineString, Point, Polygon};
 pub trait Intersects<Rhs = Self> {
     /// Checks if the geometry A intersects the geometry B.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Coordinate, Point, LineString};
     /// use geo::algorithm::intersects::Intersects;

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -8,6 +8,8 @@ pub trait MapCoords<T, NT> {
 
     /// Apply a function to all the coordinates in a geometric object, returning a new object.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::Point;
     /// use geo::algorithm::map_coords::MapCoords;
@@ -41,6 +43,8 @@ pub trait TryMapCoords<T, NT> {
 
     /// Map a fallible function over all the coordinates in a geometry, returning a Result
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::Point;
     /// use geo::algorithm::map_coords::TryMapCoords;
@@ -62,6 +66,8 @@ pub trait TryMapCoords<T, NT> {
 /// Map all the coordinates in an object in place
 pub trait MapCoordsInplace<T> {
     /// Apply a function to all the coordinates in a geometric object, in place
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo::Point;

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -8,6 +8,8 @@ pub trait Orient<T> {
     /// By default, the exterior ring of a Polygon is oriented counter-clockwise, and any interior
     /// rings are oriented clockwise.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Point, LineString, Polygon};
     /// use geo::orient::{Orient, Direction};

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -32,6 +32,8 @@ pub trait Rotate<T> {
     ///
     /// Positive angles are counter-clockwise, and negative angles are clockwise rotations.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Point, LineString};
     /// use geo::algorithm::rotate::{Rotate};
@@ -58,6 +60,8 @@ pub trait RotatePoint<T> {
     /// Rotate a Geometry around an arbitrary point by an angle, given in degrees
     ///
     /// Positive angles are counter-clockwise, and negative angles are clockwise rotations.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo::{Point, LineString};

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -58,6 +58,8 @@ where
 pub trait Simplify<T, Epsilon = T> {
     /// Returns the simplified representation of a geometry, using the [Ramer–Douglas–Peucker](https://en.wikipedia.org/wiki/Ramer–Douglas–Peucker_algorithm) algorithm
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Point, LineString};
     /// use geo::algorithm::simplify::{Simplify};

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -424,6 +424,8 @@ pub trait SimplifyVW<T, Epsilon = T> {
     ///
     /// See [here](https://bost.ocks.org/mike/simplify/) for a graphical explanation
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::{Point, LineString};
     /// use geo::algorithm::simplifyvw::{SimplifyVW};
@@ -471,6 +473,8 @@ pub trait SimplifyVWPreserve<T, Epsilon = T> {
     /// points remaining (4 for a `LineString`, 6 for a `Polygon`), the point is retained and the
     /// simplification process ends. This is because there is no guarantee that removal of two points will remove
     /// the intersection, but removal of further points would leave too few points to form a valid geometry.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo::{Point, LineString};

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -4,6 +4,7 @@ use algorithm::map_coords::{MapCoords, MapCoordsInplace};
 pub trait Translate<T> {
     /// Translate a Geometry along its axes by the given offsets
     ///
+    /// # Examples
     ///
     /// ```
     /// use geo::{Point, LineString};

--- a/geo/src/types.rs
+++ b/geo/src/types.rs
@@ -61,6 +61,8 @@ where
 
     /// Add a BoundingBox to the given BoundingBox.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use geo::Bbox;
     ///
@@ -104,6 +106,8 @@ where
     T: CoordinateType + ToPrimitive,
 {
     /// Add a BoundingBox to the given BoundingBox.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use geo::Bbox;


### PR DESCRIPTION
This is recommend by [RFC 0505].

[RFC 0505]: https://github.com/rust-lang/rfcs/blob/c892139be692586e0846fbf934be6fceec17f329/text/0505-api-comment-conventions.md#using-markdown