### PR TITLE
Introduce Triangle geometry type.

### DIFF
--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -50,6 +50,9 @@ pub use geometry::Geometry;
 mod geometry_collection;
 pub use geometry_collection::GeometryCollection;
 
+mod triangle;
+pub use triangle::Triangle;
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -1,5 +1,5 @@
 use std::iter::FromIterator;
-use {Coordinate, CoordinateType, Line, Point};
+use {Coordinate, CoordinateType, Line, Point, Triangle};
 
 /// An ordered collection of two or more [`Coordinate`s](struct.Coordinate.html), representing a
 /// path between locations.
@@ -119,10 +119,22 @@ impl<T: CoordinateType> LineString<T> {
     /// assert!(lines.next().is_none());
     /// ```
     pub fn lines<'a>(&'a self) -> impl ExactSizeIterator + Iterator<Item = Line<T>> + 'a {
-        self.0.windows(2).map(|w| unsafe {
-            // As long as the LineString has at least two coordinates, we shouldn't
-            // need to do bounds checking here.
-            Line::new(*w.get_unchecked(0), *w.get_unchecked(1))
+        self.0.windows(2).map(|w| {
+            // slice::windows(N) is guaranteed to yield a slice with exactly N elements
+            unsafe { Line::new(*w.get_unchecked(0), *w.get_unchecked(1)) }
+        })
+    }
+
+    pub fn triangles<'a>(&'a self) -> impl ExactSizeIterator + Iterator<Item = Triangle<T>> + 'a {
+        self.0.windows(3).map(|w| {
+            // slice::windows(N) is guaranteed to yield a slice with exactly N elements
+            unsafe {
+                Triangle(
+                    *w.get_unchecked(0),
+                    *w.get_unchecked(1),
+                    *w.get_unchecked(2),
+                )
+            }
         })
     }
 }

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -1,0 +1,16 @@
+use {Coordinate, CoordinateType};
+
+#[derive(Copy, Clone, Debug)]
+pub struct Triangle<T: CoordinateType>(pub Coordinate<T>, pub Coordinate<T>, pub Coordinate<T>);
+
+impl<T: CoordinateType> Triangle<T> {
+    pub fn to_array(&self) -> [Coordinate<T>; 3] {
+        [self.0, self.1, self.2]
+    }
+}
+
+impl<IC: Into<Coordinate<T>> + Copy, T: CoordinateType> From<[IC; 3]> for Triangle<T> {
+    fn from(array: [IC; 3]) -> Triangle<T> {
+        Triangle(array[0].into(), array[1].into(), array[2].into())
+    }
+}

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -1,5 +1,5 @@
 use num_traits::Float;
-use {Bbox, Line, LineString, MultiPolygon, Polygon};
+use {Bbox, Line, LineString, MultiPolygon, Polygon, Triangle};
 
 use algorithm::winding_order::twice_signed_ring_area;
 
@@ -83,10 +83,21 @@ where
     }
 }
 
+impl<T> Area<T> for Triangle<T>
+where
+    T: Float,
+{
+    fn area(&self) -> T {
+        (Line::new(self.0, self.1).determinant()
+            + Line::new(self.1, self.2).determinant()
+            + Line::new(self.2, self.0).determinant()) / (T::one() + T::one())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use algorithm::area::Area;
-    use {Bbox, Coordinate, Line, LineString, MultiPolygon, Polygon};
+    use {Bbox, Coordinate, Line, LineString, MultiPolygon, Polygon, Triangle};
 
     // Area of the polygon
     #[test]
@@ -146,5 +157,22 @@ mod test {
     fn area_line_test() {
         let line1 = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 1.0, y: 1.0 });
         assert_eq!(line1.area(), 0.);
+    }
+
+    #[test]
+    fn area_triangle_test() {
+        let triangle = Triangle(
+            Coordinate { x: 0.0, y: 0.0 },
+            Coordinate { x: 1.0, y: 0.0 },
+            Coordinate { x: 0.0, y: 1.0 },
+        );
+        assert_eq!(triangle.area(), 0.5);
+
+        let triangle = Triangle(
+            Coordinate { x: 0.0, y: 0.0 },
+            Coordinate { x: 0.0, y: 1.0 },
+            Coordinate { x: 1.0, y: 0.0 },
+        );
+        assert_eq!(triangle.area(), -0.5);
     }
 }

