### PR TITLE
Migrate Line/LineString to be a series of Coordinates (not Points).

### DIFF
--- a/geo-types/src/algorithms.rs
+++ b/geo-types/src/algorithms.rs
@@ -44,7 +44,8 @@ where
     T: Float,
 {
     fn euclidean_distance(&self, point: &Point<T>) -> T {
-        line_segment_distance(*point, self.start, self.end)
+        let (start, end) = self.points();
+        line_segment_distance(*point, start, end)
     }
 }
 
@@ -63,15 +64,15 @@ where
     fn bbox(&self) -> Self::Output {
         let a = self.start;
         let b = self.end;
-        let (xmin, xmax) = if a.x() <= b.x() {
-            (a.x(), b.x())
+        let (xmin, xmax) = if a.x <= b.x {
+            (a.x, b.x)
         } else {
-            (b.x(), a.x())
+            (b.x, a.x)
         };
-        let (ymin, ymax) = if a.y() <= b.y() {
-            (a.y(), b.y())
+        let (ymin, ymax) = if a.y <= b.y {
+            (a.y, b.y)
         } else {
-            (b.y(), a.y())
+            (b.y, a.y)
         };
         Bbox {
             xmin,

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -1,7 +1,13 @@
-use num_traits::{Float, ToPrimitive};
+use num_traits::ToPrimitive;
 use {CoordinateType, Point};
 
-/// A primitive type which holds `x` and `y` position information
+/// A lightweight struct used to store coordinates on the 2-dimensional
+/// Cartesian plane.
+///
+/// Unlike `Point` (which in the future may contain additional information such
+/// as an envelope, a precision model, and spatial reference system
+/// information), a `Coordinate` only contains ordinate values and accessor
+/// methods.
 #[derive(PartialEq, Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Coordinate<T>
@@ -32,11 +38,14 @@ impl<T: CoordinateType> From<[T; 2]> for Coordinate<T> {
 
 impl<T: CoordinateType> From<Point<T>> for Coordinate<T> {
     fn from(point: Point<T>) -> Self {
-        point.0
+        Coordinate {
+            x: point.x(),
+            y: point.y(),
+        }
     }
 }
 
-impl<T>Coordinate<T> 
+impl<T>Coordinate<T>
 where
     T: CoordinateType + ToPrimitive,
 {
@@ -48,11 +57,10 @@ where
     /// ```
     /// use geo_types::Coordinate;
     ///
-    /// 
-    ///  let c = Coordinate {
-    ///        x: 40.02f64,
-    ///        y: 116.34,
-    ///    };
+    /// let c = Coordinate {
+    ///     x: 40.02f64,
+    ///     y: 116.34,
+    /// };
     /// let (x, y) = c.x_y();
     ///
     /// assert_eq!(y, 116.34);

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -32,7 +32,7 @@ pub use multi_point::MultiPoint;
 mod line;
 pub use line::Line;
 
-mod line_string;
+pub mod line_string;
 pub use line_string::LineString;
 
 mod multi_line_string;
@@ -88,16 +88,16 @@ mod test {
     #[test]
     fn polygon_new_test() {
         let exterior = LineString(vec![
-            Point::new(0., 0.),
-            Point::new(1., 1.),
-            Point::new(1., 0.),
-            Point::new(0., 0.),
+            Coordinate { x: 0., y: 0. },
+            Coordinate { x: 1., y: 1. },
+            Coordinate { x: 1., y: 0. },
+            Coordinate { x: 0., y: 0. },
         ]);
         let interiors = vec![LineString(vec![
-            Point::new(0.1, 0.1),
-            Point::new(0.9, 0.9),
-            Point::new(0.9, 0.1),
-            Point::new(0.1, 0.1),
+            Coordinate { x: 0.1, y: 0.1 },
+            Coordinate { x: 0.9, y: 0.9 },
+            Coordinate { x: 0.9, y: 0.1 },
+            Coordinate { x: 0.1, y: 0.1 },
         ])];
         let p = Polygon::new(exterior.clone(), interiors.clone());
 
@@ -129,7 +129,10 @@ mod test {
     fn line_test() {
         use spade::primitives::SimpleEdge;
         let se = SimpleEdge::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
-        let l = Line::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
+        let l = Line::new(
+            Coordinate { x: 0.0, y: 0.0 },
+            Coordinate { x: 5., y: 5. },
+        );
         assert_eq!(se.mbr(), l.mbr());
         // difference in 15th decimal place
         assert_eq!(26.0, se.distance2(&Point::new(4.0, 10.0)));

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -10,8 +10,8 @@ pub struct Line<T>
 where
     T: CoordinateType,
 {
-    pub start: Point<T>,
-    pub end: Point<T>,
+    pub start: Coordinate<T>,
+    pub end: Coordinate<T>,
 }
 
 impl<T> Line<T>
@@ -30,16 +30,16 @@ where
     ///     Coordinate { x: 1., y: 2. },
     /// );
     ///
-    /// assert_eq!(line.start.0, Coordinate { x: 0., y: 0. });
-    /// assert_eq!(line.end.0, Coordinate { x: 1., y: 2. });
+    /// assert_eq!(line.start, Coordinate { x: 0., y: 0. });
+    /// assert_eq!(line.end, Coordinate { x: 1., y: 2. });
     /// ```
     pub fn new<C>(start: C, end: C) -> Line<T>
     where
         C: Into<Coordinate<T>>,
     {
         Line {
-            start: Point(start.into()),
-            end: Point(end.into()),
+            start: start.into(),
+            end: end.into(),
         }
     }
 
@@ -55,11 +55,11 @@ where
     /// # );
     /// # assert_eq!(
     /// #     line.dx(),
-    /// line.end.x() - line.start.x()
+    /// line.end.x - line.start.x
     /// # );
     /// ```
     pub fn dx(&self) -> T {
-        self.end.x() - self.start.x()
+        self.end.x - self.start.x
     }
 
     /// Calculate the difference in ‘y’ components (Δy).
@@ -74,11 +74,11 @@ where
     /// # );
     /// # assert_eq!(
     /// #     line.dy(),
-    /// line.end.y() - line.start.y()
+    /// line.end.y - line.start.y
     /// # );
     /// ```
     pub fn dy(&self) -> T {
-        self.end.y() - self.start.y()
+        self.end.y - self.start.y
     }
 
     /// Calculate the slope (Δy/Δx).
@@ -124,8 +124,8 @@ where
     /// # );
     /// # assert_eq!(
     /// #     line.determinant(),
-    /// line.start.x() * line.end.y() -
-    ///     line.start.y() * line.end.x()
+    /// line.start.x * line.end.y -
+    ///     line.start.y * line.end.x
     /// # );
     /// ```
     ///
@@ -140,9 +140,26 @@ where
     ///     -Line::new(b, a).determinant()
     /// # );
     /// ```
-    ///
     pub fn determinant(&self) -> T {
-        self.start.x() * self.end.y() - self.start.y() * self.end.x()
+        self.start.x * self.end.y - self.start.y * self.end.x
+    }
+
+    pub fn start_point(&self) -> Point<T> {
+        Point(self.start)
+    }
+
+    pub fn end_point(&self) -> Point<T> {
+        Point(self.end)
+    }
+
+    pub fn points(&self) -> (Point<T>, Point<T>) {
+        (self.start_point(), self.end_point())
+    }
+}
+
+impl<T: CoordinateType> From<[(T, T); 2]> for Line<T> {
+    fn from(coord: [(T, T); 2]) -> Line<T> {
+        Line::new(coord[0], coord[1])
     }
 }
 

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -1,111 +1,150 @@
 use std::iter::FromIterator;
-use {CoordinateType, Line, Point};
+use {Coordinate, CoordinateType, Line, Point};
 
-/// An ordered collection of two or more [`Point`s](struct.Point.html), representing a path between locations
+/// An ordered collection of two or more [`Coordinate`s](struct.Coordinate.html), representing a
+/// path between locations.
 ///
 /// # Examples
 ///
 /// Create a `LineString` by calling it directly:
 ///
 /// ```
-/// use geo_types::{LineString, Point};
-/// let line = LineString(vec![Point::new(0., 0.), Point::new(10., 0.)]);
+/// use geo_types::{LineString, Coordinate};
+///
+/// let line_string = LineString(vec![
+///     Coordinate { x: 0., y: 0. },
+///     Coordinate { x: 10., y: 0. },
+/// ]);
 /// ```
 ///
-/// Converting a `Vec` of `Point`-like things:
+/// Converting a `Vec` of `Coordinate`-like things:
 ///
 /// ```
-/// # use geo_types::{LineString, Point};
-/// let line: LineString<f32> = vec![(0., 0.), (10., 0.)].into();
+/// use geo_types::LineString;
+///
+/// let line_string: LineString<f32> = vec![
+///     (0., 0.),
+///     (10., 0.),
+/// ].into();
 /// ```
 ///
 /// ```
-/// # use geo_types::{LineString, Point};
-/// let line: LineString<f64> = vec![[0., 0.], [10., 0.]].into();
+/// use geo_types::LineString;
+///
+/// let line_string: LineString<f64> = vec![
+///     [0., 0.],
+///     [10., 0.],
+/// ].into();
 /// ```
 //
-/// Or `collect`ing from a Point iterator
+/// Or `collect`ing from a `Coordinate` iterator
 ///
 /// ```
-/// # use geo_types::{LineString, Point};
-/// let mut points = vec![Point::new(0., 0.), Point::new(10., 0.)];
-/// let line: LineString<f32> = points.into_iter().collect();
+/// use geo_types::{LineString, Coordinate};
+///
+/// let mut coords_iter = vec![
+///     Coordinate { x: 0., y: 0. },
+///     Coordinate { x: 10., y: 0. }
+/// ].into_iter();
+///
+/// let line_string: LineString<f32> = coords_iter.collect();
 /// ```
 ///
-/// You can iterate over the points in the `LineString`
+/// You can iterate over the coordinates in the `LineString`:
 ///
 /// ```
-/// use geo_types::{LineString, Point};
-/// let line = LineString(vec![Point::new(0., 0.), Point::new(10., 0.)]);
-/// for point in line {
-///     println!("Point x = {}, y = {}", point.x(), point.y());
+/// use geo_types::{LineString, Coordinate};
+///
+/// let line_string = LineString(vec![
+///     Coordinate { x: 0., y: 0. },
+///     Coordinate { x: 10., y: 0. },
+/// ]);
+///
+/// for coord in line_string {
+///     println!("Coordinate x = {}, y = {}", coord.x, coord.y);
 /// }
 /// ```
 ///
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct LineString<T>(pub Vec<Point<T>>)
+pub struct LineString<T>(pub Vec<Coordinate<T>>)
 where
     T: CoordinateType;
 
+pub struct PointsIter<'a, T: CoordinateType + 'a>(::std::slice::Iter<'a, Coordinate<T>>);
+
+impl<'a, T: CoordinateType> Iterator for PointsIter<'a, T> {
+    type Item = Point<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|c| Point(*c))
+    }
+}
+
+impl<'a, T: CoordinateType> DoubleEndedIterator for PointsIter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back().map(|c| Point(*c))
+    }
+}
+
 impl<T: CoordinateType> LineString<T> {
+    pub fn points_iter(&self) -> PointsIter<T> {
+        PointsIter(self.0.iter())
+    }
+
+    pub fn into_points(self) -> Vec<Point<T>> {
+        self.0.into_iter().map(Point).collect()
+    }
+
     /// Return an `Line` iterator that yields one `Line` for each line segment
     /// in the `LineString`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Line, LineString, Point};
+    /// use geo_types::{Line, LineString, Coordinate};
     ///
-    /// let mut points = vec![(0., 0.), (5., 0.), (7., 9.)];
-    /// let linestring: LineString<f32> = points.into_iter().collect();
+    /// let mut coords = vec![(0., 0.), (5., 0.), (7., 9.)];
+    /// let line_string: LineString<f32> = coords.into_iter().collect();
     ///
-    /// let mut lines = linestring.lines();
+    /// let mut lines = line_string.lines();
     /// assert_eq!(
-    ///     Some(Line::new(Point::new(0., 0.), Point::new(5., 0.))),
+    ///     Some(Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 5., y: 0. })),
     ///     lines.next()
     /// );
     /// assert_eq!(
-    ///     Some(Line::new(Point::new(5., 0.), Point::new(7., 9.))),
+    ///     Some(Line::new(Coordinate { x: 5., y: 0. }, Coordinate { x: 7., y: 9. })),
     ///     lines.next()
     /// );
     /// assert!(lines.next().is_none());
     /// ```
     pub fn lines<'a>(&'a self) -> impl ExactSizeIterator + Iterator<Item = Line<T>> + 'a {
         self.0.windows(2).map(|w| unsafe {
-            // As long as the LineString has at least two points, we shouldn't
+            // As long as the LineString has at least two coordinates, we shouldn't
             // need to do bounds checking here.
             Line::new(*w.get_unchecked(0), *w.get_unchecked(1))
         })
     }
-
-    pub fn points(&self) -> ::std::slice::Iter<Point<T>> {
-        self.0.iter()
-    }
-
-    pub fn points_mut(&mut self) -> ::std::slice::IterMut<Point<T>> {
-        self.0.iter_mut()
-    }
 }
 
 /// Turn a `Vec` of `Point`-ish objects into a `LineString`.
-impl<T: CoordinateType, IP: Into<Point<T>>> From<Vec<IP>> for LineString<T> {
-    fn from(v: Vec<IP>) -> Self {
-        LineString(v.into_iter().map(|p| p.into()).collect())
+impl<T: CoordinateType, IC: Into<Coordinate<T>>> From<Vec<IC>> for LineString<T> {
+    fn from(v: Vec<IC>) -> Self {
+        LineString(v.into_iter().map(|c| c.into()).collect())
     }
 }
 
 /// Turn a `Point`-ish iterator into a `LineString`.
-impl<T: CoordinateType, IP: Into<Point<T>>> FromIterator<IP> for LineString<T> {
-    fn from_iter<I: IntoIterator<Item = IP>>(iter: I) -> Self {
-        LineString(iter.into_iter().map(|p| p.into()).collect())
+impl<T: CoordinateType, IC: Into<Coordinate<T>>> FromIterator<IC> for LineString<T> {
+    fn from_iter<I: IntoIterator<Item = IC>>(iter: I) -> Self {
+        LineString(iter.into_iter().map(|c| c.into()).collect())
     }
 }
 
-/// Iterate over all the [Point](struct.Point.html)s in this linestring
+/// Iterate over all the [Coordinate](struct.Coordinates.html)s in this `LineString`.
 impl<T: CoordinateType> IntoIterator for LineString<T> {
-    type Item = Point<T>;
-    type IntoIter = ::std::vec::IntoIter<Point<T>>;
+    type Item = Coordinate<T>;
+    type IntoIter = ::std::vec::IntoIter<Coordinate<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,4 +1,4 @@
-use num_traits::{Float, ToPrimitive};
+use num_traits::ToPrimitive;
 use std::ops::Add;
 use std::ops::Neg;
 use std::ops::Sub;
@@ -194,22 +194,27 @@ where
     pub fn set_lat(&mut self, lat: T) -> &mut Point<T> {
         self.set_y(lat)
     }
+}
 
+impl<T> Point<T>
+where
+    T: CoordinateType,
+{
     /// Returns the dot product of the two points:
     /// `dot = x1 * x2 + y1 * y2`
     ///
     /// # Examples
     ///
     /// ```
-    /// use geo_types::Point;
+    /// use geo_types::{Coordinate, Point};
     ///
-    /// let p = Point::new(1.5, 0.5);
-    /// let dot = p.dot(Point::new(2.0, 4.5));
+    /// let point = Point(Coordinate { x: 1.5, y: 0.5 });
+    /// let dot = point.dot(Point(Coordinate { x: 2.0, y: 4.5 }));
     ///
     /// assert_eq!(dot, 5.25);
     /// ```
-    pub fn dot(self, point: Point<T>) -> T {
-        self.x() * point.x() + self.y() * point.y()
+    pub fn dot(&self, other: Point<T>) -> T {
+        self.x() * other.x() + self.y() * other.y()
     }
 
     /// Returns the cross product of 3 points. A positive value implies
@@ -219,20 +224,17 @@ where
     /// # Examples
     ///
     /// ```
-    /// use geo_types::Point;
+    /// use geo_types::{Coordinate, Point};
     ///
-    /// let p_a = Point::new(1.0, 2.0);
-    /// let p_b = Point::new(3.0,5.0);
-    /// let p_c = Point::new(7.0,12.0);
+    /// let point_a = Point(Coordinate { x: 1., y: 2. });
+    /// let point_b = Point(Coordinate { x: 3., y: 5. });
+    /// let point_c = Point(Coordinate { x: 7., y: 12. });
     ///
-    /// let cross = p_a.cross_prod(p_b, p_c);
+    /// let cross = point_a.cross_prod(point_b, point_c);
     ///
     /// assert_eq!(cross, 2.0)
     /// ```
-    pub fn cross_prod(self, point_b: Point<T>, point_c: Point<T>) -> T
-    where
-        T: Float,
-    {
+    pub fn cross_prod(&self, point_b: Point<T>, point_c: Point<T>) -> T {
         (point_b.x() - self.x()) * (point_c.y() - self.y())
             - (point_b.y() - self.y()) * (point_c.x() - self.x())
     }

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -1,5 +1,5 @@
 use num_traits::{Float, Signed};
-use {CoordinateType, LineString};
+use {CoordinateType, LineString, Point};
 
 /// A representation of an area. Its outer boundary is represented by a [`LineString`](struct.LineString.html) that is both closed and simple
 ///
@@ -33,12 +33,20 @@ where
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Point, LineString, Polygon};
+    /// use geo_types::{Coordinate, LineString, Polygon};
     ///
-    /// let exterior = LineString(vec![Point::new(0., 0.), Point::new(1., 1.),
-    ///                                Point::new(1., 0.), Point::new(0., 0.)]);
-    /// let interiors = vec![LineString(vec![Point::new(0.1, 0.1), Point::new(0.9, 0.9),
-    ///                                      Point::new(0.9, 0.1), Point::new(0.1, 0.1)])];
+    /// let exterior = LineString(vec![
+    ///     Coordinate { x: 0., y: 0. },
+    ///     Coordinate { x: 1., y: 1. },
+    ///     Coordinate { x: 1., y: 0. },
+    ///     Coordinate { x: 0., y: 0. },
+    /// ]);
+    /// let interiors = vec![LineString(vec![
+    ///     Coordinate { x: 0.1, y: 0.1 },
+    ///     Coordinate { x: 0.9, y: 0.9 },
+    ///     Coordinate { x: 0.9, y: 0.1 },
+    ///     Coordinate { x: 0.1, y: 0.1 },
+    /// ])];
     /// let p = Polygon::new(exterior.clone(), interiors.clone());
     /// assert_eq!(p.exterior, exterior);
     /// assert_eq!(p.interiors, interiors);
@@ -88,9 +96,9 @@ where
             .map(|(idx, _)| {
                 let prev_1 = self.previous_vertex(&idx);
                 let prev_2 = self.previous_vertex(&prev_1);
-                self.exterior.0[prev_2].cross_prod(
-                    self.exterior.0[prev_1],
-                    self.exterior.0[idx]
+                Point(self.exterior.0[prev_2]).cross_prod(
+                    Point(self.exterior.0[prev_1]),
+                    Point(self.exterior.0[idx])
                 )
             })
             // accumulate and check cross-product result signs in a single pass

--- a/geo/examples/algorithm.rs
+++ b/geo/examples/algorithm.rs
@@ -1,18 +1,18 @@
 extern crate geo;
 
-use geo::{Point, LineString, Coordinate};
+use geo::{LineString, Coordinate};
 use geo::algorithm::centroid::Centroid;
 
-fn main() {    
+fn main() {
     let mut vec = Vec::new();
-    vec.push(Point(Coordinate{
+    vec.push(Coordinate{
         x: 40.02f64,
         y: 116.34
-    }));
-    vec.push(Point(Coordinate{
+    });
+    vec.push(Coordinate{
         x: 41.02f64,
         y: 116.34
-    }));
+    });
     let linestring = LineString(vec);
     println!("Centroid {:?}", linestring.centroid());
 }

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -19,7 +19,7 @@ where
     /// use geo::algorithm::area::Area;
     /// let p = |x, y| Point(Coordinate { x: x, y: y });
     /// let v = Vec::new();
-    /// let linestring = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
+    /// let linestring = LineString::from(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
     /// let poly = Polygon::new(linestring, v);
     /// assert_eq!(poly.area(), 30.);
     /// ```
@@ -76,7 +76,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use ::{Bbox, Coordinate, Line, LineString, MultiPolygon, Point, Polygon};
+    use ::{Bbox, Coordinate, Line, LineString, MultiPolygon, Polygon};
     use algorithm::area::Area;
 
     // Area of the polygon
@@ -88,13 +88,12 @@ mod test {
 
     #[test]
     fn area_one_point_polygon_test() {
-        let poly = Polygon::new(LineString(vec![Point::new(1., 0.)]), Vec::new());
+        let poly = Polygon::new(LineString::from(vec![(1., 0.)]), Vec::new());
         assert_relative_eq!(poly.area(), 0.);
     }
     #[test]
     fn area_polygon_test() {
-        let p = |x, y| Point(Coordinate { x: x, y: y });
-        let linestring = LineString(vec![p(0., 0.), p(5., 0.), p(5., 6.), p(0., 6.), p(0., 0.)]);
+        let linestring = LineString::from(vec![(0., 0.), (5., 0.), (5., 6.), (0., 6.), (0., 0.)]);
         let poly = Polygon::new(linestring, Vec::new());
         assert_relative_eq!(poly.area(), 30.);
     }
@@ -110,38 +109,36 @@ mod test {
     }
     #[test]
     fn area_polygon_inner_test() {
-        let p = |x, y| Point(Coordinate { x: x, y: y });
-        let outer = LineString(vec![
-            p(0., 0.),
-            p(10., 0.),
-            p(10., 10.),
-            p(0., 10.),
-            p(0., 0.),
+        let outer = LineString::from(vec![
+            (0., 0.),
+            (10., 0.),
+            (10., 10.),
+            (0., 10.),
+            (0., 0.),
         ]);
-        let inner0 = LineString(vec![p(1., 1.), p(2., 1.), p(2., 2.), p(1., 2.), p(1., 1.)]);
-        let inner1 = LineString(vec![p(5., 5.), p(6., 5.), p(6., 6.), p(5., 6.), p(5., 5.)]);
+        let inner0 = LineString::from(vec![(1., 1.), (2., 1.), (2., 2.), (1., 2.), (1., 1.)]);
+        let inner1 = LineString::from(vec![(5., 5.), (6., 5.), (6., 6.), (5., 6.), (5., 5.)]);
         let poly = Polygon::new(outer, vec![inner0, inner1]);
         assert_relative_eq!(poly.area(), 98.);
     }
     #[test]
     fn area_multipolygon_test() {
-        let p = |x, y| Point(Coordinate { x: x, y: y });
         let poly0 = Polygon::new(
-            LineString(vec![
-                p(0., 0.),
-                p(10., 0.),
-                p(10., 10.),
-                p(0., 10.),
-                p(0., 0.),
+            LineString::from(vec![
+                (0., 0.),
+                (10., 0.),
+                (10., 10.),
+                (0., 10.),
+                (0., 0.),
             ]),
             Vec::new(),
         );
         let poly1 = Polygon::new(
-            LineString(vec![p(1., 1.), p(2., 1.), p(2., 2.), p(1., 2.), p(1., 1.)]),
+            LineString::from(vec![(1., 1.), (2., 1.), (2., 2.), (1., 2.), (1., 1.)]),
             Vec::new(),
         );
         let poly2 = Polygon::new(
-            LineString(vec![p(5., 5.), p(6., 5.), p(6., 6.), p(5., 6.), p(5., 5.)]),
+            LineString::from(vec![(5., 5.), (6., 5.), (6., 6.), (5., 6.), (5., 5.)]),
             Vec::new(),
         );
         let mpoly = MultiPolygon(vec![poly0, poly1, poly2]);
@@ -150,8 +147,10 @@ mod test {
     }
     #[test]
     fn area_line_test() {
-        let p = |x, y| Point(Coordinate { x: x, y: y });
-        let line1 = Line::new(p(0.0, 0.0), p(1.0, 1.0));
+        let line1 = Line::new(
+            Coordinate { x: 0.0, y: 0.0 },
+            Coordinate { x: 1.0, y: 1.0 },
+        );
         assert_eq!(line1.area(), 0.);
     }
 }

--- a/geo/src/algorithm/convexhull.rs
+++ b/geo/src/algorithm/convexhull.rs
@@ -107,7 +107,7 @@ where
     let mut furthest_idx = 0;
     for (idx, point) in set.iter().enumerate() {
         // let current_distance = pseudo_distance(p_a, p_b, point);
-        let current_distance = point.euclidean_distance(&Line::new(p_a, p_b));
+        let current_distance = point.euclidean_distance(&Line::new(p_a.0, p_b.0));
         if current_distance > furthest_distance {
             furthest_distance = current_distance;
             furthest_idx = idx
@@ -138,12 +138,12 @@ pub trait ConvexHull<T> {
     /// use geo::convexhull::ConvexHull;
     /// // an L shape
     /// let coords = vec![(0.0, 0.0), (4.0, 0.0), (4.0, 1.0), (1.0, 1.0), (1.0, 4.0), (0.0, 4.0), (0.0, 0.0)];
-    /// let ls = LineString(coords.iter().map(|e| Point::new(e.0, e.1)).collect());
+    /// let ls: LineString<_> = coords.iter().map(|e| Point::new(e.0, e.1)).collect();
     /// let poly = Polygon::new(ls, vec![]);
     ///
     /// // The correct convex hull coordinates
     /// let hull_coords = vec![(4.0, 0.0), (4.0, 1.0), (1.0, 4.0), (0.0, 4.0), (0.0, 0.0), (4.0, 0.0)];
-    /// let correct_hull = LineString(hull_coords.iter().map(|e| Point::new(e.0, e.1)).collect());
+    /// let correct_hull: LineString<_> = hull_coords.iter().map(|e| Point::new(e.0, e.1)).collect();
     ///
     /// let res = poly.convex_hull();
     /// assert_eq!(res.exterior, correct_hull);
@@ -158,7 +158,7 @@ where
     T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
-        Polygon::new(LineString(quick_hull(&mut self.exterior.0.clone())), vec![])
+        Polygon::new(LineString::from(quick_hull(&mut self.exterior.clone().into_points())), vec![])
     }
 }
 
@@ -169,9 +169,9 @@ where
     fn convex_hull(&self) -> Polygon<T> {
         let mut aggregated: Vec<Point<T>> = self.0
             .iter()
-            .flat_map(|elem| elem.exterior.0.iter().cloned())
+            .flat_map(|elem| elem.exterior.0.iter().map(|c| Point(*c)))
             .collect();
-        Polygon::new(LineString(quick_hull(&mut aggregated)), vec![])
+        Polygon::new(LineString::from(quick_hull(&mut aggregated)), vec![])
     }
 }
 
@@ -180,7 +180,7 @@ where
     T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
-        Polygon::new(LineString(quick_hull(&mut self.0.clone())), vec![])
+        Polygon::new(LineString::from(quick_hull(&mut self.clone().into_points())), vec![])
     }
 }
 
@@ -191,9 +191,9 @@ where
     fn convex_hull(&self) -> Polygon<T> {
         let mut aggregated: Vec<Point<T>> = self.0
             .iter()
-            .flat_map(|elem| elem.0.iter().cloned())
+            .flat_map(|elem| elem.clone().into_points())
             .collect();
-        Polygon::new(LineString(quick_hull(&mut aggregated)), vec![])
+        Polygon::new(LineString::from(quick_hull(&mut aggregated)), vec![])
     }
 }
 
@@ -202,13 +202,13 @@ where
     T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
-        Polygon::new(LineString(quick_hull(&mut self.0.clone())), vec![])
+        Polygon::new(LineString::from(quick_hull(&mut self.0.clone())), vec![])
     }
 }
 
 #[cfg(test)]
 mod test {
-    use ::Point;
+    use ::{Point, Coordinate};
     use super::*;
 
     #[test]
@@ -333,11 +333,11 @@ mod test {
         ];
         let mp = MultiPoint(v);
         let correct = vec![
-            Point::new(0.0, -10.0),
-            Point::new(10.0, 0.0),
-            Point::new(0.0, 10.0),
-            Point::new(-10.0, 0.0),
-            Point::new(0.0, -10.0),
+            Coordinate::from((0.0, -10.0)),
+            Coordinate::from((10.0, 0.0)),
+            Coordinate::from((0.0, 10.0)),
+            Coordinate::from((-10.0, 0.0)),
+            Coordinate::from((0.0, -10.0)),
         ];
         let res = mp.convex_hull();
         assert_eq!(res.exterior.0, correct);
@@ -345,69 +345,69 @@ mod test {
     #[test]
     fn quick_hull_linestring_test() {
         let v = vec![
-            Point::new(0.0, 10.0),
-            Point::new(1.0, 1.0),
-            Point::new(10.0, 0.0),
-            Point::new(1.0, -1.0),
-            Point::new(0.0, -10.0),
-            Point::new(-1.0, -1.0),
-            Point::new(-10.0, 0.0),
-            Point::new(-1.0, 1.0),
-            Point::new(0.0, 10.0),
+            (0.0, 10.0),
+            (1.0, 1.0),
+            (10.0, 0.0),
+            (1.0, -1.0),
+            (0.0, -10.0),
+            (-1.0, -1.0),
+            (-10.0, 0.0),
+            (-1.0, 1.0),
+            (0.0, 10.0),
         ];
-        let mp = LineString(v);
+        let mp = LineString::from(v);
         let correct = vec![
-            Point::new(0.0, -10.0),
-            Point::new(10.0, 0.0),
-            Point::new(0.0, 10.0),
-            Point::new(-10.0, 0.0),
-            Point::new(0.0, -10.0),
+            Coordinate::from((0.0, -10.0)),
+            Coordinate::from((10.0, 0.0)),
+            Coordinate::from((0.0, 10.0)),
+            Coordinate::from((-10.0, 0.0)),
+            Coordinate::from((0.0, -10.0)),
         ];
         let res = mp.convex_hull();
         assert_eq!(res.exterior.0, correct);
     }
     #[test]
     fn quick_hull_multilinestring_test() {
-        let v1 = LineString(vec![Point::new(0.0, 0.0), Point::new(1.0, 10.0)]);
-        let v2 = LineString(vec![
-            Point::new(1.0, 10.0),
-            Point::new(2.0, 0.0),
-            Point::new(3.0, 1.0),
+        let v1 = LineString::from(vec![(0.0, 0.0), (1.0, 10.0)]);
+        let v2 = LineString::from(vec![
+            (1.0, 10.0),
+            (2.0, 0.0),
+            (3.0, 1.0),
         ]);
         let mls = MultiLineString(vec![v1, v2]);
         let correct = vec![
-            Point::new(2.0, 0.0),
-            Point::new(3.0, 1.0),
-            Point::new(1.0, 10.0),
-            Point::new(0.0, 0.0),
-            Point::new(2.0, 0.0),
+            Coordinate::from((2.0, 0.0)),
+            Coordinate::from((3.0, 1.0)),
+            Coordinate::from((1.0, 10.0)),
+            Coordinate::from((0.0, 0.0)),
+            Coordinate::from((2.0, 0.0)),
         ];
         let res = mls.convex_hull();
         assert_eq!(res.exterior.0, correct);
     }
     #[test]
     fn quick_hull_multipolygon_test() {
-        let ls1 = LineString(vec![
-            Point::new(0.0, 0.0),
-            Point::new(1.0, 10.0),
-            Point::new(2.0, 0.0),
-            Point::new(0.0, 0.0),
+        let ls1 = LineString::from(vec![
+            (0.0, 0.0),
+            (1.0, 10.0),
+            (2.0, 0.0),
+            (0.0, 0.0),
         ]);
-        let ls2 = LineString(vec![
-            Point::new(3.0, 0.0),
-            Point::new(4.0, 10.0),
-            Point::new(5.0, 0.0),
-            Point::new(3.0, 0.0),
+        let ls2 = LineString::from(vec![
+            (3.0, 0.0),
+            (4.0, 10.0),
+            (5.0, 0.0),
+            (3.0, 0.0),
         ]);
         let p1 = Polygon::new(ls1, vec![]);
         let p2 = Polygon::new(ls2, vec![]);
         let mp = MultiPolygon(vec![p1, p2]);
         let correct = vec![
-            Point::new(5.0, 0.0),
-            Point::new(4.0, 10.0),
-            Point::new(1.0, 10.0),
-            Point::new(0.0, 0.0),
-            Point::new(5.0, 0.0),
+            Coordinate::from((5.0, 0.0)),
+            Coordinate::from((4.0, 10.0)),
+            Coordinate::from((1.0, 10.0)),
+            Coordinate::from((0.0, 0.0)),
+            Coordinate::from((5.0, 0.0)),
         ];
         let res = mp.convex_hull();
         assert_eq!(res.exterior.0, correct);

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -17,7 +17,7 @@ pub trait EuclideanLength<T, RHS = Self> {
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(40.02f64, 116.34));
     /// vec.push(Point::new(42.02f64, 116.34));
-    /// let linestring = LineString(vec);
+    /// let linestring = LineString::from(vec);
     ///
     /// println!("EuclideanLength {}", linestring.euclidean_length());
     /// ```
@@ -60,7 +60,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use ::{Coordinate, Line, LineString, MultiLineString, Point};
+    use ::{Coordinate, Line, LineString, MultiLineString};
     use algorithm::euclidean_length::EuclideanLength;
 
     #[test]
@@ -70,35 +70,35 @@ mod test {
     }
     #[test]
     fn linestring_one_point_test() {
-        let linestring = LineString(vec![Point::new(0., 0.)]);
+        let linestring = LineString::from(vec![(0., 0.)]);
         assert_eq!(0.0_f64, linestring.euclidean_length());
     }
     #[test]
     fn linestring_test() {
-        let p = |x| Point(Coordinate { x: x, y: 1. });
-        let linestring = LineString(vec![p(1.), p(7.), p(8.), p(9.), p(10.), p(11.)]);
+        let linestring = LineString::from(vec![
+            (1., 1.), (7., 1.), (8., 1.), (9., 1.), (10., 1.), (11., 1.)
+        ]);
         assert_eq!(10.0_f64, linestring.euclidean_length());
     }
     #[test]
     fn multilinestring_test() {
-        let p = |x, y| Point(Coordinate { x: x, y: y });
         let mline = MultiLineString(vec![
-            LineString(vec![
-                p(1., 0.),
-                p(7., 0.),
-                p(8., 0.),
-                p(9., 0.),
-                p(10., 0.),
-                p(11., 0.),
+            LineString::from(vec![
+                (1., 0.),
+                (7., 0.),
+                (8., 0.),
+                (9., 0.),
+                (10., 0.),
+                (11., 0.),
             ]),
-            LineString(vec![p(0., 0.), p(0., 5.)]),
+            LineString::from(vec![(0., 0.), (0., 5.)]),
         ]);
         assert_eq!(15.0_f64, mline.euclidean_length());
     }
     #[test]
     fn line_test() {
-        let line0 = Line::new(Point::new(0., 0.), Point::new(0., 1.));
-        let line1 = Line::new(Point::new(0., 0.), Point::new(3., 4.));
+        let line0 = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 0., y: 1. });
+        let line1 = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 3., y: 4. });
         assert_eq!(line0.euclidean_length(), 1.);
         assert_eq!(line1.euclidean_length(), 5.);
     }

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -77,7 +77,7 @@ where
     let mut max: usize = 0;
     for (i, _) in vertices.iter().enumerate() {
         // if vertices[i] is above prior vertices[max]
-        if above(u, vertices[i], vertices[max]) {
+        if above(u, Point(vertices[i]), Point(vertices[max])) {
             max = i;
         }
     }
@@ -97,7 +97,7 @@ pub trait ExtremeIndices<T: Float + Signed> {
     /// // a diamond shape
     /// let points_raw = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
     /// let points = points_raw.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
-    /// let poly = Polygon::new(LineString(points), vec![]);
+    /// let poly = Polygon::new(LineString::from(points), vec![]);
     /// // Polygon is both convex and oriented counter-clockwise
     /// let extremes = poly.extreme_indices().unwrap();
     /// assert_eq!(extremes.ymin, 0);
@@ -150,7 +150,7 @@ pub trait ExtremePoints<T: Float> {
     ///     .iter()
     ///     .map(|e| Point::new(e.0, e.1))
     ///     .collect::<Vec<_>>();
-    /// let poly1 = Polygon::new(LineString(points), vec![]);
+    /// let poly1 = Polygon::new(LineString::from(points), vec![]);
     /// let extremes = poly1.extreme_points();
     /// let correct = Point::new(0.0, 1.0);
     /// assert_eq!(extremes.xmin, correct);
@@ -169,10 +169,10 @@ where
         // safe to unwrap, since we're guaranteeing the polygon's convexity
         let indices = ch.extreme_indices().unwrap();
         ExtremePoint {
-            ymin: ch.exterior.0[indices.ymin],
-            xmax: ch.exterior.0[indices.xmax],
-            ymax: ch.exterior.0[indices.ymax],
-            xmin: ch.exterior.0[indices.xmin],
+            ymin: Point(ch.exterior.0[indices.ymin]),
+            xmax: Point(ch.exterior.0[indices.xmax]),
+            ymax: Point(ch.exterior.0[indices.ymax]),
+            xmin: Point(ch.exterior.0[indices.xmin]),
         }
     }
 }
@@ -190,7 +190,7 @@ mod test {
             .iter()
             .map(|e| Point::new(e.0, e.1))
             .collect::<Vec<_>>();
-        let poly1 = Polygon::new(LineString(points), vec![]);
+        let poly1 = Polygon::new(LineString::from(points), vec![]);
         let min_x = polymax_naive_indices(Point::new(-1., 0.), &poly1).unwrap();
         let correct = 3_usize;
         assert_eq!(min_x, correct);
@@ -199,7 +199,7 @@ mod test {
     #[should_panic]
     fn test_extreme_indices_bad_polygon() {
         // non-convex, with a bump on the top-right edge
-        let points_raw = vec![
+        let coords = vec![
             (1.0, 0.0),
             (1.3, 1.),
             (2.0, 1.0),
@@ -208,11 +208,7 @@ mod test {
             (0.0, 1.0),
             (1.0, 0.0),
         ];
-        let points = points_raw
-            .iter()
-            .map(|e| Point::new(e.0, e.1))
-            .collect::<Vec<_>>();
-        let poly1 = Polygon::new(LineString(points), vec![]);
+        let poly1 = Polygon::new(LineString::from(coords), vec![]);
         let extremes = find_extreme_indices(polymax_naive_indices, &poly1).unwrap();
         let correct = Extremes {
             ymin: 0,
@@ -225,7 +221,7 @@ mod test {
     #[test]
     fn test_extreme_indices_good_polygon() {
         // non-convex, with a bump on the top-right edge
-        let points_raw = vec![
+        let coords = vec![
             (1.0, 0.0),
             (1.3, 1.),
             (2.0, 1.0),
@@ -234,11 +230,7 @@ mod test {
             (0.0, 1.0),
             (1.0, 0.0),
         ];
-        let points = points_raw
-            .iter()
-            .map(|e| Point::new(e.0, e.1))
-            .collect::<Vec<_>>();
-        let poly1 = Polygon::new(LineString(points), vec![]);
+        let poly1 = Polygon::new(LineString::from(coords), vec![]);
         let extremes = find_extreme_indices(polymax_naive_indices, &poly1.convex_hull()).unwrap();
         let correct = Extremes {
             ymin: 0,
@@ -251,7 +243,7 @@ mod test {
     #[test]
     fn test_polygon_extreme_wrapper_convex() {
         // convex, with a bump on the top-right edge
-        let points_raw = vec![
+        let coords = vec![
             (1.0, 0.0),
             (2.0, 1.0),
             (1.75, 1.75),
@@ -259,11 +251,7 @@ mod test {
             (0.0, 1.0),
             (1.0, 0.0),
         ];
-        let points = points_raw
-            .iter()
-            .map(|e| Point::new(e.0, e.1))
-            .collect::<Vec<_>>();
-        let poly1 = Polygon::new(LineString(points), vec![]);
+        let poly1 = Polygon::new(LineString::from(coords), vec![]);
         let extremes = find_extreme_indices(polymax_naive_indices, &poly1.convex_hull()).unwrap();
         let correct = Extremes {
             ymin: 0,
@@ -276,12 +264,8 @@ mod test {
     #[test]
     fn test_polygon_extreme_point_x() {
         // a diamond shape
-        let points_raw = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
-        let points = points_raw
-            .iter()
-            .map(|e| Point::new(e.0, e.1))
-            .collect::<Vec<_>>();
-        let poly1 = Polygon::new(LineString(points), vec![]);
+        let coords = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
+        let poly1 = Polygon::new(LineString::from(coords), vec![]);
         let extremes = poly1.extreme_points();
         let correct = Point::new(0.0, 1.0);
         assert_eq!(extremes.xmin, correct);

--- a/geo/src/algorithm/from_postgis.rs
+++ b/geo/src/algorithm/from_postgis.rs
@@ -18,10 +18,10 @@ impl<'a, T> FromPostgis<&'a T> for Point<f64> where T: postgis::Point {
 }
 impl<'a, T> FromPostgis<&'a T> for LineString<f64> where T: postgis::LineString<'a> {
     fn from_postgis(ls: &'a T) -> Self {
-        let ret = ls.points()
+        let ret: Vec<Point<f64>> = ls.points()
             .map(|x| Point::from_postgis(x))
             .collect();
-        LineString(ret)
+        LineString::from(ret)
     }
 }
 impl<'a, T> FromPostgis<&'a T> for Option<Polygon<f64>> where T: postgis::Polygon<'a> {

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -18,7 +18,7 @@ pub trait HaversineLength<T, RHS = Self> {
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(40.02f64, 116.34));
     /// vec.push(Point::new(42.02f64, 116.34));
-    /// let linestring = LineString(vec);
+    /// let linestring = LineString::from(vec);
     ///
     /// println!("HaversineLength {}", linestring.haversine_length());
     /// ```
@@ -30,7 +30,8 @@ impl<T> HaversineLength<T> for Line<T>
     where T: Float + FromPrimitive
 {
     fn haversine_length(&self) -> T {
-        self.start.haversine_distance(&self.end)
+        let (start, end) = self.points();
+        start.haversine_distance(&end)
     }
 }
 
@@ -38,8 +39,8 @@ impl<T> HaversineLength<T> for LineString<T>
     where T: Float + FromPrimitive
 {
     fn haversine_length(&self) -> T {
-        self.0.windows(2)
-              .fold(T::zero(), |total_length, p| total_length + p[0].haversine_distance(&p[1]))
+        self.lines()
+            .fold(T::zero(), |total_length, line| total_length + line.haversine_length())
     }
 }
 

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -19,13 +19,13 @@ pub trait Orient<T> {
     /// let points_int_raw = vec![(1.0, 0.5), (1.5, 1.0), (1.0, 1.5), (0.5, 1.0), (1.0, 0.5)];
     /// let points_ext = points_ext_raw.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
     /// let points_int = points_int_raw.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
-    /// let poly = Polygon::new(LineString(points_ext), vec![LineString(points_int)]);
+    /// let poly = Polygon::new(LineString::from(points_ext), vec![LineString::from(points_int)]);
     /// // a diamond shape, oriented counter-clockwise outside,
     /// let oriented_ext = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
-    /// let oriented_ext_ls = LineString(oriented_ext.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>());
+    /// let oriented_ext_ls = LineString::from(oriented_ext.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>());
     /// // clockwise interior
     /// let oriented_int = vec![(1.0, 0.5), (0.5, 1.0), (1.0, 1.5), (1.5, 1.0), (1.0, 0.5)];
-    /// let oriented_int_ls = LineString(oriented_int.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>());
+    /// let oriented_int_ls = LineString::from(oriented_int.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>());
     /// // build corrected Polygon
     /// let oriented = poly.orient(Direction::Default);
     /// assert_eq!(oriented.exterior.0, oriented_ext_ls.0);
@@ -86,39 +86,21 @@ where
 
 #[cfg(test)]
 mod test {
-    use ::{LineString, Point, Polygon};
+    use ::{LineString, Polygon};
     use super::*;
     #[test]
     fn test_polygon_orientation() {
         // a diamond shape, oriented clockwise outside
-        let points_ext_raw = vec![(1.0, 0.0), (0.0, 1.0), (1.0, 2.0), (2.0, 1.0), (1.0, 0.0)];
+        let points_ext = vec![(1.0, 0.0), (0.0, 1.0), (1.0, 2.0), (2.0, 1.0), (1.0, 0.0)];
         // counter-clockwise interior
-        let points_int_raw = vec![(1.0, 0.5), (1.5, 1.0), (1.0, 1.5), (0.5, 1.0), (1.0, 0.5)];
-        let points_ext = points_ext_raw
-            .iter()
-            .map(|e| Point::new(e.0, e.1))
-            .collect::<Vec<_>>();
-        let points_int = points_int_raw
-            .iter()
-            .map(|e| Point::new(e.0, e.1))
-            .collect::<Vec<_>>();
-        let poly1 = Polygon::new(LineString(points_ext), vec![LineString(points_int)]);
+        let points_int = vec![(1.0, 0.5), (1.5, 1.0), (1.0, 1.5), (0.5, 1.0), (1.0, 0.5)];
+        let poly1 = Polygon::new(LineString::from(points_ext), vec![LineString::from(points_int)]);
         // a diamond shape, oriented counter-clockwise outside,
         let oriented_ext = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
-        let oriented_ext_ls = LineString(
-            oriented_ext
-                .iter()
-                .map(|e| Point::new(e.0, e.1))
-                .collect::<Vec<_>>(),
-        );
+        let oriented_ext_ls = LineString::from(oriented_ext);
         // clockwise interior
         let oriented_int_raw = vec![(1.0, 0.5), (0.5, 1.0), (1.0, 1.5), (1.5, 1.0), (1.0, 0.5)];
-        let oriented_int_ls = LineString(
-            oriented_int_raw
-                .iter()
-                .map(|e| Point::new(e.0, e.1))
-                .collect::<Vec<_>>(),
-        );
+        let oriented_int_ls = LineString::from(oriented_int_raw);
         // build corrected Polygon
         let oriented = orient(&poly1, Direction::Default);
         assert_eq!(oriented.exterior.0, oriented_ext_ls.0);

--- a/geo/src/algorithm/polygon_distance_fast_path.rs
+++ b/geo/src/algorithm/polygon_distance_fast_path.rs
@@ -16,8 +16,8 @@ where
 {
     let poly1_extremes = poly1.extreme_indices().unwrap();
     let poly2_extremes = poly2.extreme_indices().unwrap();
-    let ymin1 = poly1.exterior.0[poly1_extremes.ymin];
-    let ymax2 = poly2.exterior.0[poly2_extremes.ymax];
+    let ymin1 = Point(poly1.exterior.0[poly1_extremes.ymin]);
+    let ymax2 = Point(poly2.exterior.0[poly2_extremes.ymax]);
 
     let mut state = Polydist {
         poly1,
@@ -58,7 +58,7 @@ fn vertex_line_distance<T>(v: Point<T>, p: Point<T>, q: Point<T>) -> T
 where
     T: Float,
 {
-    v.euclidean_distance(&Line::new(p, q))
+    v.euclidean_distance(&Line::new(p.0, q.0))
 }
 
 /// Wrap-around previous Polygon index
@@ -128,18 +128,18 @@ where
     let mut sin;
     let pnext = poly.exterior.0[next_vertex(poly, idx)];
     let pprev = poly.exterior.0[prev_vertex(poly, idx)];
-    let clockwise = pprev.cross_prod(p, pnext) < T::zero();
+    let clockwise = Point(pprev).cross_prod(Point(p.0), Point(pnext)) < T::zero();
     let slope_prev;
     let slope_next;
     // Slope isn't 0, things are complicated
     if *slope != T::zero() {
         cos = cossq.sqrt();
         sin = sinsq.sqrt();
-        if pnext.x() > p.x() {
-            if pprev.x() > p.x() {
-                if pprev.y() >= p.y() && pnext.y() >= p.y() {
+        if pnext.x > p.x() {
+            if pprev.x > p.x() {
+                if pprev.y >= p.y() && pnext.y >= p.y() {
                     if *slope > T::zero() {
-                        slope_prev = Line::new(p, pprev).slope();
+                        slope_prev = Line::new(p.0, pprev).slope();
                         if clockwise && *slope <= slope_prev || !clockwise && *slope >= slope_prev {
                             cos = -cos;
                             sin = -sin;
@@ -149,15 +149,15 @@ where
                             sin = -sin;
                         }
                     }
-                } else if pprev.y() <= p.y() && pnext.y() <= p.y() {
+                } else if pprev.y <= p.y() && pnext.y <= p.y() {
                     if *slope > T::zero() {
                         if !clockwise {
                             cos = -cos;
                             sin = -sin;
                         }
                     } else {
-                        slope_prev = Line::new(p, pprev).slope();
-                        slope_next = Line::new(p, pnext).slope();
+                        slope_prev = Line::new(p.0, pprev).slope();
+                        slope_next = Line::new(p.0, pnext).slope();
                         if clockwise {
                             if *slope <= slope_prev {
                                 cos = -cos;
@@ -183,17 +183,17 @@ where
             } else if *slope < T::zero() {
                 sin = -sin;
             }
-        } else if pnext.x() < p.x() {
-            if pprev.x() < p.x() {
-                if pprev.y() >= p.y() && pnext.y() >= p.y() {
+        } else if pnext.x < p.x() {
+            if pprev.x < p.x() {
+                if pprev.y >= p.y() && pnext.y >= p.y() {
                     if *slope > T::zero() {
                         if clockwise {
                             cos = -cos;
                             sin = -sin;
                         }
                     } else {
-                        slope_prev = Line::new(p, pprev).slope();
-                        slope_next = Line::new(p, pnext).slope();
+                        slope_prev = Line::new(p.0, pprev).slope();
+                        slope_next = Line::new(p.0, pnext).slope();
                         if clockwise {
                             if *slope <= slope_prev {
                                 sin = -sin;
@@ -206,9 +206,9 @@ where
                             sin = -sin;
                         }
                     }
-                } else if pprev.y() <= p.y() && pnext.y() <= p.y() {
+                } else if pprev.y <= p.y() && pnext.y <= p.y() {
                     if *slope > T::zero() {
-                        slope_next = Line::new(p, pnext).slope();
+                        slope_next = Line::new(p.0, pnext).slope();
                         if *slope >= slope_next {
                             cos = -cos;
                             sin = -sin;
@@ -235,7 +235,7 @@ where
                     sin = -sin;
                 }
             }
-        } else if pprev.x() > p.x() {
+        } else if pprev.x > p.x() {
             cos = -cos;
             if *slope > T::zero() {
                 sin = -sin;
@@ -246,12 +246,12 @@ where
     } else {
         // Slope is 0, things are fairly simple
         sin = T::zero();
-        if pnext.x() > p.x() {
+        if pnext.x > p.x() {
             cos = T::one();
-        } else if pnext.x() < p.x() {
+        } else if pnext.x < p.x() {
             cos = -T::one();
-        } else if pnext.x() == p.x() {
-            if pprev.x() < p.x() {
+        } else if pnext.x == p.x() {
+            if pprev.x < p.x() {
                 cos = T::one();
             } else {
                 cos = -T::one();
@@ -322,15 +322,15 @@ where
     let hundred = T::from(100).unwrap();
     let pnext = poly.exterior.0[next_vertex(poly, idx)];
     let pprev = poly.exterior.0[prev_vertex(poly, idx)];
-    let clockwise = pprev.cross_prod(p, pnext) < T::zero();
+    let clockwise = Point(pprev).cross_prod(Point(p.0), Point(pnext)) < T::zero();
     let punit;
     if !vertical {
         punit = unitvector(m, poly, p, idx);
     } else if clockwise {
-        if p.x() > pprev.x() {
+        if p.x() > pprev.x {
             punit = Point::new(p.x(), p.y() - hundred);
-        } else if p.x() == pprev.x() {
-            if p.y() > pprev.y() {
+        } else if p.x() == pprev.x {
+            if p.y() > pprev.y {
                 punit = Point::new(p.x(), p.y() + hundred);
             } else {
                 // implies p.y() < pprev.y()
@@ -343,10 +343,10 @@ where
             // implies p.x() < pprev.x()
             punit = Point::new(p.x(), p.y() + hundred);
         }
-    } else if p.x() > pprev.x() {
+    } else if p.x() > pprev.x {
         punit = Point::new(p.x(), p.y() + hundred);
-    } else if p.x() == pprev.x() {
-        if p.y() > pprev.y() {
+    } else if p.x() == pprev.x {
+        if p.y() > pprev.y {
             punit = Point::new(p.x(), p.y() + hundred);
         } else {
             // implies p.y() < pprev.y()
@@ -359,8 +359,8 @@ where
         // implies p.x() < pprev.x()
         punit = Point::new(p.x(), p.y() - hundred);
     }
-    let triarea = triangle_area(p, punit, pnext);
-    let edgelen = p.euclidean_distance(&pnext);
+    let triarea = triangle_area(p, punit, Point(pnext));
+    let edgelen = p.euclidean_distance(&Point(pnext));
     let mut sine = triarea / (T::from(0.5).unwrap() * T::from(100).unwrap() * edgelen);
     if sine < -T::one() || sine > T::one() {
         sine = T::one();
@@ -368,7 +368,7 @@ where
     let angle;
     let perpunit = unitpvector(p, punit);
     let mut obtuse = false;
-    let left = leftturn(p, perpunit, pnext);
+    let left = leftturn(p, perpunit, Point(pnext));
     if clockwise {
         if left == 0 {
             obtuse = true;
@@ -400,9 +400,9 @@ fn triangle_area<T>(a: Point<T>, b: Point<T>, c: Point<T>) -> T
 where
     T: Float,
 {
-    (Line::new(a, b).determinant()
-        + Line::new(b, c).determinant()
-        + Line::new(c, a).determinant()) / (T::one() + T::one())
+    (Line::new(a.0, b.0).determinant()
+        + Line::new(b.0, c.0).determinant()
+        + Line::new(c.0, a.0).determinant()) / (T::one() + T::one())
 }
 
 /// Does abc turn left?
@@ -466,14 +466,14 @@ where
     if (state.ap1 - minangle).abs() < T::from(0.002).unwrap() {
         state.ip1 = true;
         let p1next = next_vertex(state.poly1, state.p1_idx);
-        state.p1next = state.poly1.exterior.0[p1next];
+        state.p1next = Point(state.poly1.exterior.0[p1next]);
         state.p1_idx = p1next;
         state.alignment = Some(Aligned::EdgeVertexP);
     }
     if (state.aq2 - minangle).abs() < T::from(0.002).unwrap() {
         state.iq2 = true;
         let q2next = next_vertex(state.poly2, state.q2_idx);
-        state.q2next = state.poly2.exterior.0[q2next];
+        state.q2next = Point(state.poly2.exterior.0[q2next]);
         state.q2_idx = q2next;
         state.alignment = match state.alignment {
             None => Some(Aligned::EdgeVertexQ),
@@ -489,7 +489,7 @@ where
             }
             false => {
                 state.vertical = false;
-                state.slope = Line::new(state.p1next, state.p1).slope();
+                state.slope = Line::new(state.p1next.0, state.p1.0).slope();
             }
         }
     }
@@ -502,7 +502,7 @@ where
             }
             false => {
                 state.vertical = false;
-                state.slope = Line::new(state.q2next, state.q2).slope();
+                state.slope = Line::new(state.q2next.0, state.q2.0).slope();
             }
         }
     }

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -1,6 +1,6 @@
-use algorithm::euclidean_distance::EuclideanDistance;
 use num_traits::Float;
-use {Line, LineString, MultiLineString, MultiPolygon, Point, Polygon};
+use ::{LineString, MultiLineString, MultiPolygon, Point, Polygon, Line};
+use algorithm::euclidean_distance::EuclideanDistance;
 
 // Ramer–Douglas-Peucker line simplification algorithm
 fn rdp<T>(points: &[Point<T>], epsilon: &T) -> Vec<Point<T>>
@@ -15,7 +15,7 @@ where
     let mut distance: T;
 
     for (i, _) in points.iter().enumerate().take(points.len() - 1).skip(1) {
-        distance = points[i].euclidean_distance(&Line::new(points[0], *points.last().unwrap()));
+        distance = points[i].euclidean_distance(&Line::new(points[0].0, points.last().unwrap().0));
         if distance > dmax {
             index = i;
             dmax = distance;
@@ -54,13 +54,13 @@ pub trait Simplify<T, Epsilon = T> {
     /// vec.push(Point::new(11.0, 5.5));
     /// vec.push(Point::new(17.3, 3.2));
     /// vec.push(Point::new(27.8, 0.1));
-    /// let linestring = LineString(vec);
+    /// let linestring = LineString::from(vec);
     /// let mut compare = Vec::new();
     /// compare.push(Point::new(0.0, 0.0));
     /// compare.push(Point::new(5.0, 4.0));
     /// compare.push(Point::new(11.0, 5.5));
     /// compare.push(Point::new(27.8, 0.1));
-    /// let ls_compare = LineString(compare);
+    /// let ls_compare = LineString::from(compare);
     /// let simplified = linestring.simplify(&1.0);
     /// assert_eq!(simplified, ls_compare)
     /// ```
@@ -74,7 +74,9 @@ where
     T: Float,
 {
     fn simplify(&self, epsilon: &T) -> LineString<T> {
-        LineString(rdp(&self.0, epsilon))
+        LineString::from(
+            rdp(&self.clone().into_points(), epsilon)
+        )
     }
 }
 
@@ -149,23 +151,23 @@ mod test {
 
     #[test]
     fn multilinestring() {
-        let mline = MultiLineString(vec![LineString(vec![
-            Point::new(0.0, 0.0),
-            Point::new(5.0, 4.0),
-            Point::new(11.0, 5.5),
-            Point::new(17.3, 3.2),
-            Point::new(27.8, 0.1),
+        let mline = MultiLineString(vec![LineString::from(vec![
+            (0.0, 0.0),
+            (5.0, 4.0),
+            (11.0, 5.5),
+            (17.3, 3.2),
+            (27.8, 0.1),
         ])]);
 
         let mline2 = mline.simplify(&1.0);
 
         assert_eq!(
             mline2,
-            MultiLineString(vec![LineString(vec![
-                Point::new(0.0, 0.0),
-                Point::new(5.0, 4.0),
-                Point::new(11.0, 5.5),
-                Point::new(27.8, 0.1),
+            MultiLineString(vec![LineString::from(vec![
+                (0.0, 0.0),
+                (5.0, 4.0),
+                (11.0, 5.5),
+                (27.8, 0.1),
             ])])
         );
     }
@@ -173,13 +175,13 @@ mod test {
     #[test]
     fn polygon() {
         let poly = Polygon::new(
-            LineString(vec![
-                Point::new(0., 0.),
-                Point::new(0., 10.),
-                Point::new(5., 11.),
-                Point::new(10., 10.),
-                Point::new(10., 0.),
-                Point::new(0., 0.),
+            LineString::from(vec![
+                (0., 0.),
+                (0., 10.),
+                (5., 11.),
+                (10., 10.),
+                (10., 0.),
+                (0., 0.),
             ]),
             vec![],
         );
@@ -189,12 +191,12 @@ mod test {
         assert_eq!(
             poly2,
             Polygon::new(
-                LineString(vec![
-                    Point::new(0., 0.),
-                    Point::new(0., 10.),
-                    Point::new(10., 10.),
-                    Point::new(10., 0.),
-                    Point::new(0., 0.),
+                LineString::from(vec![
+                    (0., 0.),
+                    (0., 10.),
+                    (10., 10.),
+                    (10., 0.),
+                    (0., 0.),
                 ]),
                 vec![]
             )
@@ -204,13 +206,13 @@ mod test {
     #[test]
     fn multipolygon() {
         let mpoly = MultiPolygon(vec![Polygon::new(
-            LineString(vec![
-                Point::new(0., 0.),
-                Point::new(0., 10.),
-                Point::new(5., 11.),
-                Point::new(10., 10.),
-                Point::new(10., 0.),
-                Point::new(0., 0.),
+            LineString::from(vec![
+                (0., 0.),
+                (0., 10.),
+                (5., 11.),
+                (10., 10.),
+                (10., 0.),
+                (0., 0.),
             ]),
             vec![],
         )]);
@@ -220,12 +222,12 @@ mod test {
         assert_eq!(
             mpoly2,
             MultiPolygon(vec![Polygon::new(
-                LineString(vec![
-                    Point::new(0., 0.),
-                    Point::new(0., 10.),
-                    Point::new(10., 10.),
-                    Point::new(10., 0.),
-                    Point::new(0., 0.),
+                LineString::from(vec![
+                    (0., 0.),
+                    (0., 10.),
+                    (10., 10.),
+                    (10., 0.),
+                    (0., 0.),
                 ]),
                 vec![],
             )])

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -214,14 +214,14 @@ where
     // Simplify shell
     rings.push(visvalingam_preserve(
         geomtype,
-        &exterior.0,
+        &exterior.clone().into_points(),
         epsilon,
         &mut tree,
     ));
     // Simplify interior rings, if any
     if let Some(interior_rings) = interiors {
         for ring in interior_rings {
-            rings.push(visvalingam_preserve(geomtype, &ring.0, epsilon, &mut tree))
+            rings.push(visvalingam_preserve(geomtype, &ring.clone().into_points(), epsilon, &mut tree))
         }
     }
     rings
@@ -344,8 +344,8 @@ where
                 intersector: false,
             };
             // add re-computed line segments to the tree
-            tree.insert(Line::new(orig[ai as usize], orig[current_point as usize]));
-            tree.insert(Line::new(orig[current_point as usize], orig[bi as usize]));
+            tree.insert(Line::new(orig[ai as usize].0, orig[current_point as usize].0));
+            tree.insert(Line::new(orig[current_point as usize].0, orig[bi as usize].0));
             // push re-computed triangle onto heap
             pq.push(new_triangle);
         }
@@ -381,7 +381,7 @@ where
     let point_a = orig[triangle.left];
     let point_b = orig[triangle.current];
     let point_c = orig[triangle.right];
-    let bbox = LineString(vec![
+    let bbox = LineString::from(vec![
         orig[triangle.left],
         orig[triangle.current],
         orig[triangle.right],
@@ -392,8 +392,7 @@ where
     let candidates = tree.lookup_in_rectangle(&BoundingRect::from_corners(&br, &tl));
     candidates.iter().any(|c| {
         // triangle start point, end point
-        let ca = c.start;
-        let cb = c.end;
+        let (ca, cb) = c.points();
         if ca != point_a && ca != point_c && cb != point_a && cb != point_c
             && cartesian_intersect(ca, cb, point_a, point_c)
         {
@@ -436,12 +435,12 @@ pub trait SimplifyVW<T, Epsilon = T> {
     /// vec.push(Point::new(6.0, 20.0));
     /// vec.push(Point::new(7.0, 25.0));
     /// vec.push(Point::new(10.0, 10.0));
-    /// let linestring = LineString(vec);
+    /// let linestring = LineString::from(vec);
     /// let mut compare = Vec::new();
     /// compare.push(Point::new(5.0, 2.0));
     /// compare.push(Point::new(7.0, 25.0));
     /// compare.push(Point::new(10.0, 10.0));
-    /// let ls_compare = LineString(compare);
+    /// let ls_compare = LineString::from(compare);
     /// let simplified = linestring.simplifyvw(&30.0);
     /// assert_eq!(simplified, ls_compare)
     /// ```
@@ -489,7 +488,7 @@ pub trait SimplifyVWPreserve<T, Epsilon = T> {
     /// vec.push(Point::new(117., 48.));
     /// vec.push(Point::new(300., 40.));
     /// vec.push(Point::new(301., 10.));
-    /// let linestring = LineString(vec);
+    /// let linestring = LineString::from(vec);
     /// let mut compare = Vec::new();
     /// compare.push(Point::new(10., 60.));
     /// compare.push(Point::new(126., 31.));
@@ -497,7 +496,7 @@ pub trait SimplifyVWPreserve<T, Epsilon = T> {
     /// compare.push(Point::new(117., 48.));
     /// compare.push(Point::new(300., 40.));
     /// compare.push(Point::new(301., 10.));
-    /// let ls_compare = LineString(compare);
+    /// let ls_compare = LineString::from(compare);
     /// let simplified = linestring.simplifyvw_preserve(&668.6);
     /// assert_eq!(simplified, ls_compare)
     /// ```
@@ -517,7 +516,7 @@ where
             geomtype: GeomType::Line,
         };
         let mut simplified = vwp_wrapper(&gt, self, None, epsilon);
-        LineString(simplified.pop().unwrap())
+        LineString::from(simplified.pop().unwrap())
     }
 }
 
@@ -546,8 +545,8 @@ where
             geomtype: GeomType::Ring,
         };
         let mut simplified = vwp_wrapper(&gt, &self.exterior, Some(&self.interiors), epsilon);
-        let exterior = LineString(simplified.remove(0));
-        let interiors = simplified.into_iter().map(LineString).collect();
+        let exterior = LineString::from(simplified.remove(0));
+        let interiors = simplified.into_iter().map(LineString::from).collect();
         Polygon::new(exterior, interiors)
     }
 }
@@ -571,7 +570,7 @@ where
     T: Float,
 {
     fn simplifyvw(&self, epsilon: &T) -> LineString<T> {
-        LineString(visvalingam(&self.0, epsilon))
+        LineString::from(visvalingam(&self.clone().into_points(), epsilon))
     }
 }
 
@@ -692,18 +691,18 @@ mod test {
         // with the inner ring, which would also trigger removal of outer[1],
         // leaving the geometry below min_points. It is thus retained.
         // Inner should also be reduced, but has points == initial_min for the Polygon type
-        let outer = LineString(vec![
-            Point::new(-54.4921875, 21.289374355860424),
-            Point::new(-33.5, 56.9449741808516),
-            Point::new(-22.5, 44.08758502824516),
-            Point::new(-19.5, 23.241346102386135),
-            Point::new(-54.4921875, 21.289374355860424),
+        let outer = LineString::from(vec![
+            (-54.4921875, 21.289374355860424),
+            (-33.5, 56.9449741808516),
+            (-22.5, 44.08758502824516),
+            (-19.5, 23.241346102386135),
+            (-54.4921875, 21.289374355860424),
         ]);
-        let inner = LineString(vec![
-            Point::new(-24.451171875, 35.266685523707665),
-            Point::new(-29.513671875, 47.32027765985069),
-            Point::new(-22.869140625, 43.80817468459856),
-            Point::new(-24.451171875, 35.266685523707665),
+        let inner = LineString::from(vec![
+            (-24.451171875, 35.266685523707665),
+            (-29.513671875, 47.32027765985069),
+            (-22.869140625, 43.80817468459856),
+            (-24.451171875, 35.266685523707665),
         ]);
         let poly = Polygon::new(outer.clone(), vec![inner]);
         let simplified = poly.simplifyvw_preserve(&95.4);
@@ -716,25 +715,25 @@ mod test {
         // with the inner ring, which would also trigger removal of outer[1],
         // leaving the geometry below min_points. It is thus retained.
         // Inner should be reduced to four points by removing inner[2]
-        let outer = LineString(vec![
-            Point::new(-54.4921875, 21.289374355860424),
-            Point::new(-33.5, 56.9449741808516),
-            Point::new(-22.5, 44.08758502824516),
-            Point::new(-19.5, 23.241346102386135),
-            Point::new(-54.4921875, 21.289374355860424),
+        let outer = LineString::from(vec![
+            (-54.4921875, 21.289374355860424),
+            (-33.5, 56.9449741808516),
+            (-22.5, 44.08758502824516),
+            (-19.5, 23.241346102386135),
+            (-54.4921875, 21.289374355860424),
         ]);
-        let inner = LineString(vec![
-            Point::new(-24.451171875, 35.266685523707665),
-            Point::new(-40.0, 45.),
-            Point::new(-29.513671875, 47.32027765985069),
-            Point::new(-22.869140625, 43.80817468459856),
-            Point::new(-24.451171875, 35.266685523707665),
+        let inner = LineString::from(vec![
+            (-24.451171875, 35.266685523707665),
+            (-40.0, 45.),
+            (-29.513671875, 47.32027765985069),
+            (-22.869140625, 43.80817468459856),
+            (-24.451171875, 35.266685523707665),
         ]);
-        let correct_inner = LineString(vec![
-            Point::new(-24.451171875, 35.266685523707665),
-            Point::new(-40.0, 45.0),
-            Point::new(-22.869140625, 43.80817468459856),
-            Point::new(-24.451171875, 35.266685523707665),
+        let correct_inner = LineString::from(vec![
+            (-24.451171875, 35.266685523707665),
+            (-40.0, 45.0),
+            (-22.869140625, 43.80817468459856),
+            (-24.451171875, 35.266685523707665),
         ]);
         let poly = Polygon::new(outer.clone(), vec![inner]);
         let simplified = poly.simplifyvw_preserve(&95.4);
@@ -771,8 +770,8 @@ mod test {
         let points_ls: Vec<_> = points.iter().map(|e| Point::new(e[0], e[1])).collect();
         let correct = include!("test_fixtures/vw_simplified.rs");
         let correct_ls: Vec<_> = correct.iter().map(|e| Point::new(e[0], e[1])).collect();
-        let simplified = LineString(points_ls).simplifyvw_preserve(&0.0005);
-        assert_eq!(simplified, LineString(correct_ls));
+        let simplified = LineString::from(points_ls).simplifyvw_preserve(&0.0005);
+        assert_eq!(simplified, LineString::from(correct_ls));
     }
     #[test]
     fn visvalingam_test_empty_linestring() {
@@ -808,23 +807,23 @@ mod test {
         let correct = vec![(5.0, 2.0), (7.0, 25.0), (10.0, 10.0)];
         let correct_ls: Vec<_> = correct.iter().map(|e| Point::new(e.0, e.1)).collect();
 
-        let mline = MultiLineString(vec![LineString(points_ls)]);
+        let mline = MultiLineString(vec![LineString::from(points_ls)]);
         assert_eq!(
             mline.simplifyvw(&30.),
-            MultiLineString(vec![LineString(correct_ls)])
+            MultiLineString(vec![LineString::from(correct_ls)])
         );
     }
 
     #[test]
     fn polygon() {
         let poly = Polygon::new(
-            LineString(vec![
-                Point::new(0., 0.),
-                Point::new(0., 10.),
-                Point::new(5., 11.),
-                Point::new(10., 10.),
-                Point::new(10., 0.),
-                Point::new(0., 0.),
+            LineString::from(vec![
+                (0., 0.),
+                (0., 10.),
+                (5., 11.),
+                (10., 10.),
+                (10., 0.),
+                (0., 0.),
             ]),
             vec![],
         );
@@ -834,7 +833,7 @@ mod test {
         assert_eq!(
             poly2,
             Polygon::new(
-                LineString(vec![
+                LineString::from(vec![
                     Point::new(0., 0.),
                     Point::new(0., 10.),
                     Point::new(10., 10.),
@@ -850,13 +849,13 @@ mod test {
     fn multipolygon() {
         let mpoly = MultiPolygon(vec![
             Polygon::new(
-                LineString(vec![
-                    Point::new(0., 0.),
-                    Point::new(0., 10.),
-                    Point::new(5., 11.),
-                    Point::new(10., 10.),
-                    Point::new(10., 0.),
-                    Point::new(0., 0.),
+                LineString::from(vec![
+                    (0., 0.),
+                    (0., 10.),
+                    (5., 11.),
+                    (10., 10.),
+                    (10., 0.),
+                    (0., 0.),
                 ]),
                 vec![],
             ),
@@ -868,12 +867,12 @@ mod test {
             mpoly2,
             MultiPolygon(vec![
                 Polygon::new(
-                    LineString(vec![
-                        Point::new(0., 0.),
-                        Point::new(0., 10.),
-                        Point::new(10., 10.),
-                        Point::new(10., 0.),
-                        Point::new(0., 0.),
+                    LineString::from(vec![
+                        (0., 0.),
+                        (0., 10.),
+                        (10., 10.),
+                        (10., 0.),
+                        (0., 0.),
                     ]),
                     vec![],
                 ),

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -14,13 +14,13 @@ pub trait Translate<T> {
     /// vec.push(Point::new(0.0, 0.0));
     /// vec.push(Point::new(5.0, 5.0));
     /// vec.push(Point::new(10.0, 10.0));
-    /// let linestring = LineString(vec);
+    /// let linestring = LineString::from(vec);
     /// let translated = linestring.translate(1.5, 3.5);
     /// let mut correct = Vec::new();
     /// correct.push(Point::new(1.5, 3.5));
     /// correct.push(Point::new(6.5, 8.5));
     /// correct.push(Point::new(11.5, 13.5));
-    /// let correct_ls = LineString(correct);
+    /// let correct_ls = LineString::from(correct);
     /// assert_eq!(translated, correct_ls);
     /// ```
     fn translate(&self, xoff: T, yoff: T) -> Self where T: CoordinateType;
@@ -44,7 +44,7 @@ impl<T, G> Translate<T> for G
 
 #[cfg(test)]
 mod test {
-  use ::{LineString, Point, Polygon};
+  use ::{LineString, Point, Polygon, Coordinate};
   use super::*;
   #[test]
   fn test_translate_point() {
@@ -54,17 +54,17 @@ mod test {
   }
   #[test]
   fn test_translate_linestring() {
-    let mut vec = Vec::new();
-    vec.push(Point::new(0.0, 0.0));
-    vec.push(Point::new(5.0, 1.0));
-    vec.push(Point::new(10.0, 0.0));
-    let linestring = LineString(vec);
+    let linestring = LineString::from(vec![
+      (0.0, 0.0),
+      (5.0, 1.0),
+      (10.0, 0.0),
+    ]);
     let translated = linestring.translate(17.0, 18.0);
     let mut correct = Vec::new();
-    correct.push(Point::new(17.0, 18.0));
-    correct.push(Point::new(22.0, 19.0));
-    correct.push(Point::new(27., 18.));
-    let correct_ls = LineString(correct);
+    correct.push((17.0, 18.0));
+    correct.push((22.0, 19.0));
+    correct.push((27., 18.));
+    let correct_ls = LineString::from(correct);
     assert_eq!(translated, correct_ls);
   }
   #[test]
@@ -84,7 +84,7 @@ mod test {
       .iter()
       .map(|e| Point::new(e.0, e.1))
       .collect::<Vec<_>>();
-    let poly1 = Polygon::new(LineString(points), vec![]);
+    let poly1 = Polygon::new(LineString::from(points), vec![]);
     let translated = poly1.translate(17.0, 18.0);
     let correct_outside = vec![
       (22.0, 19.0),
@@ -101,7 +101,7 @@ mod test {
       LineString(
         correct_outside
           .iter()
-          .map(|e| Point::new(e.0, e.1))
+          .map(|e| Coordinate { x: e.0, y: e.1 })
           .collect::<Vec<_>>(),
       ),
       vec![],
@@ -111,44 +111,44 @@ mod test {
   }
   #[test]
   fn test_rotate_polygon_holes() {
-    let ls1 = LineString(vec![
-      Point::new(5.0, 1.0),
-      Point::new(4.0, 2.0),
-      Point::new(4.0, 3.0),
-      Point::new(5.0, 4.0),
-      Point::new(6.0, 4.0),
-      Point::new(7.0, 3.0),
-      Point::new(7.0, 2.0),
-      Point::new(6.0, 1.0),
-      Point::new(5.0, 1.0),
+    let ls1 = LineString::from(vec![
+      (5.0, 1.0),
+      (4.0, 2.0),
+      (4.0, 3.0),
+      (5.0, 4.0),
+      (6.0, 4.0),
+      (7.0, 3.0),
+      (7.0, 2.0),
+      (6.0, 1.0),
+      (5.0, 1.0),
     ]);
 
-    let ls2 = LineString(vec![
-      Point::new(5.0, 1.3),
-      Point::new(5.5, 2.0),
-      Point::new(6.0, 1.3),
-      Point::new(5.0, 1.3),
+    let ls2 = LineString::from(vec![
+      (5.0, 1.3),
+      (5.5, 2.0),
+      (6.0, 1.3),
+      (5.0, 1.3),
     ]);
 
     let poly1 = Polygon::new(ls1, vec![ls2]);
     let rotated = poly1.translate(17.0, 18.0);
     let correct_outside = vec![
-      (22.0, 19.0),
-      (21.0, 20.0),
-      (21.0, 21.0),
-      (22.0, 22.0),
-      (23.0, 22.0),
-      (24.0, 21.0),
-      (24.0, 20.0),
-      (23.0, 19.0),
-      (22.0, 19.0),
-    ].iter()
-      .map(|e| Point::new(e.0, e.1))
-      .collect::<Vec<_>>();
-    let correct_inside = vec![(22.0, 19.3), (22.5, 20.0), (23.0, 19.3), (22.0, 19.3)]
-      .iter()
-      .map(|e| Point::new(e.0, e.1))
-      .collect::<Vec<_>>();
+      Coordinate::from((22.0, 19.0)),
+      Coordinate::from((21.0, 20.0)),
+      Coordinate::from((21.0, 21.0)),
+      Coordinate::from((22.0, 22.0)),
+      Coordinate::from((23.0, 22.0)),
+      Coordinate::from((24.0, 21.0)),
+      Coordinate::from((24.0, 20.0)),
+      Coordinate::from((23.0, 19.0)),
+      Coordinate::from((22.0, 19.0)),
+    ];
+    let correct_inside = vec![
+      Coordinate::from((22.0, 19.3)),
+      Coordinate::from((22.5, 20.0)),
+      Coordinate::from((23.0, 19.3)),
+      Coordinate::from((22.0, 19.3)),
+    ];
     assert_eq!(rotated.exterior.0, correct_outside);
     assert_eq!(rotated.interiors[0].0, correct_inside);
   }

--- a/geo/src/algorithm/vincenty_length.rs
+++ b/geo/src/algorithm/vincenty_length.rs
@@ -12,7 +12,8 @@ impl<T> VincentyLength<T> for Line<T>
 {
     /// The units of the returned value is meters.
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
-        self.start.vincenty_distance(&self.end)
+        let (start, end) = self.points();
+        start.vincenty_distance(&end)
     }
 }
 
@@ -21,8 +22,8 @@ impl<T> VincentyLength<T> for LineString<T>
 {
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
         let mut length = T::zero();
-        for window in self.0.windows(2) {
-            length = length + window[0].vincenty_distance(&window[1])?;
+        for line in self.lines() {
+            length = length + line.vincenty_length()?;
         }
         Ok(length)
     }


### PR DESCRIPTION
Relevant conversation in https://github.com/georust/rust-geo/issues/15.

This is a breaking change for `geo-types`.

I'm _not_ planning to publish a release if this merges. I have a couple other breaking changes I'd like to consider before bumping the Rust geo ecosystem.