### PR TITLE
Remove unnecessary borrows in function params for `Copy` types.

### DIFF
--- a/geo-types/src/algorithms.rs
+++ b/geo-types/src/algorithms.rs
@@ -8,22 +8,22 @@ pub trait EuclideanDistance<T, Rhs = Self> {
     fn euclidean_distance(&self, rhs: &Rhs) -> T;
 }
 
-fn line_segment_distance<T>(point: &Point<T>, start: &Point<T>, end: &Point<T>) -> T
+fn line_segment_distance<T>(point: Point<T>, start: Point<T>, end: Point<T>) -> T
 where
     T: Float + ToPrimitive,
 {
     if start == end {
-        return point.euclidean_distance(start);
+        return point.euclidean_distance(&start);
     }
     let dx = end.x() - start.x();
     let dy = end.y() - start.y();
     let r =
         ((point.x() - start.x()) * dx + (point.y() - start.y()) * dy) / (dx.powi(2) + dy.powi(2));
     if r <= T::zero() {
-        return point.euclidean_distance(start);
+        return point.euclidean_distance(&start);
     }
     if r >= T::one() {
-        return point.euclidean_distance(end);
+        return point.euclidean_distance(&end);
     }
     let s = ((start.y() - point.y()) * dx - (start.x() - point.x()) * dy) / (dx * dx + dy * dy);
     s.abs() * (dx * dx + dy * dy).sqrt()
@@ -44,7 +44,7 @@ where
     T: Float,
 {
     fn euclidean_distance(&self, point: &Point<T>) -> T {
-        line_segment_distance(point, &self.start, &self.end)
+        line_segment_distance(*point, self.start, self.end)
     }
 }
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -129,7 +129,7 @@ where
     ///
     /// assert_eq!(p.lng(), 1.234);
     /// ```
-    pub fn lng(&self) -> T {
+    pub fn lng(self) -> T {
         self.x()
     }
 
@@ -160,7 +160,7 @@ where
     ///
     /// assert_eq!(p.lat(), 2.345);
     /// ```
-    pub fn lat(&self) -> T {
+    pub fn lat(self) -> T {
         self.y()
     }
 
@@ -189,11 +189,11 @@ where
     /// use geo_types::Point;
     ///
     /// let p = Point::new(1.5, 0.5);
-    /// let dot = p.dot(&Point::new(2.0, 4.5));
+    /// let dot = p.dot(Point::new(2.0, 4.5));
     ///
     /// assert_eq!(dot, 5.25);
     /// ```
-    pub fn dot(&self, point: &Point<T>) -> T {
+    pub fn dot(self, point: Point<T>) -> T {
         self.x() * point.x() + self.y() * point.y()
     }
 
@@ -210,11 +210,11 @@ where
     /// let p_b = Point::new(3.0,5.0);
     /// let p_c = Point::new(7.0,12.0);
     ///
-    /// let cross = p_a.cross_prod(&p_b, &p_c);
+    /// let cross = p_a.cross_prod(p_b, p_c);
     ///
     /// assert_eq!(cross, 2.0)
     /// ```
-    pub fn cross_prod(&self, point_b: &Point<T>, point_c: &Point<T>) -> T
+    pub fn cross_prod(self, point_b: Point<T>, point_c: Point<T>) -> T
     where
         T: Float,
     {

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -89,8 +89,8 @@ where
                 let prev_1 = self.previous_vertex(&idx);
                 let prev_2 = self.previous_vertex(&prev_1);
                 self.exterior.0[prev_2].cross_prod(
-                    &self.exterior.0[prev_1],
-                    &self.exterior.0[idx]
+                    self.exterior.0[prev_1],
+                    self.exterior.0[idx]
                 )
             })
             // accumulate and check cross-product result signs in a single pass

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -64,7 +64,7 @@ impl<F: Float> ClosestPoint<F> for Line<F> {
         let direction_vector = self.end - self.start;
         let to_p = *p - self.start;
 
-        let t = to_p.dot(&direction_vector) / direction_vector.dot(&direction_vector);
+        let t = to_p.dot(direction_vector) / direction_vector.dot(direction_vector);
 
         // check the cases where the closest point is "outside" the line
         if t < F::zero() {
@@ -91,7 +91,7 @@ impl<F: Float> ClosestPoint<F> for Line<F> {
 /// the `Closest::SinglePoint` which is closest to `p`.
 ///
 /// If the iterator is empty, we get `Closest::Indeterminate`.
-fn closest_of<C, F, I>(iter: I, p: &Point<F>) -> Closest<F>
+fn closest_of<C, F, I>(iter: I, p: Point<F>) -> Closest<F>
 where
     F: Float,
     I: IntoIterator<Item = C>,
@@ -100,7 +100,7 @@ where
     let mut best = Closest::Indeterminate;
 
     for line_segment in iter {
-        let got = line_segment.closest_point(p);
+        let got = line_segment.closest_point(&p);
         best = got.best_of_two(&best, p);
     }
 
@@ -109,32 +109,32 @@ where
 
 impl<F: Float> ClosestPoint<F> for LineString<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.lines(), p)
+        closest_of(self.lines(), *p)
     }
 }
 
 impl<F: Float> ClosestPoint<F> for Polygon<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
         let prospectives = self.interiors.iter().chain(iter::once(&self.exterior));
-        closest_of(prospectives, p)
+        closest_of(prospectives, *p)
     }
 }
 
 impl<F: Float> ClosestPoint<F> for MultiPolygon<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.0.iter(), p)