--- a/geo/src/algorithm/boundingbox.rs
+++ b/geo/src/algorithm/boundingbox.rs
@@ -1,6 +1,6 @@
 use {
     Bbox, Coordinate, CoordinateType, Line, LineString, MultiLineString, MultiPoint, MultiPolygon,
-    Polygon,
+    Polygon, Triangle,
 };
 
 /// Calculation of the bounding box of a geometry.
@@ -161,6 +161,17 @@ where
                 .iter()
                 .flat_map(|poly| (poly.exterior).0.iter().map(|c| *c)),
         )
+    }
+}
+
+impl<T> BoundingBox<T> for Triangle<T>
+where
+    T: CoordinateType,
+{
+    type Output = Bbox<T>;
+
+    fn bbox(&self) -> Self::Output {
+        get_bbox(self.to_array().into_iter().cloned()).unwrap()
     }
 }
 

--- a/geo/src/algorithm/polygon_distance_fast_path.rs
+++ b/geo/src/algorithm/polygon_distance_fast_path.rs
@@ -1,8 +1,8 @@
-use algorithm::euclidean_distance::EuclideanDistance;
 use algorithm::extremes::ExtremeIndices;
 use num_traits::float::FloatConst;
 use num_traits::{Float, Signed};
-use {Line, Point, Polygon};
+use prelude::*;
+use {Line, Point, Polygon, Triangle};
 
 // These are helper functions for the "fast path" of Polygon-Polygon distance
 // They use the rotating calipers method to speed up calculations.
@@ -359,7 +359,7 @@ where
         // implies p.x() < pprev.x()
         punit = Point::new(p.x(), p.y() - hundred);
     }
-    let triarea = triangle_area(p, punit, Point(pnext));
+    let triarea = Triangle::from([p, punit, Point(pnext)]).area();
     let edgelen = p.euclidean_distance(&Point(pnext));
     let mut sine = triarea / (T::from(0.5).unwrap() * T::from(100).unwrap() * edgelen);
     if sine < -T::one() || sine > T::one() {
@@ -395,22 +395,12 @@ where
     angle
 }
 
-// self-explanatory
-fn triangle_area<T>(a: Point<T>, b: Point<T>, c: Point<T>) -> T
-where
-    T: Float,
-{
-    (Line::new(a.0, b.0).determinant()
-        + Line::new(b.0, c.0).determinant()
-        + Line::new(c.0, a.0).determinant()) / (T::one() + T::one())
-}
-
 /// Does abc turn left?
 fn leftturn<T>(a: Point<T>, b: Point<T>, c: Point<T>) -> i8
 where
     T: Float,
 {
-    let narea = triangle_area(a, b, c);
+    let narea = Triangle::from([a, b, c]).area();
     if narea > T::zero() {
         1
     } else if narea < T::zero() {

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -17,7 +17,7 @@ pub use types::*;
 
 pub use geo_types::{
     Coordinate, CoordinateType, Geometry, GeometryCollection, Line, LineString, MultiLineString,
-    MultiPoint, MultiPolygon, Point, Polygon,
+    MultiPoint, MultiPolygon, Point, Polygon, Triangle,
 };
 
 /// This module includes all the functions of geometric calculations


### PR DESCRIPTION
Fixes https://github.com/georust/rust-geo/issues/261.

GEOS also offers a Triangle type:

- http://geos.osgeo.org/doxygen/classgeos_1_1geom_1_1Triangle.html

I updated the `polygon_distance_fast_path` and `simplifyvw` algorithms
to utilize this new geometry type. As a result of this change and
tangential optimizations, the `simplify vw simple f32` benchmark is now
10% faster.