+        closest_of(self.0.iter(), *p)
     }
 }
 
 impl<F: Float> ClosestPoint<F> for MultiPoint<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.0.iter(), p)
+        closest_of(self.0.iter(), *p)
     }
 }
 
 impl<F: Float> ClosestPoint<F> for MultiLineString<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.0.iter(), p)
+        closest_of(self.0.iter(), *p)
     }
 }
 

--- a/geo/src/algorithm/contains.rs
+++ b/geo/src/algorithm/contains.rs
@@ -144,7 +144,7 @@ pub(crate) enum PositionPoint {
 }
 
 /// Calculate the position of `Point` p relative to a linestring
-pub(crate) fn get_position<T>(p: &Point<T>, linestring: &LineString<T>) -> PositionPoint
+pub(crate) fn get_position<T>(p: Point<T>, linestring: &LineString<T>) -> PositionPoint
 where
     T: Float,
 {
@@ -157,7 +157,7 @@ where
         return PositionPoint::Outside;
     }
     // Point is on linestring
-    if linestring.contains(p) {
+    if linestring.contains(&p) {
         return PositionPoint::OnBoundary;
     }
 
@@ -188,11 +188,11 @@ where
     T: Float,
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        match get_position(p, &self.exterior) {
+        match get_position(*p, &self.exterior) {
             PositionPoint::OnBoundary | PositionPoint::Outside => false,
             _ => self.interiors
                 .iter()
-                .all(|ls| get_position(p, ls) == PositionPoint::Outside),
+                .all(|ls| get_position(*p, ls) == PositionPoint::Outside),
         }
     }
 }

--- a/geo/src/algorithm/convexhull.rs
+++ b/geo/src/algorithm/convexhull.rs
@@ -49,7 +49,7 @@ fn partition<T, F: FnMut(&T) -> bool>(mut slice: &mut [T], mut pred: F) -> usize
 // we can compute the cross product AB x AC and check its sign:
 // If it's negative, it will be on the "right" side of AB
 // (when standing on A and looking towards B). If positive, it will be on the left side
-fn point_location<T>(p_a: &Point<T>, p_b: &Point<T>, p_c: &Point<T>) -> bool
+fn point_location<T>(p_a: Point<T>, p_b: Point<T>, p_c: Point<T>) -> bool
 where
     T: Float,
 {
@@ -79,11 +79,11 @@ where
             mem::swap(point, max);
         }
     }
-    let last = partition(&mut points, |p| point_location(max, min, p));
-    hull_set(max, min, &mut points[..last], &mut hull);
+    let last = partition(&mut points, |p| point_location(*max, *min, *p));
+    hull_set(*max, *min, &mut points[..last], &mut hull);
     hull.push(*max);
-    let last = partition(&mut points, |p| point_location(min, max, p));
-    hull_set(min, max, &mut points[..last], &mut hull);
+    let last = partition(&mut points, |p| point_location(*min, *max, *p));
+    hull_set(*min, *max, &mut points[..last], &mut hull);
     hull.push(*min);
     // close the polygon
     let final_element = *hull.first().unwrap();
@@ -92,7 +92,7 @@ where
 }
 
 // recursively calculate the convex hull of a subset of points
-fn hull_set<T>(p_a: &Point<T>, p_b: &Point<T>, mut set: &mut [Point<T>], hull: &mut Vec<Point<T>>)
+fn hull_set<T>(p_a: Point<T>, p_b: Point<T>, mut set: &mut [Point<T>], hull: &mut Vec<Point<T>>)
 where
     T: Float,
 {
@@ -107,7 +107,7 @@ where
     let mut furthest_idx = 0;
     for (idx, point) in set.iter().enumerate() {
         // let current_distance = pseudo_distance(p_a, p_b, point);
-        let current_distance = point.euclidean_distance(&Line::new(*p_a, *p_b));
+        let current_distance = point.euclidean_distance(&Line::new(p_a, p_b));
         if current_distance > furthest_distance {
             furthest_distance = current_distance;
             furthest_idx = idx
@@ -116,12 +116,12 @@ where
     // move Point at furthest_point from set into hull
     let furthest_point = swap_remove_to_first(&mut set, furthest_idx);
     // points over PB
-    let last = partition(set, |p| point_location(furthest_point, p_b, p));
-    hull_set(furthest_point, p_b, &mut set[..last], hull);
+    let last = partition(set, |p| point_location(*furthest_point, p_b, *p));
+    hull_set(*furthest_point, p_b, &mut set[..last], hull);
     hull.push(*furthest_point);
     // points over AP
-    let last = partition(set, |p| point_location(p_a, furthest_point, p));
-    hull_set(p_a, furthest_point, &mut set[..last], hull);
+    let last = partition(set, |p| point_location(p_a, *furthest_point, *p));
+    hull_set(p_a, *furthest_point, &mut set[..last], hull);
 }
 
 pub trait ConvexHull<T> {

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -13,22 +13,22 @@ use ::{ExtremePoint, Extremes};
 
 // Not currently used, but maybe useful in the future
 #[allow(dead_code)]
-fn up<T>(u: &Point<T>, v: &Point<T>) -> bool
+fn up<T>(u: Point<T>, v: Point<T>) -> bool
 where
     T: Float,
 {
     u.dot(v) > T::zero()
 }
 
-fn direction_sign<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> T
+fn direction_sign<T>(u: Point<T>, vi: Point<T>, vj: Point<T>) -> T
 where
     T: Float,
 {
-    u.dot(&(*vi - *vj))
+    u.dot(vi - vj)
 }
 
 // true if Vi is above Vj
-fn above<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> bool
+fn above<T>(u: Point<T>, vi: Point<T>, vj: Point<T>) -> bool
 where
     T: Float,
 {
@@ -38,7 +38,7 @@ where
 // true if Vi is below Vj
 // Not currently used, but maybe useful in the future
 #[allow(dead_code)]
-fn below<T>(u: &Point<T>, vi: &Point<T>, vj: &Point<T>) -> bool
+fn below<T>(u: Point<T>, vi: Point<T>, vj: Point<T>) -> bool
 where
     T: Float,
 {
@@ -49,7 +49,7 @@ where
 fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes, ()>
 where
     T: Float + Signed,
-    F: Fn(&Point<T>, &Polygon<T>) -> Result<usize, ()>,
+    F: Fn(Point<T>, &Polygon<T>) -> Result<usize, ()>,
 {
     if !polygon.is_convex() {
         return Err(());
@@ -62,14 +62,14 @@ where
     ];
     Ok(directions
         .iter()
-        .map(|p| func(p, polygon).unwrap())
+        .map(|p| func(*p, polygon).unwrap())
         .collect::<Vec<usize>>()
         .into())
 }
 
 // find a convex, counter-clockwise oriented polygon's maximum vertex in a specified direction
 // u: a direction vector. We're using a point to represent this, which is a hack but works fine
-fn polymax_naive_indices<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<usize, ()>
+fn polymax_naive_indices<T>(u: Point<T>, poly: &Polygon<T>) -> Result<usize, ()>
 where
     T: Float,
 {
@@ -77,7 +77,7 @@ where
     let mut max: usize = 0;
     for (i, _) in vertices.iter().enumerate() {
         // if vertices[i] is above prior vertices[max]
-        if above(u, &vertices[i], &vertices[max]) {
+        if above(u, vertices[i], vertices[max]) {
             max = i;
         }
     }
@@ -191,7 +191,7 @@ mod test {
             .map(|e| Point::new(e.0, e.1))
             .collect::<Vec<_>>();
         let poly1 = Polygon::new(LineString(points), vec![]);
-        let min_x = polymax_naive_indices(&Point::new(-1., 0.), &poly1).unwrap();
+        let min_x = polymax_naive_indices(Point::new(-1., 0.), &poly1).unwrap();
         let correct = 3_usize;
         assert_eq!(min_x, correct);
     }

--- a/geo/src/algorithm/polygon_distance_fast_path.rs
+++ b/geo/src/algorithm/polygon_distance_fast_path.rs
@@ -54,15 +54,15 @@ where
 }
 
 /// Minimum distance between a vertex and an imaginary line drawn from p to q
-fn vertex_line_distance<T>(v: &Point<T>, p: &Point<T>, q: &Point<T>) -> T
+fn vertex_line_distance<T>(v: Point<T>, p: Point<T>, q: Point<T>) -> T
 where
     T: Float,
 {
-    v.euclidean_distance(&Line::new(*p, *q))
+    v.euclidean_distance(&Line::new(p, q))
 }
 
 /// Wrap-around previous Polygon index
-fn prev_vertex<T>(poly: &Polygon<T>, current_vertex: &usize) -> usize
+fn prev_vertex<T>(poly: &Polygon<T>, current_vertex: usize) -> usize
 where
     T: Float,
 {
@@ -70,7 +70,7 @@ where
 }
 
 /// Wrap-around next Polygon index
-fn next_vertex<T>(poly: &Polygon<T>, current_vertex: &usize) -> usize
+fn next_vertex<T>(poly: &Polygon<T>, current_vertex: usize) -> usize
 where
     T: Float,
 {
@@ -117,7 +117,7 @@ where
 
 // much of the following code is ported from Java, copyright 1999 Hormoz Pirzadeh, available at:
 // http://web.archive.org/web/20150330010154/http://cgm.cs.mcgill.ca/%7Eorm/rotcal.html
-fn unitvector<T>(slope: &T, poly: &Polygon<T>, p: &Point<T>, idx: &usize) -> Point<T>
+fn unitvector<T>(slope: &T, poly: &Polygon<T>, p: Point<T>, idx: usize) -> Point<T>
 where
     T: Float + Signed,
 {
@@ -128,7 +128,7 @@ where
     let mut sin;
     let pnext = poly.exterior.0[next_vertex(poly, idx)];
     let pprev = poly.exterior.0[prev_vertex(poly, idx)];
-    let clockwise = pprev.cross_prod(p, &pnext) < T::zero();
+    let clockwise = pprev.cross_prod(p, pnext) < T::zero();
     let slope_prev;
     let slope_next;
     // Slope isn't 0, things are complicated
@@ -139,7 +139,7 @@ where
             if pprev.x() > p.x() {
                 if pprev.y() >= p.y() && pnext.y() >= p.y() {
                     if *slope > T::zero() {
-                        slope_prev = Line::new(*p, pprev).slope();
+                        slope_prev = Line::new(p, pprev).slope();
                         if clockwise && *slope <= slope_prev || !clockwise && *slope >= slope_prev {
                             cos = -cos;
                             sin = -sin;
@@ -156,8 +156,8 @@ where
                             sin = -sin;
                         }
                     } else {
-                        slope_prev = Line::new(*p, pprev).slope();
-                        slope_next = Line::new(*p, pnext).slope();
+                        slope_prev = Line::new(p, pprev).slope();
+                        slope_next = Line::new(p, pnext).slope();
                         if clockwise {
                             if *slope <= slope_prev {
                                 cos = -cos;
@@ -192,8 +192,8 @@ where
                             sin = -sin;
                         }
                     } else {
-                        slope_prev = Line::new(*p, pprev).slope();
-                        slope_next = Line::new(*p, pnext).slope();
+                        slope_prev = Line::new(p, pprev).slope();
+                        slope_next = Line::new(p, pnext).slope();
                         if clockwise {
                             if *slope <= slope_prev {
                                 sin = -sin;
@@ -208,7 +208,7 @@ where
                     }
                 } else if pprev.y() <= p.y() && pnext.y() <= p.y() {
                     if *slope > T::zero() {
-                        slope_next = Line::new(*p, pnext).slope();
+                        slope_next = Line::new(p, pnext).slope();
                         if *slope >= slope_next {
                             cos = -cos;
                             sin = -sin;
@@ -265,7 +265,7 @@ where
 }
 
 /// Perpendicular unit vector of a vertex and a unit vector
-fn unitpvector<T>(p: &Point<T>, u: &Point<T>) -> Point<T>
+fn unitpvector<T>(p: Point<T>, u: Point<T>) -> Point<T>
 where
     T: Float,
 {
@@ -274,7 +274,7 @@ where
     let slope = if vertical || p.y() == u.y() {
         T::zero()
     } else {
-        Line::new(*p, *u).slope()
+        Line::new(p, u).slope()
     };
     let upx;
     let upy;
@@ -315,14 +315,14 @@ where
 }
 
 /// Angle between a vertex and an edge
-fn vertex_line_angle<T>(poly: &Polygon<T>, p: &Point<T>, m: &T, vertical: bool, idx: &usize) -> T
+fn vertex_line_angle<T>(poly: &Polygon<T>, p: Point<T>, m: &T, vertical: bool, idx: usize) -> T
 where
     T: Float + FloatConst + Signed,
 {
     let hundred = T::from(100).unwrap();
     let pnext = poly.exterior.0[next_vertex(poly, idx)];
     let pprev = poly.exterior.0[prev_vertex(poly, idx)];
-    let clockwise = pprev.cross_prod(p, &pnext) < T::zero();
+    let clockwise = pprev.cross_prod(p, pnext) < T::zero();
     let punit;
     if !vertical {
         punit = unitvector(m, poly, p, idx);
@@ -359,16 +359,16 @@ where
         // implies p.x() < pprev.x()
         punit = Point::new(p.x(), p.y() - hundred);
     }
-    let triarea = triangle_area(p, &punit, &pnext);
+    let triarea = triangle_area(p, punit, pnext);
     let edgelen = p.euclidean_distance(&pnext);
     let mut sine = triarea / (T::from(0.5).unwrap() * T::from(100).unwrap() * edgelen);
     if sine < -T::one() || sine > T::one() {
         sine = T::one();
     }
     let angle;
-    let perpunit = unitpvector(p, &punit);
+    let perpunit = unitpvector(p, punit);
     let mut obtuse = false;
-    let left = leftturn(p, &perpunit, &pnext);
+    let left = leftturn(p, perpunit, pnext);
     if clockwise {
         if left == 0 {
             obtuse = true;
@@ -396,17 +396,17 @@ where
 }
 
 // self-explanatory
-fn triangle_area<T>(a: &Point<T>, b: &Point<T>, c: &Point<T>) -> T
+fn triangle_area<T>(a: Point<T>, b: Point<T>, c: Point<T>) -> T
 where
     T: Float,
 {
-    (Line::new(*a, *b).determinant()
-        + Line::new(*b, *c).determinant()
-        + Line::new(*c, *a).determinant()) / (T::one() + T::one())
+    (Line::new(a, b).determinant()
+        + Line::new(b, c).determinant()
+        + Line::new(c, a).determinant()) / (T::one() + T::one())
 }
 
 /// Does abc turn left?
-fn leftturn<T>(a: &Point<T>, b: &Point<T>, c: &Point<T>) -> i8
+fn leftturn<T>(a: Point<T>, b: Point<T>, c: Point<T>) -> i8
 where
     T: Float,
 {
@@ -430,17 +430,17 @@ where
     state.iq2 = false;
     state.ap1 = vertex_line_angle(
         state.poly1,
-        &state.p1,
+        state.p1,
         &state.slope,
         state.vertical,
-        &state.p1_idx,
+        state.p1_idx,
     );
     state.aq2 = vertex_line_angle(
         state.poly2,
-        &state.q2,
+        state.q2,
         &state.slope,
         state.vertical,
-        &state.q2_idx,
+        state.q2_idx,
     );
     let minangle = state.ap1.min(state.aq2);
     state.p1prev = state.p1;
@@ -465,14 +465,14 @@ where
     // see Pirzadeh (1999), p31
     if (state.ap1 - minangle).abs() < T::from(0.002).unwrap() {
         state.ip1 = true;
-        let p1next = next_vertex(state.poly1, &state.p1_idx);
+        let p1next = next_vertex(state.poly1, state.p1_idx);
         state.p1next = state.poly1.exterior.0[p1next];
         state.p1_idx = p1next;
         state.alignment = Some(Aligned::EdgeVertexP);
     }
     if (state.aq2 - minangle).abs() < T::from(0.002).unwrap() {
         state.iq2 = true;
-        let q2next = next_vertex(state.poly2, &state.q2_idx);
+        let q2next = next_vertex(state.poly2, state.q2_idx);
         state.q2next = state.poly2.exterior.0[q2next];
         state.q2_idx = q2next;
         state.alignment = match state.alignment {
@@ -538,20 +538,20 @@ where
                     u = unitvector(
                         &(-T::one() / state.slope),
                         state.poly2,
-                        &state.q2,
-                        &state.q2_idx,
+                        state.q2,
+                        state.q2_idx,
                     );
                 } else {
                     u = Point::new(state.q2.x(), state.q2.y() + T::from(100).unwrap());
                 }
             } else {
-                u = unitvector(&T::zero(), state.poly2, &state.q2, &state.q2_idx);
+                u = unitvector(&T::zero(), state.poly2, state.q2, state.q2_idx);
             }
-            let line_1 = leftturn(&u, &state.q2, &state.p1);
-            let line_2 = leftturn(&u, &state.q2, &state.p1prev);
+            let line_1 = leftturn(u, state.q2, state.p1);
+            let line_2 = leftturn(u, state.q2, state.p1prev);
             if line_1 != line_2 && line_1 != -1 && line_2 != -1 {
                 // an orthogonal intersection exists
-                newdist = vertex_line_distance(&state.q2, &state.p1prev, &state.p1);
+                newdist = vertex_line_distance(state.q2, state.p1prev, state.p1);
                 if newdist <= state.dist {
                     // New minimum distance is between edge (p1prev, p1) and q2
                     state.dist = newdist;
@@ -565,20 +565,20 @@ where
                     u = unitvector(
                         &(-T::one() / state.slope),
                         state.poly1,
-                        &state.p1,
-                        &state.p1_idx,
+                        state.p1,
+                        state.p1_idx,
                     );
                 } else {
                     u = Point::new(state.p1.x(), state.p1.y() + T::from(100).unwrap());
                 }
             } else {
-                u = unitvector(&T::zero(), state.poly1, &state.p1, &state.p1_idx);
+                u = unitvector(&T::zero(), state.poly1, state.p1, state.p1_idx);
             }
-            let line_1 = leftturn(&u, &state.p1, &state.q2);
-            let line_2 = leftturn(&u, &state.p1, &state.q2prev);
+            let line_1 = leftturn(u, state.p1, state.q2);
+            let line_2 = leftturn(u, state.p1, state.q2prev);
             if line_1 != line_2 && line_1 != -1 && line_2 != -1 {
                 // an orthogonal intersection exists
-                newdist = vertex_line_distance(&state.p1, &state.q2prev, &state.q2);
+                newdist = vertex_line_distance(state.p1, state.q2prev, state.q2);
                 if newdist <= state.dist {
                     // New minimum distance is between edge (q2prev, q2) and p1
                     state.dist = newdist;
@@ -602,32 +602,32 @@ where
                     u1 = unitvector(
                         &(-T::one() / state.slope),
                         state.poly1,
-                        &state.p1prev,
-                        &state.p1_idx,
+                        state.p1prev,
+                        state.p1_idx,
                     );
                     u2 = unitvector(
                         &(-T::one() / state.slope),
                         state.poly1,
-                        &state.p1,
-                        &state.p1_idx,
+                        state.p1,
+                        state.p1_idx,
                     );
                 } else {
                     u1 = Point::new(state.p1prev.x(), state.p1prev.y() + T::from(100).unwrap());
                     u2 = Point::new(state.p1.x(), state.p1.y() + T::from(100).unwrap());
                 }
             } else {
-                u1 = unitvector(&T::zero(), state.poly1, &state.p1prev, &state.p1_idx);
-                u2 = unitvector(&T::zero(), state.poly1, &state.p1, &state.p1_idx);
+                u1 = unitvector(&T::zero(), state.poly1, state.p1prev, state.p1_idx);
+                u2 = unitvector(&T::zero(), state.poly1, state.p1, state.p1_idx);
             }
-            let line_1a = leftturn(&u1, &state.p1prev, &state.q2prev);
-            let line_1b = leftturn(&u1, &state.p1prev, &state.q2);
-            let line_2a = leftturn(&u2, &state.p1, &state.q2prev);
-            let line_2b = leftturn(&u2, &state.p1, &state.q2);
+            let line_1a = leftturn(u1, state.p1prev, state.q2prev);
+            let line_1b = leftturn(u1, state.p1prev, state.q2);
+            let line_2a = leftturn(u2, state.p1, state.q2prev);
+            let line_2b = leftturn(u2, state.p1, state.q2);
             if line_1a != line_1b && line_1a != -1 && line_1b != -1
                 || line_2a != line_2b && line_2a != -1 && line_2b != -2
             {
                 // an orthogonal intersection exists
-                newdist = vertex_line_distance(&state.p1, &state.q2prev, &state.q2);
+                newdist = vertex_line_distance(state.p1, state.q2prev, state.q2);
                 if newdist <= state.dist {
                     // New minimum distance is between edge (p1prev, p1) and q2prev
                     state.dist = newdist;
@@ -646,7 +646,7 @@ mod test {
         let p = Point::new(0., 0.);
         let q = Point::new(3.8, 5.7);
         let r = Point::new(22.5, 10.);
-        let dist = vertex_line_distance(&p, &q, &r);
+        let dist = vertex_line_distance(p, q, r);
         assert_eq!(dist, 6.850547423381579);
     }
 }

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -7,7 +7,7 @@ use {Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon
 // rotate a slice of points "angle" degrees about an origin
 // origin can be an arbitrary point, pass &Point::new(0., 0.)
 // for the actual origin
-fn rotation_matrix<T>(angle: T, origin: &Point<T>, points: &[Point<T>]) -> Vec<Point<T>>
+fn rotation_matrix<T>(angle: T, origin: Point<T>, points: &[Point<T>]) -> Vec<Point<T>>
 where
     T: Float,
 {
@@ -72,7 +72,7 @@ pub trait RotatePoint<T> {
     /// vec.push(Point::new(5.0, 5.0));
     /// vec.push(Point::new(10.0, 10.0));
     /// let linestring = LineString(vec);
-    /// let rotated = linestring.rotate_around_point(-45.0, &Point::new(10.0, 0.0));
+    /// let rotated = linestring.rotate_around_point(-45.0, Point::new(10.0, 0.0));
     /// let mut correct = Vec::new();
     /// correct.push(Point::new(2.9289321881345245, 7.071067811865475));
     /// correct.push(Point::new(10.0, 7.0710678118654755));
@@ -80,7 +80,7 @@ pub trait RotatePoint<T> {
     /// let correct_ls = LineString(correct);
     /// assert_eq!(rotated, correct_ls);
     /// ```
-    fn rotate_around_point(&self, angle: T, point: &Point<T>) -> Self
+    fn rotate_around_point(&self, angle: T, point: Point<T>) -> Self
     where
         T: Float;
 }
@@ -90,7 +90,7 @@ where
     T: Float,
     G: MapCoords<T, T, Output = G>,
 {
-    fn rotate_around_point(&self, angle: T, point: &Point<T>) -> Self {
+    fn rotate_around_point(&self, angle: T, point: Point<T>) -> Self {
         let (sin_theta, cos_theta) = angle.to_radians().sin_cos();
         let x0 = point.x();
         let y0 = point.y();
@@ -112,7 +112,7 @@ where
     /// Rotate the Point about itself by the given number of degrees
     /// This operation leaves the point coordinates unchanged
     fn rotate(&self, angle: T) -> Self {
-        rotation_matrix(angle, &self.centroid(), &[*self])[0]
+        rotation_matrix(angle, self.centroid(), &[*self])[0]
     }
 }
 
@@ -122,7 +122,7 @@ where
 {
     fn rotate(&self, angle: T) -> Self {
         let pts = vec![self.start, self.end];
-        let rotated = rotation_matrix(angle, &self.centroid(), &pts);
+        let rotated = rotation_matrix(angle, self.centroid(), &pts);
         Line::new(rotated[0], rotated[1])
     }
 }
@@ -133,7 +133,7 @@ where
 {
     /// Rotate the LineString about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
-        LineString(rotation_matrix(angle, &self.centroid().unwrap(), &self.0))
+        LineString(rotation_matrix(angle, self.centroid().unwrap(), &self.0))
     }
 }
 
@@ -150,10 +150,10 @@ where
             self.exterior.centroid().unwrap()
         };
         Polygon::new(
-            LineString(rotation_matrix(angle, &centroid, &self.exterior.0)),
+            LineString(rotation_matrix(angle, centroid, &self.exterior.0)),
             self.interiors
                 .iter()
-                .map(|ring| LineString(rotation_matrix(angle, &centroid, &ring.0)))
+                .map(|ring| LineString(rotation_matrix(angle, centroid, &ring.0)))
                 .collect(),
         )
     }
@@ -316,7 +316,7 @@ mod test {
     #[test]
     fn test_rotate_around_point_arbitrary() {
         let p = Point::new(5.0, 10.0);
-        let rotated = p.rotate_around_point(-45., &Point::new(10., 34.));
+        let rotated = p.rotate_around_point(-45., Point::new(10., 34.));
         assert_eq!(rotated, Point::new(-10.506096654409877, 20.564971157455595));
     }
     #[test]
@@ -332,6 +332,6 @@ mod test {
             Point::new(0., 0.),
             Point::new(-2., 0.00000000000000012246467991473532),
         );
-        assert_eq!(line0.rotate_around_point(90., &Point::new(0., 0.)), line1);
+        assert_eq!(line0.rotate_around_point(90., Point::new(0., 0.)), line1);
     }
 }

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -127,7 +127,7 @@ where
     // of 3 points and form triangles from them
     for (i, win) in orig.windows(3).enumerate() {
         pq.push(VScore {
-            area: area(win.first().unwrap(), &win[1], win.last().unwrap()),
+            area: area(*win.first().unwrap(), win[1], *win.last().unwrap()),
             current: i + 1,
             left: i,
             right: i + 2,
@@ -173,7 +173,7 @@ where
             );
             let new_right = Point::new(orig[bi as usize].x(), orig[bi as usize].y());
             pq.push(VScore {
-                area: area(&new_left, &new_current, &new_right),
+                area: area(new_left, new_current, new_right),
                 current: current_point as usize,
                 left: ai as usize,
                 right: bi as usize,
@@ -265,7 +265,7 @@ where
     // of 3 points and form triangles from them
     for (i, win) in orig.windows(3).enumerate() {
         let v = VScore {
-            area: area(&win[0], &win[1], &win[2]),
+            area: area(win[0], win[1], win[2]),
             current: i + 1,
             left: i,
             right: i + 2,
@@ -334,7 +334,7 @@ where
             let temp_area = if smallest.intersector && (current_point as usize) < smallest.current {
                 -*epsilon
             } else {
-                area(&new_left, &new_current, &new_right)
+                area(new_left, new_current, new_right)
             };
             let new_triangle = VScore {
                 area: temp_area,
@@ -358,7 +358,7 @@ where
 }
 
 /// is p1 -> p2 -> p3 wound counterclockwise?
-fn ccw<T>(p1: &Point<T>, p2: &Point<T>, p3: &Point<T>) -> bool
+fn ccw<T>(p1: Point<T>, p2: Point<T>, p3: Point<T>) -> bool
 where
     T: Float,
 {
@@ -366,7 +366,7 @@ where
 }
 
 /// checks whether line segments with p1-p4 as their start and endpoints touch or cross
-fn cartesian_intersect<T>(p1: &Point<T>, p2: &Point<T>, p3: &Point<T>, p4: &Point<T>) -> bool
+fn cartesian_intersect<T>(p1: Point<T>, p2: Point<T>, p3: Point<T>, p4: Point<T>) -> bool
 where
     T: Float,
 {
@@ -395,18 +395,18 @@ where
         let ca = c.start;
         let cb = c.end;
         if ca != point_a && ca != point_c && cb != point_a && cb != point_c
-            && cartesian_intersect(&ca, &cb, &point_a, &point_c)
+            && cartesian_intersect(ca, cb, point_a, point_c)
         {
             true
         } else {
             ca != point_b && ca != point_c && cb != point_b && cb != point_c
-                && cartesian_intersect(&ca, &cb, &point_b, &point_c)
+                && cartesian_intersect(ca, cb, point_b, point_c)
         }
     })
 }
 
 /// Area of a triangle given three vertices
-fn area<T>(p1: &Point<T>, p2: &Point<T>, p3: &Point<T>) -> T
+fn area<T>(p1: Point<T>, p2: Point<T>, p3: Point<T>) -> T
 where
     T: Float,
 {
@@ -640,13 +640,13 @@ mod test {
         let c = Point::new(3., 3.);
         let d = Point::new(1., 1.);
         // cw + ccw
-        assert_eq!(cartesian_intersect(&a, &b, &c, &d), true);
+        assert_eq!(cartesian_intersect(a, b, c, d), true);
         // ccw + ccw
-        assert_eq!(cartesian_intersect(&b, &a, &c, &d), true);
+        assert_eq!(cartesian_intersect(b, a, c, d), true);
         // cw + cw
-        assert_eq!(cartesian_intersect(&a, &b, &d, &c), true);
+        assert_eq!(cartesian_intersect(a, b, d, c), true);
         // ccw + cw
-        assert_eq!(cartesian_intersect(&b, &a, &d, &c), true);
+        assert_eq!(cartesian_intersect(b, a, d, c), true);
     }
     #[test]
     fn simple_vwp_test() {

--- a/geo/src/types.rs
+++ b/geo/src/types.rs
@@ -160,7 +160,7 @@ pub enum Closest<F: Float> {
 impl<F: Float> Closest<F> {
     /// Compare two `Closest`s relative to `p` and return a copy of the best
     /// one.
-    pub fn best_of_two(&self, other: &Self, p: &Point<F>) -> Self {
+    pub fn best_of_two(&self, other: &Self, p: Point<F>) -> Self {
         use algorithm::euclidean_distance::EuclideanDistance;
 
         let left = match *self {
@@ -174,7 +174,7 @@ impl<F: Float> Closest<F> {
             Closest::SinglePoint(r) => r,
         };
 
-        if left.euclidean_distance(p) <= right.euclidean_distance(p) {
+        if left.euclidean_distance(&p) <= right.euclidean_distance(&p) {
             *self
         } else {
             *other


### PR DESCRIPTION
Breaking changes for `geo` and `geo-types`.